### PR TITLE
Update style.css to fix broken layout

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -54,9 +54,6 @@
 
   .DayPicker-Weekdays {
     display: table-header-group;
-    > div {
-      display: table-row;
-    }
   }
 
     .DayPicker-Weekday {


### PR DESCRIPTION
This was overriding `.DayPicker-Weekday { display: table-cell }` and causing the layout to break