### PR TITLE
handle the situation when no day is selected

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -95,6 +95,7 @@ render() {
   const { selectedDay } = this.state;
   const modifiers = {
     selected(day) {
+      if (selectedDay == null) return false;
       return day.getDate() === selectedDay.getDate() &&
         day.getMonth() === selectedDay.getMonth() &&
         day.getFullYear() === selectedDay.getFullYear();


### PR DESCRIPTION
I made a little addition to documentation, about `modifiers` section
In your `selected` function when no day is selected (for example when datepicker is rendered on the page, and the user hasn't chose some date yet) the `selectedDay` is `null`, and this code will throw an error `Uncaught TypeError: Cannot read property 'getDate' of null`.

Users who will copy this chunk of code will get this error, so i added a little check for the preventing of such situation.