### PR TITLE
Add reverseMonths property to render months in the reverse orde…

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -43,7 +43,7 @@ export default class DayPicker extends Component {
 
     enableOutsideDays: PropTypes.bool,
     canChangeMonth: PropTypes.bool,
-    reverseMonthsRender: PropTypes.bool,
+    reverseMonths: PropTypes.bool,
     fromMonth: PropTypes.instanceOf(Date),
     toMonth: PropTypes.instanceOf(Date),
 
@@ -67,7 +67,7 @@ export default class DayPicker extends Component {
     localeUtils: LocaleUtils,
     enableOutsideDays: false,
     canChangeMonth: true,
-    reverseMonthsRender: false,
+    reverseMonths: false,
     renderDay: day => day.getDate(),
     captionElement: <Caption />
   };
@@ -501,7 +501,7 @@ export default class DayPicker extends Component {
   }
 
   render() {
-    const { numberOfMonths, locale, canChangeMonth, reverseMonthsRender, ...attributes } = this.props;
+    const { numberOfMonths, locale, canChangeMonth, reverseMonths, ...attributes } = this.props;
     const { currentMonth } = this.state;
     let className = `DayPicker DayPicker--${locale}`;
 
@@ -519,7 +519,7 @@ export default class DayPicker extends Component {
       months.push(this.renderMonth(month, i));
     }
 
-    if (reverseMonthsRender) {
+    if (reverseMonths) {
       months.reverse();
     }
 

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -43,6 +43,7 @@ export default class DayPicker extends Component {
 
     enableOutsideDays: PropTypes.bool,
     canChangeMonth: PropTypes.bool,
+    reverseMonthsRender: PropTypes.bool,
     fromMonth: PropTypes.instanceOf(Date),
     toMonth: PropTypes.instanceOf(Date),
 
@@ -66,6 +67,7 @@ export default class DayPicker extends Component {
     localeUtils: LocaleUtils,
     enableOutsideDays: false,
     canChangeMonth: true,
+    reverseMonthsRender: false,
     renderDay: day => day.getDate(),
     captionElement: <Caption />
   };
@@ -499,7 +501,7 @@ export default class DayPicker extends Component {
   }
 
   render() {
-    const { numberOfMonths, locale, canChangeMonth, ...attributes } = this.props;
+    const { numberOfMonths, locale, canChangeMonth, reverseMonthsRender, ...attributes } = this.props;
     const { currentMonth } = this.state;
     let className = `DayPicker DayPicker--${locale}`;
 
@@ -515,6 +517,10 @@ export default class DayPicker extends Component {
     for (let i = 0; i < numberOfMonths; i++) {
       month = DateUtils.addMonths(currentMonth, i);
       months.push(this.renderMonth(month, i));
+    }
+
+    if (reverseMonthsRender) {
+      months.reverse();
     }
 
     return (

--- a/test/DayPicker.js
+++ b/test/DayPicker.js
@@ -37,6 +37,7 @@ describe("DayPicker", () => {
     expect(dayPicker.props.locale).to.equal("en");
     expect(dayPicker.props.enableOutsideDays).to.equal(false);
     expect(dayPicker.props.canChangeMonth).to.equal(true);
+    expect(dayPicker.props.reverseMonthsRender).to.equal(false);
     expect(dayPicker.props.tabIndex).to.equal(0);
     expect(dayPicker.props.style).to.be.undefined;
     expect(dayPicker.props.className).to.be.undefined;
@@ -112,6 +113,16 @@ describe("DayPicker", () => {
     const months = TestUtils.scryRenderedDOMComponentsWithClass(dayPickerEl,
       "DayPicker-Month");
     expect(months).to.have.length(3);
+  });
+
+  it("renders the months on a reverse order as specified by reverseMonthsRender", () => {
+    const dayPickerEl = TestUtils.renderIntoDocument(
+      <DayPicker initialMonth={new Date(2015, 11, 6)} numberOfMonths={4} reverseMonthsRender={true} />
+    );
+    const captionEl = TestUtils.scryRenderedDOMComponentsWithClass(dayPickerEl,
+      "DayPicker-Caption");
+    expect(ReactDOM.findDOMNode(captionEl[0]).innerHTML).to.equal("March 2016");
+    expect(ReactDOM.findDOMNode(captionEl[1]).innerHTML).to.equal("February 2016");
   });
 
   it("renders a caption for each month", () => {

--- a/test/DayPicker.js
+++ b/test/DayPicker.js
@@ -37,7 +37,7 @@ describe("DayPicker", () => {
     expect(dayPicker.props.locale).to.equal("en");
     expect(dayPicker.props.enableOutsideDays).to.equal(false);
     expect(dayPicker.props.canChangeMonth).to.equal(true);
-    expect(dayPicker.props.reverseMonthsRender).to.equal(false);
+    expect(dayPicker.props.reverseMonths).to.equal(false);
     expect(dayPicker.props.tabIndex).to.equal(0);
     expect(dayPicker.props.style).to.be.undefined;
     expect(dayPicker.props.className).to.be.undefined;
@@ -115,9 +115,9 @@ describe("DayPicker", () => {
     expect(months).to.have.length(3);
   });
 
-  it("renders the months on a reverse order as specified by reverseMonthsRender", () => {
+  it("renders the months on a reverse order as specified by reverseMonths", () => {
     const dayPickerEl = TestUtils.renderIntoDocument(
-      <DayPicker initialMonth={new Date(2015, 11, 6)} numberOfMonths={4} reverseMonthsRender={true} />
+      <DayPicker initialMonth={new Date(2015, 11, 6)} numberOfMonths={4} reverseMonths={true} />
     );
     const captionEl = TestUtils.scryRenderedDOMComponentsWithClass(dayPickerEl,
       "DayPicker-Caption");


### PR DESCRIPTION
Desire Functionality: Display months in reverse order using the reverseMonths property

This pull request is intended to display the months on a reverse order when we are displaying multiple months in a column.

I'm attaching images as examples, (I'm displaying a calendar column from January of 2008 until today):

![reverseMonths false default](https://cloud.githubusercontent.com/assets/16649596/14152656/3b9fc322-f6ac-11e5-9f5c-b4a36e404e3a.png)

![reverseMonths true](https://cloud.githubusercontent.com/assets/16649596/14152658/3d494de2-f6ac-11e5-8dcb-6d71edc607b4.png)

On the first image, reverseMonths property is set to false (default) Jan 2008 appears at the top of the column. 

On the second image, reverseMonths property is set to true Mar 2016 appears at the top of the column.