### PR TITLE
Fix currentMonth when props are being updated

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -64,7 +64,7 @@ class DayPicker extends Component {
   componentWillReceiveProps(nextProps) {
     if (this.props.initialMonth !== nextProps.initialMonth) {
       this.setState({
-        currentMonth: nextProps.initialMonth
+        currentMonth: Utils.startOfMonth(nextProps.initialMonth)
       });
     }
   }

--- a/test/DayPicker.js
+++ b/test/DayPicker.js
@@ -350,6 +350,7 @@ describe("DayPicker", () => {
     parent.setState({
       month: 8
     }, () => {
+      expect(daypicker.state.currentMonth.getDate()).to.equal(1);
       expect(daypicker.state.currentMonth.getMonth()).to.equal(8);
       done();
     });


### PR DESCRIPTION
Alternative solution to #57, and testing that `componentWillReceiveProps` sets `currentMonth` to the first day of the month