### PR TITLE
Ensure weekday labels respect the locale’s `firstDayOfWeek`

### DIFF
--- a/src/Month.js
+++ b/src/Month.js
@@ -29,6 +29,7 @@ export default function Month({
     <div className={ className }>
       {React.cloneElement(captionElement, captionProps)}
       <Weekdays
+        firstDayOfWeek={ firstDayOfWeek }
         locale={ locale }
         localeUtils={ localeUtils }
         weekdayComponent={ weekdayComponent }

--- a/src/Weekdays.js
+++ b/src/Weekdays.js
@@ -10,7 +10,7 @@ export default function Weekdays({
 }) {
   const days = [];
   for (let i = 0; i < 7; i += 1) {
-    const weekday = (i + firstDayOfWeek) % 7
+    const weekday = (i + firstDayOfWeek) % 7;
     const elementProps = {
       key: i,
       className: 'DayPicker-Weekday',

--- a/src/Weekdays.js
+++ b/src/Weekdays.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 import DayPickerPropTypes from './PropTypes';
 
 export default function Weekdays({
+  firstDayOfWeek,
   locale,
   localeUtils,
   weekdayComponent,
@@ -9,10 +10,11 @@ export default function Weekdays({
 }) {
   const days = [];
   for (let i = 0; i < 7; i += 1) {
+    const weekday = (i + firstDayOfWeek) % 7
     const elementProps = {
       key: i,
       className: 'DayPicker-Weekday',
-      weekday: i,
+      weekday,
       localeUtils,
       locale,
     };
@@ -32,6 +34,7 @@ export default function Weekdays({
 }
 
 Weekdays.propTypes = {
+  firstDayOfWeek: PropTypes.number.isRequired,
   locale: PropTypes.string.isRequired,
   localeUtils: DayPickerPropTypes.localeUtils.isRequired,
   weekdayComponent: PropTypes.func,

--- a/test/DayPicker.js
+++ b/test/DayPicker.js
@@ -7,6 +7,7 @@ import { shallow, mount, render } from 'enzyme';
 import { expect } from 'chai';
 import sinon, { spy } from 'sinon';
 import DayPicker from '../src/DayPicker';
+import * as LocaleUtils from '../src/LocaleUtils';
 import keys from '../src/keys';
 
 describe('<DayPicker />', () => {
@@ -158,6 +159,11 @@ describe('<DayPicker />', () => {
         <DayPicker enableOutsideDays fixedWeeks initialMonth={ new Date(2015, 1) } />
       );
       expect(wrapper.find('.DayPicker-Day')).to.have.length(42);
+    });
+    it('should render weekday labels accounting for locale settings', () => {
+      const localeUtils = Object.assign({}, LocaleUtils, {getFirstDayOfWeek: (locale) => 1})
+      const wrapper = mount(<DayPicker localeUtils={localeUtils} />);
+      expect(wrapper.find('.DayPicker-Weekday').at(0)).to.have.text('Mo');
     });
   });
 

--- a/test/DayPicker.js
+++ b/test/DayPicker.js
@@ -161,8 +161,8 @@ describe('<DayPicker />', () => {
       expect(wrapper.find('.DayPicker-Day')).to.have.length(42);
     });
     it('should render weekday labels accounting for locale settings', () => {
-      const localeUtils = Object.assign({}, LocaleUtils, {getFirstDayOfWeek: (locale) => 1})
-      const wrapper = mount(<DayPicker localeUtils={localeUtils} />);
+      const localeUtils = Object.assign({}, LocaleUtils, { getFirstDayOfWeek: () => 1 });
+      const wrapper = mount(<DayPicker localeUtils={ localeUtils } />);
       expect(wrapper.find('.DayPicker-Weekday').at(0)).to.have.text('Mo');
     });
   });


### PR DESCRIPTION
I noticed today that the `firstDayOfWeek` locale setting isn’t respected by the weekday headings. 

This change passes through that prop to the `<Weekdays>` component and then appropriately normalises it to a `0-6` integer using the modulo operator so that they do match up to the dates below.