### PR TITLE
Fix addMonths 31st day bug

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -11,7 +11,7 @@ const Utils = {
 
   addMonths(d, months) {
     const newDate = this.clone(d);
-    newDate.setMonth(d.getMonth() + months);
+    newDate.setMonth(d.getMonth() + months, 1);
     return newDate;
   },
 


### PR DESCRIPTION
When adding months, if the `currentMonth` value has a day out of range of the target month, the date carries over into the next month. For example, if `currentMonth` is set to August 31st and `addMonths` is called with `months = 1`, the resultant date is October 1st, where the expected output month would be September, because September has no 31st day.

From the [Mozilla docs for `Date.prototype.setMonth()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setMonth) :
> If you do not specify the `dayValue` parameter, the value returned from the getDate() method is used.

So this issue can be avoided by ensuring that the day value argument in `setMonth` is always set to 1.