### PR TITLE
Add support for adjusting the `initialMonth` to the start of a page.

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -96,9 +96,24 @@ export default class DayPicker extends Component {
     }
   }
 
-  getStateFromProps = props => ({
-    currentMonth: Helpers.startOfMonth(props.initialMonth),
-  })
+  getStateFromProps = props => {
+    const initialMonth = Helpers.startOfMonth(props.initialMonth);
+    let currentMonth = initialMonth;
+
+    if (
+      props.pagedNavigation &&
+      props.numberOfMonths > 1 &&
+      props.fromMonth
+    ) {
+      const diffInMonths = Helpers.getMonthsDiff(props.fromMonth, currentMonth);
+
+      currentMonth = DateUtils.addMonths(
+        props.fromMonth,
+        Math.floor(diffInMonths / props.numberOfMonths) * props.numberOfMonths
+      );
+    }
+    return { currentMonth };
+  }
 
   getModifiersFromProps(props) {
     const modifiers = { ...props.modifiers };

--- a/test/DayPicker.js
+++ b/test/DayPicker.js
@@ -783,4 +783,20 @@ describe('<DayPicker />', () => {
       focusPreviousWeek.restore();
     });
   });
+
+  describe('paged navigation', () => {
+    it('should set the current month to the first month in its page if fromMonth is set', () => {
+      const instance = shallow(
+        <DayPicker
+          initialMonth={new Date(2015, 7)}
+          fromMonth={new Date(2015, 1)}
+          numberOfMonths={4}
+          pagedNavigation
+        />
+      ).instance();
+      expect(instance.state.currentMonth.getFullYear()).to.equal(2015);
+      expect(instance.state.currentMonth.getMonth()).to.equal(5);
+      expect(instance.state.currentMonth.getDate()).to.equal(1);
+    });
+  });
 });


### PR DESCRIPTION
As discussed in [#196](https://github.com/gpbl/react-day-picker/issues/196#issuecomment-233597654).