### PR TITLE
Add default option to onDayKeyDown switch statement

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -302,9 +302,8 @@ export default class DayPicker extends Component {
       }
       break;
     default:
-        if (onDayKeyDown) {
-          onDayKeyDown(e);
-        }
+      if (onDayKeyDown) {
+        onDayKeyDown(e);
       }
     }
   }

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -303,7 +303,7 @@ export default class DayPicker extends Component {
       break;
     default:
       if (this.props.onDayKeyDown) {
-        this.props.onDayKeyDown(e.target);
+        this.props.onDayKeyDown(e);
       }
     }
   }

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -9,7 +9,8 @@ const keys = {
   RIGHT: 39,
   DOWN: 40,
   ENTER: 13,
-  SPACE: 32
+  SPACE: 32,
+  TAB: 9
 };
 
 class Caption extends Component {
@@ -272,7 +273,6 @@ export default class DayPicker extends Component {
 
   handleDayKeyDown(e, day, modifiers) {
     e.persist();
-    const { onDayKeyDown } = this.props;
 
     switch (e.keyCode) {
     case keys.LEFT:
@@ -302,8 +302,8 @@ export default class DayPicker extends Component {
       }
       break;
     default:
-      if (onDayKeyDown) {
-        onDayKeyDown(e);
+      if (this.props.onDayKeyDown) {
+        this.props.onDayKeyDown(e.target);
       }
     }
   }

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -47,6 +47,7 @@ export default class DayPicker extends Component {
     toMonth: PropTypes.instanceOf(Date),
 
     onDayClick: PropTypes.func,
+    onDayKeyDown: PropTypes.func,
     onDayTouchTap: PropTypes.func,
     onDayMouseEnter: PropTypes.func,
     onDayMouseLeave: PropTypes.func,
@@ -271,6 +272,8 @@ export default class DayPicker extends Component {
 
   handleDayKeyDown(e, day, modifiers) {
     e.persist();
+     const { onDayKeyDown } = this.props;
+
     switch (e.keyCode) {
     case keys.LEFT:
       this.cancelEvent(e);
@@ -298,6 +301,11 @@ export default class DayPicker extends Component {
         this.handleDayTouchTap(e, day, modifiers);
       }
       break;
+    default:
+        if (onDayKeyDown) {
+          onDayKeyDown(e);
+        }
+      }
     }
   }
 

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -272,7 +272,7 @@ export default class DayPicker extends Component {
 
   handleDayKeyDown(e, day, modifiers) {
     e.persist();
-     const { onDayKeyDown } = this.props;
+    const { onDayKeyDown } = this.props;
 
     switch (e.keyCode) {
     case keys.LEFT:

--- a/test/DayPicker.js
+++ b/test/DayPicker.js
@@ -23,7 +23,8 @@ const keys = {
   UP: 38,
   DOWN: 40,
   ENTER: 13,
-  SPACE: 32
+  SPACE: 32,
+  TAB: 9
 };
 
 describe("DayPicker", () => {
@@ -962,6 +963,19 @@ describe("DayPicker", () => {
       keyCode: keys.SPACE
     });
     expect(handleDayClick).to.be.called;
+  });
+
+  it("calls onDayKeyDown when tab key is pressed on a day cell", () => {
+    const handleDayKeyDown = sinon.spy();
+    const dayPickerEl = TestUtils.renderIntoDocument(
+      <DayPicker onDayKeyDown={handleDayKeyDown} />
+    );
+    const node = dayPickerEl.refs.dayPicker;
+    const dayNode = node.querySelector(".DayPicker-Day:not(.DayPicker-Day--outside)");
+    TestUtils.Simulate.keyDown(dayNode, {
+      keyCode: keys.TAB
+    });
+    expect(handleDayKeyDown).to.be.called;
   });
 
   it("calls onDayTouchTap when enter key is pressed on a day cell", () => {


### PR DESCRIPTION
Thanks for this pull request!

Please explain the intent of your changes. If they involve a lot of code, you may want to discuss this first on our gitter room: https://gitter.im/gpbl/react-day-picker.

Add support for additional, custom keyDown events. For example passing a function to close the day picker if the user presses tab while focussed on a day.