### PR TITLE
Added fixedWeeks flag

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -11,6 +11,7 @@
 | [captionElement](APIProps.md#captionelement) | | `Element` |
 | [disabledDays](APIProps.md#disableddays) | | `Bool` |
 | [enableOutsideDays](APIProps.md#enableoutsidedays) | false | `Bool` |
+| [enableFixedAmountOfWeeks](APIProps.md#enableFixedAmountOfWeeks) | false | `Bool` |
 | [fromMonth](APIProps.md#frommonth) | | `Date` |
 | [initialMonth](APIProps.md#initialmonth) | Current month | `Date` |
 | [locale](APIProps.md#locale) | en | `String` |

--- a/docs/APIProps.md
+++ b/docs/APIProps.md
@@ -47,6 +47,12 @@ Display the days outside the current month. Default is `false`.
 
 ---
 
+#### enableFixedAmountOfWeeks `Bool`
+
+Display a fixed number of weeks. All months have a number of weeks between 4 and 6. With this flag, the calendar will show exactly 6 weeks (Examples for 4 and 6 weeks: Febrary 2015, July 2016). Default is `false`.
+
+---
+
 #### canChangeMonth `Bool`
 
 Enable the navigation between months. Default is `true`.

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -27,6 +27,7 @@ export default class DayPicker extends Component {
     localeUtils: DayPickerPropTypes.localeUtils,
 
     enableOutsideDays: PropTypes.bool,
+    fixedWeeks: PropTypes.bool,
     canChangeMonth: PropTypes.bool,
     reverseMonths: PropTypes.bool,
     fromMonth: PropTypes.instanceOf(Date),
@@ -60,6 +61,7 @@ export default class DayPicker extends Component {
     locale: 'en',
     localeUtils: LocaleUtils,
     enableOutsideDays: false,
+    fixedWeeks: false,
     canChangeMonth: true,
     reverseMonths: false,
     renderDay: day => day.getDate(),
@@ -392,6 +394,7 @@ export default class DayPicker extends Component {
           key={i}
           month={month}
           firstDayOfWeek={firstDayOfWeek}
+          fixedWeeks={this.props.fixedWeeks}
           captionElement={this.props.captionElement}
           onCaptionClick={this.props.onCaptionClick}
         >

--- a/src/Helpers.js
+++ b/src/Helpers.js
@@ -38,7 +38,7 @@ export function getMonthsDiff(d1, d2) {
     (12 * (d2.getFullYear() - d1.getFullYear()));
 }
 
-export function getWeekArray(d, firstDayOfWeek = getFirstDayOfWeek()) {
+export function getWeekArray(d, firstDayOfWeek = getFirstDayOfWeek(), fixedWeeks) {
   const daysInMonth = getDaysInMonth(d);
   const dayArray = [];
 
@@ -74,6 +74,25 @@ export function getWeekArray(d, firstDayOfWeek = getFirstDayOfWeek()) {
     const outsideDate = clone(lastWeek[lastWeek.length - 1]);
     outsideDate.setDate(lastWeek[lastWeek.length - 1].getDate() + 1);
     lastWeek.push(outsideDate);
+  }
+
+  // add extra weeks to reach 6 weeks
+  if (fixedWeeks && weekArray.length < 6) {
+    let lastExtraWeek;
+
+    for (let i = weekArray.length; i < 6; i++) {
+      lastExtraWeek = weekArray[weekArray.length - 1];
+      const lastDay = lastExtraWeek[lastExtraWeek.length - 1];
+      const extraWeek = [];
+
+      for (let j = 0; j < 7; j++) {
+        const outsideDate = clone(lastDay);
+        outsideDate.setDate(lastDay.getDate() + j + 1);
+        extraWeek.push(outsideDate);
+      }
+
+      weekArray.push(extraWeek);
+    }
   }
 
   return weekArray;

--- a/src/Month.js
+++ b/src/Month.js
@@ -15,6 +15,7 @@ export default function Month({
   wrapperClassName,
   weekClassName,
   weekdayComponent,
+  fixedWeeks,
 }) {
   const captionProps = {
     date: month,
@@ -22,7 +23,7 @@ export default function Month({
     locale,
     onClick: onCaptionClick ? e => onCaptionClick(e, month) : undefined,
   };
-  const weeks = getWeekArray(month, firstDayOfWeek);
+  const weeks = getWeekArray(month, firstDayOfWeek, fixedWeeks);
   return (
     <div className={className}>
       {React.cloneElement(captionElement, captionProps)}
@@ -51,4 +52,5 @@ Month.propTypes = {
   wrapperClassName: PropTypes.string,
   weekClassName: PropTypes.string,
   weekdayComponent: PropTypes.func.isRequired,
+  fixedWeeks: PropTypes.bool,
 };

--- a/test/DayPicker.js
+++ b/test/DayPicker.js
@@ -22,6 +22,7 @@ describe('<DayPicker />', () => {
       expect(dayPicker.props.numberOfMonths).to.equal(1);
       expect(dayPicker.props.locale).to.equal('en');
       expect(dayPicker.props.enableOutsideDays).to.equal(false);
+      expect(dayPicker.props.fixedWeeks).to.equal(false);
       expect(dayPicker.props.canChangeMonth).to.equal(true);
       expect(dayPicker.props.reverseMonths).to.equal(false);
       expect(dayPicker.props.renderDay).to.be.a('Function');
@@ -120,6 +121,10 @@ describe('<DayPicker />', () => {
       expect(wrapper.find('.DayPicker-Day').at(0)).to.have.text('28');
       expect(wrapper.find('.DayPicker-Day').at(1)).to.have.text('29');
       expect(wrapper.find('.DayPicker-Day').at(2)).to.have.text('30');
+    });
+    it('should render the fixed amount of weeks', () => {
+      const wrapper = mount(<DayPicker enableOutsideDays fixedWeeks initialMonth={new Date(2015, 1)} />);
+      expect(wrapper.find('.DayPicker-Day')).to.have.length(42);
     });
   });
 


### PR DESCRIPTION
#### Problem

If your calendar is in a container with other elements around and you move between months, the container resizes to the number of weeks shown and this can create an annoying effect.

#### Solution

**Added fixedWeeks flag**

With this new flag, the calendar will show always the same number of
weeks. Exactly 6, because is the maximum number of week that a month can
have.

You can see here an example with this flag enabled:

![6weeks](https://cloud.githubusercontent.com/assets/135988/15829371/d12f4c9a-2c13-11e6-8187-114eaf3ec034.gif)