### PR TITLE
add: ARIA attributes to the nav buttons

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -262,16 +262,23 @@ class DayPicker extends Component {
 
   renderNavBar() {
     const baseClass = "DayPicker-NavButton DayPicker-NavButton";
+    const { localeUtils, locale } = this.props;
     return (
       <div className="DayPicker-NavBar">
-        <span
+        <button
           key="prev"
           className={ `${baseClass}--prev` }
-          onClick={ ::this.handlePrevMonthClick } />
-        <span
+          onClick={ ::this.handlePrevMonthClick }
+          tabIndex="-1"
+          type="button"
+          aria-label={ localeUtils.getPreviousLabel(locale) } />
+        <button
           key="next"
           className={ `${baseClass}--next` }
-          onClick={ ::this.handleNextMonthClick } />
+          onClick={ ::this.handleNextMonthClick }
+          tabIndex="-1"
+          type="button"
+          aria-label={ localeUtils.getNextLabel(locale) } />
       </div>
     );
   }

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -7,6 +7,12 @@ const WEEKDAYS_SHORT = ["Su", "Mo", "Tu",
 const MONTHS = ["January", "February", "March", "April", "May", "June",
   "July", "August", "September", "October", "November", "December"];
 
+const LABELS = {
+  NEXT: "Next",
+  PREV: "Previous"
+};
+
+
 const Utils = {
 
   addMonths(d, months) {
@@ -127,6 +133,14 @@ const Utils = {
 
   getMonthsDiff(d1, d2) {
     return d2.getMonth() - d1.getMonth() + (12 * (d2.getFullYear() - d1.getFullYear()));
+  },
+
+  getNextLabel() {
+    return LABELS.NEXT;
+  },
+
+  getPreviousLabel() {
+    return LABELS.PREV;
   }
 
 };

--- a/test/Utils.js
+++ b/test/Utils.js
@@ -244,4 +244,15 @@ describe("Utils", () => {
     });
   });
 
+  describe("getNextLabel", () => {
+    it("returns Next", () => {
+      expect(Utils.getNextLabel()).to.equal("Next");
+    });
+  });
+
+  describe("getPreviousLabel", () => {
+    it("returns Previous", () => {
+      expect(Utils.getPreviousLabel()).to.equal("Previous");
+    });
+  });
 });


### PR DESCRIPTION
This is related to #33. I think this as more of a continuation of that discussion than anything else.

Basically: the nav buttons aren't ARIA compliant, and this solves that problem, but there's a better option: use real `<button>` elements instead of `<span>`s. This is more correct, but might be a breaking change. What do you think?
