### PR TITLE
Adds 'numberOfMonths' option to the DayPicker, allowing multiple months to be displayed side-by-side.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ npm start
 ```js
 <DayPicker
   initialMonth={Object}
+  numberOfMonths={Number}
   enableOutsideDays={Boolean}
   modifiers={Object}
   onDayClick={Function}
@@ -99,7 +100,11 @@ npm start
 
 #### initialMonth `moment object`
 
-A `moment()` object with the month to display in the calendar.
+A `moment()` object with the first month to display in the calendar.
+
+#### numberOfMonths `int`
+
+An integer value indicating the number of months to display in the calendar
 
 #### modifiers `Object`
 

--- a/example/src/scss/daypicker.scss
+++ b/example/src/scss/daypicker.scss
@@ -4,8 +4,10 @@
 .DayPicker {
   border-collapse: collapse;
   border-spacing: 0;
-  margin: 24px auto;
+  display: inline-block;
+  margin: 24px 10px;
   user-select: none;
+  vertical-align: top;
 }
 
 /* Caption & navigation buttons */

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -9,6 +9,8 @@ const DayPicker = React.createClass({
     enableOutsideDays: React.PropTypes.bool,
 
     initialMonth: React.PropTypes.object, // default is current month
+    numberOfMonths: React.PropTypes.number, // default is 1
+
     modifiers: React.PropTypes.object,
 
     onDayClick: React.PropTypes.func,
@@ -22,7 +24,7 @@ const DayPicker = React.createClass({
   },
 
   getDefaultProps() {
-    return { initialMonth: moment(), enableOutsideDays: false };
+    return { initialMonth: moment(), numberOfMonths: 1, enableOutsideDays: false };
   },
 
   getInitialState() {
@@ -92,19 +94,36 @@ const DayPicker = React.createClass({
   },
 
   render() {
-    const { month } = this.state;
+    let { month } = this.state;
+
+    let months = [];
+    for (let i = 0; i < this.props.numberOfMonths; i++) {
+      months.push(this.renderMonth(month, i));
+      month = month.clone().add(1, 'month');
+    }
+
+    return (
+      <div>
+        {months}
+      </div>
+    );
+  },
+
+  renderMonth(month, monthIndex) {
+    const isFirstMonth = (month === this.state.month);
+    const isLastMonth = (monthIndex === this.props.numberOfMonths - 1);
     return (
       <table className="DayPicker">
         <caption className="DayPicker-caption">
-          { this.renderNavButton('left') }
+          { isFirstMonth && this.renderNavButton('left') }
           { month.format('MMMM YYYY') }
-          { this.renderNavButton('right') }
+          { isLastMonth && this.renderNavButton('right') }
         </caption>
         <thead>
           { this.renderWeekHeader() }
         </thead>
         <tbody>
-          { this.renderWeeks() }
+          { this.renderWeeks(month) }
         </tbody>
       </table>
     );
@@ -120,8 +139,8 @@ const DayPicker = React.createClass({
       style={{float: position}} onClick={handler} />;
   },
 
-  renderWeeks() {
-    return weeks(this.state.month).map((week, i) =>
+  renderWeeks(month) {
+    return weeks(month).map((week, i) =>
       <tr key={i} className="DayPicker-week">
         { this.renderDays(week) }
       </tr>


### PR DESCRIPTION
In reference to https://github.com/gpbl/react-day-picker/issues/11, @iancmyers @gpbl

I separated out the logic to render a single month into its own method, and simply called it as many times as was indicated by the new property. Each month is its own table, and I added some custom styling to the example css to make the months render side-by-side (which I think is desirable). 

Here are some screenshots of the example with multiple months:
![screen shot 2015-04-13 at 3 21 01 pm](https://cloud.githubusercontent.com/assets/1383861/7127252/358ab4f4-e1f6-11e4-970b-042f3cd8076e.png)
![3-months-visible](https://cloud.githubusercontent.com/assets/1383861/7127249/33f9820a-e1f6-11e4-976e-4ebf43b13261.png)

It was super awesome how easy it was to add this functionality! :) Let me know what you guys think? This does not affect the default calendar whatsoever. It still functions exactly as it did before.
 