### PR TITLE
IE11 for of loop fix #174

### DIFF
--- a/src/Helpers.js
+++ b/src/Helpers.js
@@ -20,17 +20,14 @@ export function getDaysInMonth(d) {
   return resultDate.getDate();
 }
 
-export function getModifiersForDay(d, modifierFunctions) {
-  const modifiers = [];
-  if (modifierFunctions) {
-    for (const modifier of Object.keys(modifierFunctions)) {
-      const func = modifierFunctions[modifier];
-      if (func(d)) {
-        modifiers.push(modifier);
-      }
+export function getModifiersForDay(d, modifierFunctions = {}) {
+  return Object.keys(modifierFunctions).reduce((modifiers, modifier) => {
+    const func = modifierFunctions[modifier];
+    if (func(d)) {
+      modifiers.push(modifier);
     }
-  }
-  return modifiers;
+    return modifiers;
+  }, []);
 }
 
 export function getMonthsDiff(d1, d2) {


### PR DESCRIPTION
As discussed in ticket #174 this pull request replaces the for of loop with a a reduce function, as babel compiles it to a Symbol, which has not support in IE.

