### PR TITLE
Let the event from next/previous month click to propagate.

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -218,11 +218,11 @@ class DayPicker extends Component {
     }
   }
 
-  handleNextMonthClick(e) {
+  handleNextMonthClick() {
     this.showNextMonth();
   }
 
-  handlePrevMonthClick(e) {
+  handlePrevMonthClick() {
     this.showPreviousMonth();
   }
 

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -219,12 +219,10 @@ class DayPicker extends Component {
   }
 
   handleNextMonthClick(e) {
-    e.stopPropagation();
     this.showNextMonth();
   }
 
   handlePrevMonthClick(e) {
-    e.stopPropagation();
     this.showPreviousMonth();
   }
 


### PR DESCRIPTION
There seem to be no real need to stop event propagation in this case, and doing so might cause unwanted side-effects in certain cases.