### PR TITLE
New containerProps prop

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -9,7 +9,9 @@
 | --- | --- | --- |
 | [canChangeMonth](APIProps.md#canchangemonth) | true | `Bool` |
 | [captionElement](APIProps.md#captionelement) | | `Element` |
-| [disabledDays](APIProps.md#disableddays) | | `Date || Object || (day: Date) ⇒ Bool || Array<Date|Object|Function>` |
+| [className](APIProps.md#className) | | `String` |
+| [containerProps](APIProps.md#containerprops) | | `Object` |
+| [disabledDays](APIProps.md#disableddays) | | See [Modifiers.md](modifiers) |
 | [enableOutsideDays](APIProps.md#enableoutsidedays) | false | `Bool` |
 | [firstDayOfWeek](APIProps.md#firstdayofweek) | 0 | `Number` |
 | [fixedWeeks](APIProps.md#fixedWeeks) | false | `Bool` |
@@ -17,21 +19,24 @@
 | [initialMonth](APIProps.md#initialmonth) | Current month | `Date` |
 | [locale](APIProps.md#locale) | en | `String` |
 | [localeUtils](APIProps.md#localeutils) | | `Object` |
-| [modifiers](APIProps.md#modifiers) | | `Object` |
+| [modifiers](APIProps.md#modifiers) | | `Object` of [Modifiers.md](modifiers) |
 | [months](APIProps.md#months) | | `Array<String>` |
 | [navbarElement](APIProps.md#navbarelement) | | `Element` |
 | [numberOfMonths](APIProps.md#numberofmonths) | 1 | `Number` |
 | [onCaptionClick](APIProps.md#oncaptionclick) | | `(e: SyntethicEvent, currentMonth: Date) ⇒ void` |
+| [onBlur](APIProps.md#onblur) | | `(e: SyntethicEvent) ⇒ void` |
 | [onDayClick](APIProps.md#ondayclick) | | `(e: SyntethicEvent, day: Date, modifiers: Object) ⇒ void` |
 | [onDayMouseEnter](APIProps.md#ondaymouseenter) | | `(e: SyntethicEvent, day: Date, modifiers: Object) ⇒ void` |
 | [onDayMouseLeave](APIProps.md#ondaymouseleave) | | `(e: SyntethicEvent, day: Date, modifiers: Object) ⇒ void` |
 | [onDayTouchStart](APIProps.md#ondaytouchstart) | | `(e: SyntethicEvent, day: Date, modifiers: Object) ⇒ void` |
 | [onDayTouchEnd](APIProps.md#ondaytouchend) | | `(e: SyntethicEvent, day: Date, modifiers: Object) ⇒ void` |
+| [onFocus](APIProps.md#onfocus) | | `(e: SyntethicEvent) ⇒ void` |
+| [onKeyDown](APIProps.md#onkeydown) | | `(e: SyntethicEvent) ⇒ void` |
 | [onMonthChange](APIProps.md#onmonthchange) | | `(month: Date) ⇒ void` |
 | [pagedNavigation](APIProps.md#pagednavigation) |false | `Bool` |
 | [renderDay](APIProps.md#renderday) | day ⇒ day.getDate() | `(day: Date) ⇒ Element` |
 | [reverseMonths](APIProps.md#reversemonths) | false | `Bool` |
-| [selectedDays](APIProps.md#selecteddays) | | `Date || Object || (day: Date) ⇒ Bool || Array<Date|Object|Function>` |
+| [selectedDays](APIProps.md#selecteddays) | | See [Modifiers.md](modifiers) |
 | [tabIndex](APIProps.md#tabindex) | | `Number` |
 | [toMonth](APIProps.md#tomonth) | | `Date` |
 | [weekdayElement](APIProps.md#weekdayelement) | | `Element` |

--- a/docs/APIProps.md
+++ b/docs/APIProps.md
@@ -1,7 +1,5 @@
 # Component props
 
-Please note that HTML props (such as `className`, `tabIndex`, `style` etc.) are spread to the root's `div` element.
-
 ### canChangeMonth
 
 **Type**: `Bool` | **Default**: `true`

--- a/docs/APIProps.md
+++ b/docs/APIProps.md
@@ -23,6 +23,27 @@ The default caption is a `div` with class `DayPicker-Caption`, showing a "month 
 
 See also [this advanced example](../examples?yearNavigation), showing a year navigation element using this prop.
 
+### className
+
+**Type**: `String`
+
+Additional CSS class names to add to the defaults.
+
+### containerProps
+
+**Type**: `Object`
+
+Props to pass to the container `div` HTML element. Only props by a `div` are valid.
+
+`className`, `role`, `tabIndex`, `onKeyDown`, `onFocus` and `onBlur` must be passed directly to the component. E.g.:
+
+```jsx
+<DayPicker
+  containerProps={{ className: 'will_be_ignored' }}
+  className="will_work"
+/> 
+```
+
 ### disabledDays
 
 **Type**: `Date` || `Object` || `(day: Date) ⇒ Bool` || `Array<Date|Object|Function>`
@@ -185,11 +206,17 @@ Event handler when the user clicks on a day cell.
 
 ---
 
+### onBlur
+
+**Type**: `(e: SyntethicEvent) ⇒ void`
+
+Event handler when the calendar get the `blur` event.
+
 ### onDayKeyDown
 
 **Type**: `(e: SyntethicEvent, day: Date, modifiers: Object) ⇒ void`
 
-Event handler when the day cell gets the key down event.
+Event handler when the day cell gets the `keydown` event.
 
 ### onDayMouseEnter
 
@@ -214,6 +241,18 @@ Event handler when the day cell gets the `touchStart` event.
 **Type**: `(e: SyntethicEvent, day: Date, modifiers: Object) ⇒ void`
 
 Event handler when the day cell gets the `touchEnd` event.
+
+### onFocus
+
+**Type**: `(e: SyntethicEvent) ⇒ void`
+
+Event handler when the calendar get the `focus` event
+
+### onKeyDown
+
+**Type**: `(e: SyntethicEvent) ⇒ void`
+
+Event handler when the calendar get the `keydown` event
 
 ### onMonthChange
 

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -47,6 +47,8 @@ export default class DayPicker extends Component {
     weekdaysLong: PropTypes.arrayOf(PropTypes.string),
     weekdaysShort: PropTypes.arrayOf(PropTypes.string),
 
+    onBlur: PropTypes.func,
+    onFocus: PropTypes.func,
     onKeyDown: PropTypes.func,
     onDayClick: PropTypes.func,
     onDayKeyDown: PropTypes.func,
@@ -67,6 +69,8 @@ export default class DayPicker extends Component {
     dir: PropTypes.string,
     className: PropTypes.string,
     tabIndex: PropTypes.number,
+
+    containerProps: PropTypes.object,
 
   };
 
@@ -442,7 +446,6 @@ export default class DayPicker extends Component {
           wrapperClassName="DayPicker-Body"
           weekClassName="DayPicker-Week"
 
-          weekdayComponent={ this.props.weekdayComponent }
           weekdayElement={ this.props.weekdayElement }
           captionElement={ this.props.captionElement }
 
@@ -459,7 +462,6 @@ export default class DayPicker extends Component {
   }
 
   render() {
-    const customProps = Helpers.getCustomProps(this.props, DayPicker.propTypes);
     let className = 'DayPicker';
 
     if (!this.props.onDayClick) {
@@ -471,13 +473,15 @@ export default class DayPicker extends Component {
 
     return (
       <div
-        { ...customProps }
+        { ...this.props.containerProps }
         className={ className }
         ref={ (el) => { this.dayPicker = el; } }
         role="application"
         lang={ this.props.locale }
         tabIndex={ this.props.canChangeMonth && this.props.tabIndex }
         onKeyDown={ this.handleKeyDown }
+        onFocus={ this.props.onFocus }
+        onBlur={ this.props.onBlur }
       >
         {this.renderNavbar()}
         {this.renderMonths()}

--- a/src/Helpers.js
+++ b/src/Helpers.js
@@ -7,16 +7,6 @@ export function cancelEvent(e) {
   e.stopPropagation();
 }
 
-export function getCustomProps(props, propTypes) {
-  const customProps = {};
-  Object.keys(props)
-      .filter(propName => !{}.hasOwnProperty.call(propTypes, propName))
-      .forEach((propName) => {
-        customProps[propName] = props[propName];
-      });
-  return customProps;
-}
-
 export function getFirstDayOfMonth(d) {
   return new Date(d.getFullYear(), d.getMonth(), 1, 12);
 }

--- a/test/DayPicker.js
+++ b/test/DayPicker.js
@@ -72,8 +72,8 @@ describe('<DayPicker />', () => {
       const wrapper = shallow(<DayPicker tabIndex={ 10 } />);
       expect(wrapper).to.have.attr('tabindex', '10');
     });
-    it('should spread the rest of the props to the container', () => {
-      const wrapper = shallow(<DayPicker data-foo="bar" />);
+    it('should spread props to the container', () => {
+      const wrapper = shallow(<DayPicker containerProps={ { 'data-foo': 'bar' } } />);
       expect(wrapper).to.have.attr('data-foo', 'bar');
     });
     it('should handle focus and blur events', () => {

--- a/test/Helpers.js
+++ b/test/Helpers.js
@@ -16,19 +16,6 @@ describe('Helpers', () => {
     });
   });
 
-  describe('getCustomProps', () => {
-    it('should filter props existing in the given propTypes', () => {
-      const props = {
-        foo: 1,
-        bar: 2,
-      };
-      const propTypes = {
-        bar: 'thing',
-      };
-      expect(Helpers.getCustomProps(props, propTypes)).to.eql({ foo: 1 });
-    });
-  });
-
   describe('getFirstDayOfWeekFromProps', () => {
     it('should return Sunday as default', () => {
       expect(Helpers.getFirstDayOfWeekFromProps({ })).to.equal(0);


### PR DESCRIPTION
This new prop remove the previous behavior of props being spread to the container's `<div />` element by default. Instead, developers should use `containerProps`:

```diff
<DayPicker 
-    data-my-thing="foo" 
+    containerProps={ 'data-my-thing': 'foo' }
/>
```

This will avoid to loop over the prop types to remove the invalid ones, [improving rendering performance](https://github.com/gpbl/react-day-picker/issues/192) as suggested [here](https://gist.github.com/jimfb/d99e0678e9da715ccf6454961ef04d1b).
