### PR TITLE
Adds the style definition to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.5",
   "description": "Flexible date picker component for React",
   "main": "DayPicker.js",
+  "style": "lib/style.css",
   "directories": {
     "doc": "docs"
   },


### PR DESCRIPTION
Allows the require in css to be

```javascript
import 'react-date-picker';
``` 

instead of

```javascript
import 'react-date-picker/lib/style.css';
```
