### PR TITLE
Persist events on month changes

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -67,6 +67,7 @@ class DayPicker extends Component {
   }
 
   handleNextMonthClick(e) {
+    e.persist();
     const { month } = this.state;
     const nextMonth = month.clone().add(1, 'month');
     this.setState({ month: nextMonth }, () => {
@@ -77,6 +78,7 @@ class DayPicker extends Component {
   }
 
   handlePrevMonthClick(e) {
+    e.persist();
     const { month } = this.state;
     const prevMonth = month.clone().subtract(1, 'month');
     this.setState({ month: prevMonth }, () => {


### PR DESCRIPTION
Because React reuses event objects by the time the event reaches the onPrev/NextMonthClick callback all of the attributes are null.

This change has React persist the events so that they can actually be used in the callback.