### PR TITLE
Restore the row for the weekdays header (fix #82)

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -327,7 +327,9 @@ export default class DayPicker extends Component {
           { localeUtils.formatMonthTitle(d, locale) }
         </div>
         <div className="DayPicker-Weekdays">
-          { this.renderWeekDays() }
+          <div className="DayPicker-WeekdaysRow">
+            { this.renderWeekDays() }
+          </div>
         </div>
         <div className="DayPicker-Body">
           { this.renderWeeksInMonth(d) }

--- a/src/style.css
+++ b/src/style.css
@@ -54,18 +54,19 @@
 
   .DayPicker-Weekdays {
     display: table-header-group;
-    > div {
-      display: table-row;
-    }
   }
 
-    .DayPicker-Weekday {
-      display: table-cell;
-      padding: .5rem;
-      font-size: .875em;
-      text-align: center;
-      color: #8b9898;
+    .DayPicker-WeekdaysRow {
+      display: table-row;
     }
+
+      .DayPicker-Weekday {
+        display: table-cell;
+        padding: .5rem;
+        font-size: .875em;
+        text-align: center;
+        color: #8b9898;
+      }
 
   .DayPicker-Body {
     display: table-row-group;


### PR DESCRIPTION
This PR address reverts [this commit](https://github.com/gpbl/react-day-picker/commit/0164a38f651771c00d3b4949898937d2013c7ddd) adding a `table-row` element around the `DayPicker-Weekday` table cells. #82