### PR TITLE
Add version number to DayPicker class

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -25,6 +25,7 @@ class Caption extends Component { // eslint-disable-line
 }
 
 export default class DayPicker extends Component {
+  static VERSION = "2.0.0";
 
   static propTypes = {
     tabIndex: PropTypes.number,


### PR DESCRIPTION
This can be helpful if you need to figure out what version of a library is actually running in your app.

The downside is that as a dev, you have to remember to update this for each release, but I think it's worth it!