### PR TITLE
Fix incorrect import

### DIFF
--- a/test/DayPicker.js
+++ b/test/DayPicker.js
@@ -14,7 +14,7 @@ ExecutionEnvironment.canUseDOM = true;
 
 const TestUtils = require("react-addons-test-utils");
 
-const DayPicker = require("../src/DayPicker");
+const DayPicker = require("../src/DayPicker").default;
 
 const keys = {
   LEFT: 37,


### PR DESCRIPTION
When require('../src/DayPicker') returns a object. The class itself is on 'default' property.
It's the way ES6 modules work.