### PR TITLE
Integrate react-a11y into tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel": "^5.8.21",
     "babel-core": "^5.8.22",
     "babel-eslint": "^4.0.10",
+    "chai": "^3.3.0",
     "classlist-polyfill": "^1.0.1",
     "coveralls": "^2.11.2",
     "eslint": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "mocha": "^2.2.5",
     "moment": "^2.10.3",
     "react": "^0.14.0",
+    "react-a11y": "^0.2.6",
     "react-addons-test-utils": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-tap-event-plugin": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel": "^5.8.21",
     "babel-core": "^5.8.22",
     "babel-eslint": "^4.0.10",
+    "babel-runtime": "^5.8.25",
     "chai": "^3.3.0",
     "classlist-polyfill": "^1.0.1",
     "coveralls": "^2.11.2",

--- a/test/DayPicker.js
+++ b/test/DayPicker.js
@@ -1,8 +1,8 @@
-
 import testDom from "testdom";
 import chai, { expect } from "chai";
 import sinon from "sinon";
 import sinonChai from "sinon-chai";
+import a11y from "react-a11y";
 
 chai.use(sinonChai);
 
@@ -22,6 +22,24 @@ const keys = {
   ENTER: 13,
   SPACE: 32
 };
+
+describe("DayPicker a11y", () => {
+  let createElement;
+
+  before(() => {
+    createElement = React.createElement;
+    a11y(React, {throw: true});
+  });
+
+  after(() => {
+    React.createElement = createElement;
+  });
+
+  it("passes a11y", () => {
+    const shallowRenderer = TestUtils.createRenderer();
+    shallowRenderer.render(<DayPicker />);
+  });
+});
 
 describe("DayPicker", () => {
 


### PR DESCRIPTION
Related to #33 This might be a good way to ensure future ARIA compatibility. It runs react-a11y within the tests. This is just a demo for discussion purposes. Thoughts?