### PR TITLE
Change documented return type of getFirstDayOfWeek to number

### DIFF
--- a/docs/LocaleUtils.md
+++ b/docs/LocaleUtils.md
@@ -29,7 +29,7 @@ Return the string used to render the weekday's short name, e.g. `Mo` for Monday.
 
 Return the string used to render the weekday's long name, e.g. `Monday`. It is used mainly for ARIA.
 
-### `getFirstDayOfWeek(locale: string) -> bool`
+### `getFirstDayOfWeek(locale: string) -> number`
 
 Return the first day of the week for the given locale, e.g. `0` (Sunday) when `locale` is `en`.
 


### PR DESCRIPTION
In the documentation the return type of `getFirstDayOfWeek` is a `bool`. This should actually be a `number`. The [code that uses](https://github.com/gpbl/react-day-picker/blob/master/src/Helpers.js#L37) this value does a strict comparison with a number
```
if(week.length > 0 && day.getDay() === firstDayOfWeek) {
```

Also that value can indeed be a number different than 0 (Sunday) and 1 (Monday), for example in Hebrew it is commonly 6 (Saturday).