### PR TITLE
Accept different kind of modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ See this [jsfiddle](https://jsfiddle.net/gpbl/gh072eqt/) as example.
 
 ```js
 import React from 'react';
-import DayPicker, { DateUtils } from "react-day-picker";
+import DayPicker from "react-day-picker";
 
-function sunday(day) {
+function sundays(day) {
   return day.getDay() === 0;
 }
 
@@ -59,22 +59,18 @@ class MyComponent extends React.Component {
   state = {
     selectedDay: new Date(),
   }
-  handleDayClick(e, day, { selected, disabled }) {
+  handleDayClick(e, day, { disabled, selected }) {
     if (disabled) {
       return;
     }
-    if (selected) {
-      this.setState({ selectedDay: null })
-    } else {
-      this.setState({ selectedDay: day });
-    }
+    this.setState({ selectedDay: selected ? null : day })
   },
   render() {
     return (
       <DayPicker
         initialMonth={ new Date(2016, 1) }
-        disabledDays={ sunday }
-        selectedDays={ day => DateUtils.isSameDay(this.state.selectedDay, day) }
+        disabledDays={ sundays }
+        selectedDays={ this.state.selectedDay }
         onDayClick={ this.handleDayClick.bind(this) }
     />);
   }

--- a/docs/API.md
+++ b/docs/API.md
@@ -9,7 +9,7 @@
 | --- | --- | --- |
 | [canChangeMonth](APIProps.md#canchangemonth) | true | `Bool` |
 | [captionElement](APIProps.md#captionelement) | | `Element` |
-| [disabledDays](APIProps.md#disableddays) | | `Bool` |
+| [disabledDays](APIProps.md#disableddays) | | `Date || Object || (day: Date) ⇒ Bool || Array<Date|Object|Function>` |
 | [enableOutsideDays](APIProps.md#enableoutsidedays) | false | `Bool` |
 | [firstDayOfWeek](APIProps.md#firstdayofweek) | 0 | `Number` |
 | [fixedWeeks](APIProps.md#fixedWeeks) | false | `Bool` |
@@ -31,7 +31,7 @@
 | [pagedNavigation](APIProps.md#pagednavigation) |false | `Bool` |
 | [renderDay](APIProps.md#renderday) | day ⇒ day.getDate() | `(day: Date) ⇒ Element` |
 | [reverseMonths](APIProps.md#reversemonths) | false | `Bool` |
-| [selectedDays](APIProps.md#selecteddays) | | `Bool` |
+| [selectedDays](APIProps.md#selecteddays) | | `Date || Object || (day: Date) ⇒ Bool || Array<Date|Object|Function>` |
 | [tabIndex](APIProps.md#tabindex) | | `Number` |
 | [toMonth](APIProps.md#tomonth) | | `Date` |
 | [weekdayElement](APIProps.md#weekdayelement) | | `Element` |

--- a/docs/APIProps.md
+++ b/docs/APIProps.md
@@ -25,9 +25,11 @@ See also [this advanced example](../examples?yearNavigation), showing a year nav
 
 ### disabledDays
 
-**Type**: `(day: Date) ⇒ Bool`
+**Type**: `Date` || `Object` || `(day: Date) ⇒ Bool` || `Array<Date|Object|Function>`
 
-A function returning a boolean indicating if a day is disabled. Set a `disabled` modifier.
+Indicate which day should appear as disabled. Set a `selected` modifier. 
+
+See [Modifiers](Modifiers.md) for a reference of the accepted values.
 
 ### enableOutsideDays
 
@@ -77,7 +79,8 @@ By default the used locale is English (US). See also [Localization](Localization
 
 **Type**: `Object`
 
-An object of named functions returning a boolean: `modifier(day: Date) -> Bool`. When a function of this object evaluates `true`, its name is used as CSS modifier for the day's cell.
+An object of [modifiers values](Modifiers.md), whose keys will be used as CSS modifiers.
+
 As default, the calendar includes `today` and `outside` modifiers. (_Outside_ are the days that appear on the calendar but don't belong to the current month).
 
 ### months
@@ -129,9 +132,11 @@ Render the months in reversed order. Useful when `numberOfMonths` is greater tha
 
 ### selectedDays 
 
-**Type**: `(day: Date) ⇒ Bool`
+**Type**: `Date` || `Object` || `(day: Date) ⇒ Bool` || `Array<Date|Object|Function>`
 
-A function returning a boolean indicating if a day is selected. Set a `selected` modifier.
+Indicate which day should appear as selected. Set a `selected` modifier.
+
+See [Modifiers](Modifiers.md) for a reference of the accepted values.
 
 ### toMonth
 

--- a/docs/Basic.md
+++ b/docs/Basic.md
@@ -4,7 +4,7 @@ react-day-picker is designed to cover the most common needs for a date picker in
 
 ## Selecting a day
 
-react-day-picker doesn't hold the selected day in its state. Instead, you have to set it in your component when the user interacts with the calendar.
+react-day-picker doesn't hold the selected day in its state. Instead, you have to save it in your component as the user interacts with the calendar.
 
 The following component uses the `onDayClick` prop to save the clicked day in its own state:
 
@@ -18,8 +18,7 @@ class SelectDay extends React.Component {
     this.handleDayClick = this.handleDayClick.bind(this);
   }
   state = {
-    // The default selected day is today
-    selectedDay: new Date(),
+    selectedDay: new Date(), // We set the selected default as today
   };
   handleDayClick(e, day) {
     this.setState({ selectedDay: day });
@@ -37,9 +36,9 @@ class SelectDay extends React.Component {
 }
 ```
 
-Somewhere your CSS must style the appearance for the selected day, but first you need to tell the Day Picker which days have been selected.
+Somewhere your CSS must style the appearance for the selected day cell, but first you need to tell the Day Picker which days have been selected.
 
-The `selectedDays` prop is a function that checks whether a day should get the `selected` CSS modifier:
+We pass then the selected day (saved in the component’s state) to the `selectedDays` prop. That day cell will get the `--selected` CSS modifier:
 
 ```jsx
 import React from 'react';
@@ -65,7 +64,7 @@ class SelectDay extends React.Component {
       <div>
         <DayPicker
           onDayClick={ this.handleDayClick }
-          selectedDays={ this.isDaySelected }
+          selectedDays={ this.state.selectedDay }
         />
         <p>
           The selected day is { this.state.selectedDay.toLocaleDateString() }
@@ -89,16 +88,16 @@ Then, in your CSS, add a `.DayPicker-Day--selected` selector to highlight the ce
 
 ### Clearing the selected day
 
-When a selected day is clicked again, we want to clear it. This can be made setting the component's `selectedDay` to `null`.
+When a selected day is clicked again, we want to clear it. This can be made setting the component's `selectedDay` to `undefined` (or `null`).
 
-The `onDayClick` handler receives as third argument a `modifiers` object that can be inspected if the clicked day has been selected or not:
+The `onDayClick` handler receives as third argument an object that can be inspected to check if the clicked day has been selected or not:
 
 ```jsx
 // snip
 handleDayClick(e, day, { selected }) {
   if (selected) {
     // Unselect the day if already selected
-    this.state({ selectedDay: null });
+    this.state({ selectedDay: undefined });
     return;
   }
   this.setState({ selectedDay: day });
@@ -109,19 +108,21 @@ That's all! [See this example](http://react-day-picker.js.org/examples?selectabl
 
 ## Marking days as disabled
 
-Disabled days should not respond to the user's interaction and should appear as "disabled" on the calendar. Use the `disabledDays` prop to specify which days should be disabled.
+Disabled days should not respond to the user's interaction and should appear as "disabled" (e.g. grayed out) on the calendar. 
+
+Use the `disabledDays` prop to specify which days should be disabled.
 
 In the following example, we choose to disable every Sunday:
 
 ```jsx
 import DayPicker from 'react-day-picker';
 
-const isSunday = day => day.getDay() === 0;
+const sundays = day => day.getDay() === 0;
 
 class SelectDay extends React.Component {
   render() {
     return (
-      <DayPicker disabledDays={ isSunday } />
+      <DayPicker disabledDays={ sundays } />
     )
   }
 }
@@ -142,9 +143,9 @@ Then, style the day to appear as disabled in your CSS using the `.DayPicker-Day-
 In the previous example nothing happens when the user clicks on a day, since the `onDayClick` prop is missing. As before, we need to save the value of the selected day in our component's state:
 
 ```jsx
-import DayPicker, { DateUtils } from 'react-day-picker';
+import DayPicker from 'react-day-picker';
 
-const isSunday = day => day.getDay() === 0;
+const sundays = day => day.getDay() === 0;
 
 class SelectDay extends React.Component {
   constructor(props) {
@@ -154,9 +155,6 @@ class SelectDay extends React.Component {
   state = {
     selectedDay: new Date(),
   };
-  isDaySelected(day) {
-    return DateUtils.isSameDay(day, this.state.selectedDay);
-  }
   handleDayClick(e, day) {
     this.setState({ selectedDay: day });
   }
@@ -164,8 +162,8 @@ class SelectDay extends React.Component {
     return (
       <div>
         <DayPicker
-          disabledDays={ isSunday }
-          selectedDays={ this.isSelectedDay }
+          disabledDays={ sundays }
+          selectedDays={ this.state.selectedDay }
           onDayClick={ this.handleDayClick }
         />
         <p>
@@ -177,7 +175,9 @@ class SelectDay extends React.Component {
 }
 ```
 
-This, however, will make selectable even the disabled days. We need instead our component to _not_ update its state, in case the clicked day is disabled. In the click handler we can use the day's modifiers to check if the day was disabled:
+This, however, will make selectable _the disabled days too_. We need instead our component to _not_ update its state if the clicked day is disabled. 
+
+In the click handler we can use the day's modifiers to check if the day was disabled, and prevent its selection:
 
 ```jsx
 handleDayClick(e, day, { disabled }) {
@@ -193,6 +193,6 @@ Check out [this example](http://react-day-picker.js.org/examples?disabled) shows
 
 ## Next steps
 
-The `selectedDays` function and the `onDayClick` event handler can implement a more complex logic to make the date picker more powerful. For example, you can make the date picker to [select a range of days](http://react-day-picker.js.org/examples?range).
+The `selectedDays` prop and the `onDayClick` event handler can implement a more complex logic to make the date picker more powerful. For example, you can make the date picker to [select a range of days](http://react-day-picker.js.org/examples?range).
 
 You can go deeper with the customization using **modifiers**. Modifiers are a powerful concept behind react-day-picker. Read more about them in the [next chapter](Modifiers.md).

--- a/docs/Modifiers.md
+++ b/docs/Modifiers.md
@@ -1,38 +1,97 @@
-# Use of modifiers
+# Use of Modifiers
 
 Modifiers give you the full control over the appearance and the behavior of the date picker. You use modifiers to implement the different logic according to your data.
 
-Modifiers are _named functions_ called when rendering a day cell. They take the day as first argument and return a boolean value. For example, these functions are valid modifiers:
+Modifier values are passed to the component via the `selectedDays`, `disabledDays` and `modifier` props. 
 
-```js
-function isSunday(day) {
-  return day.getDay() === 0;
-}
-function isFirstDayOfMonth(day) {
-  return day.getDate() === 1;
-}
-```
+The value of a modifier can be either:
 
-You pass modifiers to the Day Picker using the `modifiers` prop:
+- **a `Date` object**, to match a specific day
+- **a `range` object** with `from` and `to` keys, to match a range of days. For example 
+
+  ```js
+  const range = { 
+    from: new Date(2015, 0, 12), 
+    to: new Date(2015, 0, 16) 
+  }
+  ```
+  will match the days between the 12th and the 16th of January.
+
+- **an object with a `before` key**, to match the days before the given date. For example 
+  ```js
+  const range = { 
+    before: new Date(), 
+  }
+  ```
+  will match all the past the days (i.e. the days before today).
+
+- **an object with a `after` key**, to match the days after the given date. For example 
+
+  ```js
+  const range = { 
+    before: new Date(2018, 0, 1), 
+  }
+  ```
+
+  will match all the days after the January, 1st 2018.
+
+- **a function** that take the day as first argument and return a boolean value. For example:
+  
+  ```js
+  function sundays(day) {
+    return day.getDay() === 0;
+  }
+  function isFirstOfMonth(day) {
+    return day.getDate() === 1;
+  }
+  ```
+  are all valid modifiers.
+- **an array of the above** 
+
+You pass modifiers to the day-picker using the `modifiers` prop. Here some example of modifiers:
 
 ```jsx
-<DayPicker modifiers={{ isSunday, isFirstDayOfMonth }} />
+<DayPicker 
+  modifiers={{ 
+    special: new Date(2018, 11, 11),
+    booked: { from: new Date(2017, 1, 11), to: new Date(2017, 2, 23) },
+    holiday: [new Date(2018, 11, 25), new Date(2018, 10, 31)],
+    sunday: day => day.getDay() === 0, 
+    firstOfMonth: day => day.getDate() === 1,
+  }}
+/>
 ```
 
 #### `selected` and `disabled` modifiers
 
-Under the hood, the `selectedDays` and `disabledDays` props set a `selected` and a `disabled` modifier. This code is the same:
+Under the hood, the `selectedDays` and `disabledDays` props act as shortcut for the `selected` and a `disabled` modifiers. 
+
+Hence, the following two day-picker render the same:
 
 ```jsx
-<DayPicker disabledDays={ isSunday } selectedDays={ isFirstDayOfMonth } />
-<DayPicker modifiers={ { disabled: isSunday, selected: isFirstDayOfMonth }} />
+
+function sundays(day) {
+    return day.getDay() === 0;
+  }
+function isFirstOfMonth(day) {
+  return day.getDate() === 1;
+}
+
+<DayPicker disabledDays={ sundays } selectedDays={ firstOfMonth } />
+
+<DayPicker 
+  modifiers={ { 
+    disabled: sundays, 
+    selected: firstOfMonth 
+  }} 
+/>
 ```
 
 ### Use modifiers to style the day cells
 
 The CSS class for a day cell will get the modifier (as in [BEM-like syntax](https://css-tricks.com/bem-101/)) when the corresponding function returns `true` for the given day.
 
-For example, using the modifiers above, any cell representing a Sunday will have the `DayPicker-Day--isSunday` class name, and the first day of the month will have a `DayPicker-Day--isFirstDayOfMonth` class name.
+For example, using the modifiers above, any cell representing a Sunday will have the `DayPicker-Day--sundays` class name, and the first day of the month will have a `DayPicker-Day--isFirstOfMonth` class name.
 
 ### Access modifiers from the event handlers
 
@@ -40,19 +99,19 @@ Modifiers are passed as argument to the event handlers:
 
 ```jsx
 function handleDayClick(e, day, modifiers) {
-  if (modifiers.isSunday) {
+  if (modifiers.sundays) {
     console.log('Sunday has been clicked')
   }
 }
 
-function handleDayMouseEnter(e, day, { isFirstDayOfMonth }) {
-  if (isFirstDayOfMonth) {
+function handleDayMouseEnter(e, day, { isFirstOfMonth }) {
+  if (isFirstOfMonth) {
     console.log('The first day of month received mouse enter')
   }
 }
 
 <DayPicker
-  modifiers={{ isSunday, isFirstDayOfMonth }}
+  modifiers={{ sundays, isFirstOfMonth }}
   onDayClick={ handleDayClick }
   onDayMouseEnter={ handleDayMouseEnter }
 />
@@ -60,4 +119,4 @@ function handleDayMouseEnter(e, day, { isFirstDayOfMonth }) {
 
 ### Use DateUtils to create modifiers
 
-react-day-picker includes [DateUtils](DateUtils.md), a small function library useful to simplify the creation of modifiers.
+react-day-picker includes [DateUtils](DateUtils.md), a small function library useful to simplify the creation of advanced modifiers.

--- a/examples/.eslintrc
+++ b/examples/.eslintrc
@@ -2,6 +2,7 @@
   "rules": {
     "max-len": 0,
     "no-console": 0,
+    "no-return-assign": 0,
     "react/prop-types": 0,
     "react/jsx-filename-extension": 0,
     "react/jsx-curly-spacing": [2, "always"],

--- a/examples/src/Examples.js
+++ b/examples/src/Examples.js
@@ -6,6 +6,7 @@ import createHistory from 'history/createBrowserHistory';
 
 import './vendors/prism.css';
 
+import AdvancedModifiers from './examples/AdvancedModifiers';
 import Birthdays from './examples/Birthdays';
 import DisabledDays from './examples/DisabledDays';
 import BlockedNavigation from './examples/BlockedNavigation';
@@ -44,24 +45,29 @@ const EXAMPLES = {
     description: 'Show the clicked day in an alert window.',
     Component: SimpleCalendar,
   },
+  modifiers: {
+    title: 'Simple modifiers',
+    description: 'Use the <code>selectedDays</code> and <code>disabledDays</code> props to style a day as selected or disabled.',
+    Component: Modifiers,
+  },
   selectable: {
     title: 'Selectable Day',
-    description: "Use the <code>selectedDays</code> prop and <a href='http://react-day-picker.js.org/DateUtils.html'>DateUtils</a> to select a day. Note how the selected day is stored in the parent component’s state.",
+    description: 'Use the <code>onDayClick</code> event to mark or unmark a day as selected when the user clicks a day cell. Note how the selected day is stored in the parent component’s state, not in the react-day-picker.',
     Component: SelectableDay,
   },
   multipleselect: {
     title: 'Selecting Multiple Days',
-    description: 'A more advanced version showing how to select/unselect multiple days.',
+    description: 'Pass an array of days to <code>selectDays</code> to select multiple days.',
     Component: MultipleDays,
   },
   disabled: {
     title: 'Disabled Days',
-    description: 'Use the <code>disabledDays</code> prop to prevent the selection of days: the <code>handleDayClick</code> handler doesn\'t update the state if the day has been marked as <code>disabled</code>.',
+    description: 'Use the <code>disabledDays</code> prop to prevent the selection of a day. Here we are passing a function to disable all the weekend days. <ul><li>Note how the <code>handleDayClick</code> handler is set to not select days marked as <code>disabled</code>.</li></ul>',
     Component: DisabledDays,
   },
   input: {
     title: 'Input Field',
-    description: 'How to connect the day picker with an input field.',
+    description: 'Connect the day picker with an input field. Libraries like moment.js can help to parse/validate the input date.',
     Component: InputField,
   },
   fixedWeeks: {
@@ -71,18 +77,13 @@ const EXAMPLES = {
   },
   range: {
     title: 'Range of Days - click',
-    description: "Select a range of days using the range functions available in <a href='http://react-day-picker.js.org/DateUtils.html'>DateUtils</a>.",
+    description: 'To select a range of days, pass to <code>selectedDays</code> an object with the following shape <code>{ from: &lt;Date&gt;, to: &lt;Date&gt; }</code>.',
     Component: Range,
   },
   rangeAdvanced: {
     title: 'Range of Days – mouse enter',
-    description: 'Select a range of days when the mouse enters in a day cell.',
+    description: 'Select a range of days when the mouse enters in a day cell. Some things to note: <ul><li><code>disabledDays</code> can accept an object with a <code>before</code> key to match days before the given one</li><li>the <code>modifiers</code> prop can be used to set custom CSS modifiers, such as <code>--start</code> or <code>--end</code>.</li></ul>',
     Component: RangeAdvanced,
-  },
-  modifiers: {
-    title: 'Advanced Modifiers',
-    description: 'Use the <code>modifiers</code> prop to customize the aspect and the behaviour for each day. Note how the <code>onDay*</code> props receive the modifiers as third argument.',
-    Component: Modifiers,
   },
   blocked: {
     title: 'Block Navigation',
@@ -108,6 +109,11 @@ const EXAMPLES = {
     title: 'Localization (advanced)',
     description: "You can provide your own <code>localeUtils</code>. The following example provides Russian and English localizations.  <a href='http://react-day-picker.js.org/Localization.html'>Read more about localization</a>.",
     Component: LocalizedCustom,
+  },
+  advancedModifiers: {
+    title: 'Advanced Modifiers',
+    description: 'Use the <code>modifiers</code> prop to fully customize the aspect and have full control of the calendar behavior. <ul><li>Note how the <code>onDay*</code> props receive the modifiers as third argument.</li></ul>',
+    Component: AdvancedModifiers,
   },
   yearNavigation: {
     title: 'Year Navigation',

--- a/examples/src/examples/AdvancedModifiers.js
+++ b/examples/src/examples/AdvancedModifiers.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import DayPicker from '../../../src';
+
+import '../../../src/style.css';
+import '../styles/odd-even.css';
+
+export default class AdvancedModifiers extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleDayClick = this.handleDayClick.bind(this);
+    this.handleDayMouseEnter = this.handleDayMouseEnter.bind(this);
+  }
+  state = {
+    text: 'Please select a day 👻',
+  };
+  handleDayClick(e, day, { even, odd, blahblah }) {
+    let text;
+    if (even) {
+      text = 'Just an even day';
+    }
+    if (odd) {
+      text = 'An odd day';
+    }
+    if (blahblah) {
+      text += ': the first of the month 😱';
+    }
+    this.setState({ text });
+  }
+  handleDayMouseEnter(e, day, modifiers) {
+    console.log('Day\'s CSS classes', e.target.classList.toString());
+    console.log('Day\'s modifiers', modifiers);
+  }
+  render() {
+    const modifiers = {
+      even: day => day.getDate() % 2 === 0,
+      odd: day => day.getDate() % 2 !== 0,
+      first: day => day.getDate() === 1,
+    };
+    return (
+      <div>
+        <span>
+          <DayPicker
+            modifiers={ modifiers }
+            onDayMouseEnter={ this.handleDayMouseEnter }
+            onDayClick={ this.handleDayClick }
+          />
+        </span>
+        <p>
+          { this.state.text }
+        </p>
+      </div>
+    );
+  }
+}

--- a/examples/src/examples/DisabledDays.js
+++ b/examples/src/examples/DisabledDays.js
@@ -24,9 +24,9 @@ export default class DisabledDays extends React.Component {
     return (
       <div>
         <DayPicker
-          selectedDays={ day => DateUtils.isSameDay(selectedDay, day) }
-          disabledDays={ DateUtils.isPastDay }
           enableOutsideDays
+          selectedDays={ selectedDay }
+          disabledDays={ day => day.getDay() === 0 || day.getDay() === 6 }
           onDayClick={ this.handleDayClick }
         />
         <p>

--- a/examples/src/examples/InputField.js
+++ b/examples/src/examples/InputField.js
@@ -60,9 +60,9 @@ export default class InputField extends React.Component {
           />
         </p>
         <DayPicker
-          ref={ (el) => { this.daypicker = el; } }
+          ref={ el => this.daypicker = el }
           initialMonth={ this.state.month }
-          selectedDays={ day => DateUtils.isSameDay(selectedDay, day) }
+          selectedDays={ selectedDay }
           onDayClick={ this.handleDayClick }
         />
       </div>

--- a/examples/src/examples/Modifiers.js
+++ b/examples/src/examples/Modifiers.js
@@ -2,52 +2,25 @@ import React from 'react';
 import DayPicker from '../../../src';
 
 import '../../../src/style.css';
-import '../styles/odd-even.css';
 
 export default class Modifiers extends React.Component {
   constructor(props) {
     super(props);
     this.handleDayClick = this.handleDayClick.bind(this);
-    this.handleDayMouseEnter = this.handleDayMouseEnter.bind(this);
   }
-  state = {
-    text: 'Please select a day 👻',
-  };
-  handleDayClick(e, day, { even, odd, blahblah }) {
-    let text;
-    if (even) {
-      text = 'Just an even day';
-    }
-    if (odd) {
-      text = 'An odd day';
-    }
-    if (blahblah) {
-      text += ': the first of the month 😱';
-    }
-    this.setState({ text });
-  }
-  handleDayMouseEnter(e, day, modifiers) {
+  handleDayClick(e, day, modifiers) {
     console.log('Day\'s CSS classes', e.target.classList.toString());
     console.log('Day\'s modifiers', modifiers);
   }
   render() {
-    const modifiers = {
-      even: day => day.getDate() % 2 === 0,
-      odd: day => day.getDate() % 2 !== 0,
-      blahblah: day => day.getDate() === 1,
-    };
     return (
       <div>
-        <span>
-          <DayPicker
-            onDayMouseEnter={ this.handleDayMouseEnter }
-            modifiers={ modifiers }
-            onDayClick={ this.handleDayClick }
-          />
-        </span>
-        <p>
-          { this.state.text }
-        </p>
+        <DayPicker
+          initialMonth={ new Date(2017, 3) }
+          selectedDays={ new Date(2017, 3, 12) }
+          disabledDays={ new Date(2017, 3, 15) }
+          onDayClick={ this.handleDayClick }
+        />
       </div>
     );
   }

--- a/examples/src/examples/MultipleDays.js
+++ b/examples/src/examples/MultipleDays.js
@@ -5,17 +5,11 @@ import '../../../src/style.css';
 export default class MultipleDays extends React.Component {
   constructor(props) {
     super(props);
-    this.isDaySelected = this.isDaySelected.bind(this);
     this.handleDayClick = this.handleDayClick.bind(this);
   }
   state = {
     selectedDays: [],
   };
-  isDaySelected(day) {
-    return this.state.selectedDays.some(selectedDay =>
-      DateUtils.isSameDay(selectedDay, day),
-    );
-  }
   handleDayClick(e, day, { selected }) {
     const { selectedDays } = this.state;
     if (selected) {
@@ -32,7 +26,7 @@ export default class MultipleDays extends React.Component {
     return (
       <div>
         <DayPicker
-          selectedDays={ this.isDaySelected }
+          selectedDays={ this.state.selectedDays }
           onDayClick={ this.handleDayClick }
         />
       </div>

--- a/examples/src/examples/Range.js
+++ b/examples/src/examples/Range.js
@@ -39,7 +39,7 @@ export default class Range extends React.Component {
         }
         <DayPicker
           numberOfMonths={ 2 }
-          selectedDays={ day => DateUtils.isDayInRange(day, { from, to }) }
+          selectedDays={ [from, { from, to }] }
           onDayClick={ this.handleDayClick }
         />
       </div>

--- a/examples/src/examples/RangeAdvanced.js
+++ b/examples/src/examples/RangeAdvanced.js
@@ -81,11 +81,11 @@ export default class RangeAdvanced extends React.Component {
           className="Range"
           numberOfMonths={ 2 }
           fromMonth={ from }
-          selectedDays={ day => DateUtils.isDayInRange(day, { from, to }) }
-          disabledDays={ day => this.state.from && day < this.state.from }
+          selectedDays={ [from, { from, to }] }
+          disabledDays={ { before: this.state.from } }
           modifiers={ {
-            from: day => DateUtils.isSameDay(day, from),
-            to: day => DateUtils.isSameDay(day, to),
+            start: from,
+            end: to,
           } }
           onDayClick={ this.handleDayClick }
           onDayMouseEnter={ this.handleDayMouseEnter }

--- a/examples/src/examples/Restricted.js
+++ b/examples/src/examples/Restricted.js
@@ -3,18 +3,21 @@ import DayPicker from '../../../src';
 
 import '../../../src/style.css';
 
-const fromMonth = new Date(2015, 3, 1, 0, 0);
-const toMonth = new Date(2015, 10, 30, 23, 59);
+const start = new Date(2015, 3, 1, 0, 0);
+const end = new Date(2015, 10, 30, 23, 59);
 
 export default function Restricted() {
   return (
     <DayPicker
       enableOutsideDays
       numberOfMonths={ 2 }
-      initialMonth={ fromMonth }
-      fromMonth={ fromMonth }
-      toMonth={ toMonth }
-      disabledDays={ day => fromMonth > day || day > toMonth }
+      initialMonth={ start }
+      fromMonth={ start }
+      toMonth={ end }
+      disabledDays={ [
+        { before: start },
+        { after: end },
+      ] }
       onDayClick={ (e, day, { disabled }) => {
         if (!disabled) {
           console.log(day.toLocaleDateString());

--- a/examples/src/examples/SelectableDay.js
+++ b/examples/src/examples/SelectableDay.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import DayPicker, { DateUtils } from '../../../src';
+import DayPicker from '../../../src';
 import '../../../src/style.css';
 
 export default class SelectableDay extends React.Component {
@@ -12,7 +12,7 @@ export default class SelectableDay extends React.Component {
   };
   handleDayClick(e, day, { selected }) {
     this.setState({
-      selectedDay: selected ? null : day,
+      selectedDay: selected ? undefined : day,
     });
   }
   render() {
@@ -20,7 +20,7 @@ export default class SelectableDay extends React.Component {
     return (
       <div>
         <DayPicker
-          selectedDays={ day => DateUtils.isSameDay(selectedDay, day) }
+          selectedDays={ selectedDay }
           onDayClick={ this.handleDayClick }
         />
         <p>

--- a/examples/src/styles/odd-even.css
+++ b/examples/src/styles/odd-even.css
@@ -8,7 +8,7 @@
   color: white;
 }
 
-.DayPicker-Day--blahblah:not(.DayPicker-Day--outside) {
+.DayPicker-Day--first:not(.DayPicker-Day--outside) {
   background-color: black;
   color: white;
 }

--- a/examples/src/styles/range.css
+++ b/examples/src/styles/range.css
@@ -12,12 +12,12 @@
   color: #555;
 }
 
-.DayPicker-Day--from,
-.DayPicker-Day--to {
+.DayPicker-Day--start,
+.DayPicker-Day--end {
   position: relative;
 }
 
-.DayPicker-Day--from:not(.DayPicker-Day--outside):before {
+.DayPicker-Day--start:not(.DayPicker-Day--outside):before {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -29,7 +29,7 @@
   border-bottom-left-radius: 10px;
 }
 
-.DayPicker-Day--to:not(.DayPicker-Day--outside):after {
+.DayPicker-Day--end:not(.DayPicker-Day--outside):after {
   position: absolute;
   top: 0;
   bottom: 0;

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -40,6 +40,7 @@ module.exports = {
     new webpack.optimize.UglifyJsPlugin({
       mangle: {
         except: [
+          'AdvancedModifiers',
           'Birthdays',
           'DisabledDays',
           'BlockedNavigation',

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -10,7 +10,7 @@ import * as DateUtils from './DateUtils';
 import * as LocaleUtils from './LocaleUtils';
 
 import keys from './keys';
-import DayPickerPropTypes from './PropTypes';
+import DayPickerPropTypes, { ModifierPropType } from './PropTypes';
 
 export default class DayPicker extends Component {
   static VERSION = '4.0.0';
@@ -18,8 +18,16 @@ export default class DayPicker extends Component {
   static propTypes = {
     initialMonth: PropTypes.instanceOf(Date),
     numberOfMonths: PropTypes.number,
-    selectedDays: PropTypes.func,
-    disabledDays: PropTypes.func,
+
+    selectedDays: PropTypes.oneOfType([
+      ModifierPropType,
+      PropTypes.arrayOf(ModifierPropType),
+    ]),
+
+    disabledDays: PropTypes.oneOfType([
+      ModifierPropType,
+      PropTypes.arrayOf(ModifierPropType),
+    ]),
 
     modifiers: PropTypes.object,
 

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -1,10 +1,30 @@
 import { PropTypes } from 'react';
 
-export default {
+const PrimitiveTypes = {
   localeUtils: PropTypes.shape({
     formatMonthTitle: PropTypes.func,
     formatWeekdayShort: PropTypes.func,
     formatWeekdayLong: PropTypes.func,
     getFirstDayOfWeek: PropTypes.func,
   }),
+  range: PropTypes.shape({
+    from: PropTypes.instanceOf(Date),
+    to: PropTypes.instanceOf(Date),
+  }),
+  after: PropTypes.shape({
+    after: PropTypes.instanceOf(Date),
+  }),
+  before: PropTypes.shape({
+    before: PropTypes.instanceOf(Date),
+  }),
 };
+
+export const ModifierPropType = PropTypes.oneOfType([
+  PrimitiveTypes.after,
+  PrimitiveTypes.before,
+  PrimitiveTypes.range,
+  PropTypes.func,
+  PropTypes.array,
+]);
+
+export default PrimitiveTypes;

--- a/test/Helpers.js
+++ b/test/Helpers.js
@@ -96,6 +96,14 @@ describe('Helpers', () => {
       expect(modifiers).to.have.length(1);
       expect(modifiers.indexOf('foo')).to.equal(0);
     });
+    it('ignore falsy values', () => {
+      const modifiers = Helpers.getModifiersForDay(
+        new Date(2015, 8, 19),
+        { foo: null, bar: false },
+      );
+      expect(modifiers).to.have.length(0);
+      expect(modifiers.indexOf('foo')).to.equal(-1);
+    });
     it('accepts an array of days', () => {
       const modifiersObj = {
         foo: [
@@ -122,6 +130,18 @@ describe('Helpers', () => {
       expect(modifiers3).to.have.length(1);
       expect(modifiers3.indexOf('foo')).to.equal(0);
       expect(modifiers3.indexOf('bar')).to.equal(-1);
+    });
+    it('accepts an array of days ignoring falsy values', () => {
+      const values = {
+        foo: [
+          null,
+          'test',
+          new Date(2015, 8, 21),
+        ],
+      };
+      const modifiers = Helpers.getModifiersForDay(new Date(2015, 8, 21), values);
+      expect(modifiers).to.have.length(1);
+      expect(modifiers.indexOf('foo')).to.be.above(-1);
     });
     it('accepts a single range of days', () => {
       const range = {

--- a/test/Helpers.js
+++ b/test/Helpers.js
@@ -88,7 +88,110 @@ describe('Helpers', () => {
       expect(modifiers.indexOf('maybe')).to.equal(-1);
       expect(modifiers.indexOf('no')).to.equal(-1);
     });
-    it('works without passing modifiers', () => {
+    it('accepts a single day', () => {
+      const modifiers = Helpers.getModifiersForDay(
+        new Date(2015, 8, 19),
+        { foo: new Date(2015, 8, 19) },
+      );
+      expect(modifiers).to.have.length(1);
+      expect(modifiers.indexOf('foo')).to.equal(0);
+    });
+    it('accepts an array of days', () => {
+      const modifiersObj = {
+        foo: [
+          new Date(2015, 8, 19),
+          new Date(2015, 8, 20),
+          new Date(2015, 8, 21),
+        ],
+        bar: [
+          new Date(2015, 8, 19),
+          new Date(2015, 8, 20),
+        ],
+      };
+      const modifiers1 = Helpers.getModifiersForDay(new Date(2015, 8, 19), modifiersObj);
+      expect(modifiers1).to.have.length(2);
+      expect(modifiers1.indexOf('foo')).to.be.above(-1);
+      expect(modifiers1.indexOf('bar')).to.be.above(-1);
+
+      const modifiers2 = Helpers.getModifiersForDay(new Date(2015, 8, 20), modifiersObj);
+      expect(modifiers2).to.have.length(2);
+      expect(modifiers2.indexOf('foo')).to.be.above(-1);
+      expect(modifiers2.indexOf('bar')).to.be.above(-1);
+
+      const modifiers3 = Helpers.getModifiersForDay(new Date(2015, 8, 21), modifiersObj);
+      expect(modifiers3).to.have.length(1);
+      expect(modifiers3.indexOf('foo')).to.equal(0);
+      expect(modifiers3.indexOf('bar')).to.equal(-1);
+    });
+    it('accepts a single range of days', () => {
+      const range = {
+        foo: {
+          from: new Date(2015, 8, 18),
+          to: new Date(2015, 8, 20),
+        },
+      };
+      const modifiers1 = Helpers.getModifiersForDay(new Date(2015, 8, 19), range);
+      expect(modifiers1).to.have.length(1);
+      expect(modifiers1.indexOf('foo')).to.equal(0);
+      const modifiers2 = Helpers.getModifiersForDay(new Date(2015, 8, 17), range);
+      expect(modifiers2).to.have.length(0);
+    });
+    it('accepts multiple ranges of days', () => {
+      const ranges = {
+        foo: [{
+          from: new Date(2015, 8, 18),
+          to: new Date(2015, 8, 20),
+        }, {
+          from: new Date(2015, 9, 18),
+          to: new Date(2015, 9, 20),
+        }],
+      };
+      const modifiers1 = Helpers.getModifiersForDay(new Date(2015, 8, 19), ranges);
+      expect(modifiers1.indexOf('foo')).to.equal(0);
+      const modifiers2 = Helpers.getModifiersForDay(new Date(2015, 9, 18), ranges);
+      expect(modifiers2.indexOf('foo')).to.equal(0);
+    });
+    it('accepts an "after" modifier', () => {
+      const afterModifier = {
+        foo: {
+          after: new Date(2015, 8, 18),
+        },
+      };
+      const modifiers = Helpers.getModifiersForDay(new Date(2015, 8, 19), afterModifier);
+      expect(modifiers).to.have.length(1);
+      expect(modifiers.indexOf('foo')).to.equal(0);
+    });
+    it('accepts an "after" modifier in an array of days', () => {
+      const afterModifier = {
+        foo: [
+          { after: new Date(2015, 8, 18) },
+        ],
+      };
+      const modifiers = Helpers.getModifiersForDay(new Date(2015, 8, 19), afterModifier);
+      expect(modifiers).to.have.length(1);
+      expect(modifiers.indexOf('foo')).to.equal(0);
+    });
+    it('accepts a "before" modifier', () => {
+      const afterModifier = {
+        foo: {
+          before: new Date(2015, 8, 15),
+        },
+      };
+      const modifiers = Helpers.getModifiersForDay(new Date(2015, 8, 10), afterModifier);
+      expect(modifiers).to.have.length(1);
+      expect(modifiers.indexOf('foo')).to.equal(0);
+    });
+    it('accepts a "before" modifier in an array of days', () => {
+      const afterModifier = {
+        foo: [
+          { before: new Date(2015, 8, 15) },
+        ],
+      };
+      const modifiers = Helpers.getModifiersForDay(new Date(2015, 8, 10), afterModifier);
+      expect(modifiers).to.have.length(1);
+      expect(modifiers.indexOf('foo')).to.equal(0);
+    });
+    it('works even without modifiers', () => {
       const modifiers = Helpers.getModifiersForDay(new Date(2015, 8, 19));
       expect(modifiers).to.have.length(0);
     });


### PR DESCRIPTION
This PR extends the type of modifiers values. In addition to a function `(day: Date) => Bool`, modifiers can be now contain:

- `Date` objects
- range objects (e.g. `{ from: new Date(2017, 10, 18), to: new Date(2017, 10, 25) }`)
- after/before objects (e.g. `{ before: new Date() }` or `{ after: new Date(2017, 10, 25) }`
- an array of the above.

Using these new values, we can avoid to create new functions at each rendering (see https://github.com/gpbl/react-day-picker/issues/181) and pre-populate the modifiers with a predefined set of data (see https://github.com/gpbl/react-day-picker/issues/247).