### PR TITLE
Feature: caption click -> show this month

### DIFF
--- a/site/src/style/DayPicker.scss
+++ b/site/src/style/DayPicker.scss
@@ -51,6 +51,7 @@
     display: table-caption;
     height: 1.5rem;
     text-align: center;
+    cursor: pointer;
   }
 
   .DayPicker-Weekdays {

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -123,7 +123,7 @@ class DayPicker extends Component {
       <div
         className="DayPicker-Month"
         key={i}>
-        <div className="DayPicker-Caption">
+        <div className="DayPicker-Caption" onClick={ ::this.handleCaptionClick }>
           { localeUtils.formatMonthTitle(d, locale) }
         </div>
         <div className="DayPicker-Weekdays">
@@ -230,6 +230,14 @@ class DayPicker extends Component {
     this.setState({
       currentMonth: Utils.startOfMonth(d)
     });
+  }
+
+  showThisMonth() {
+    const today = new Date();
+
+    if (today.getMonth() !== this.state.currentMonth.getMonth()) {
+      this.showMonth(today);
+    }
   }
 
   showNextMonth(callback) {
@@ -346,6 +354,11 @@ class DayPicker extends Component {
         }
       break;
     }
+  }
+
+  handleCaptionClick(e) {
+    e.stopPropagation();
+    this.showThisMonth();
   }
 
   handleNextMonthClick(e) {


### PR DESCRIPTION
While testing this component, I navigated pretty far away from the current month and noticed that clicking the month display on the header didn't bring me back to today's month.

This PR enables a click on the displayed month `.DayPicker-Caption` to return the picker to the current month (at the time of the click).