### PR TITLE
Add classNames prop (close #73)

### DIFF
--- a/examples/src/Examples.js
+++ b/examples/src/Examples.js
@@ -11,6 +11,7 @@ import Birthdays from './examples/Birthdays';
 import DisabledDays from './examples/DisabledDays';
 import BlockedNavigation from './examples/BlockedNavigation';
 import CustomElements from './examples/CustomElements';
+import CSSModules from './examples/CSSModules';
 import FixedWeeks from './examples/FixedWeeks';
 import InputField from './examples/InputField';
 import InputFieldOverlay from './examples/InputFieldOverlay';
@@ -139,6 +140,11 @@ const EXAMPLES = {
     title: 'Year Calendar',
     description: 'Use <code>numberOfMonths</code> to display a custom number of calendars.',
     Component: YearCalendar,
+  },
+  cssModules: {
+    title: 'CSS Modules',
+    description: 'Use the <code>classNames</code> prop to pass to the component the styles imported with <a href="https://github.com/css-modules/css-modules">CSS Modules</a>.',
+    Component: CSSModules,
   },
 };
 

--- a/examples/src/examples/AdvancedModifiers.js
+++ b/examples/src/examples/AdvancedModifiers.js
@@ -26,7 +26,7 @@ export default class AdvancedModifiers extends React.Component {
     }
     this.setState({ text });
   }
-  handleDayMouseEnter(day, modifiers) {
+  handleDayMouseEnter(day, modifiers, e) {
     console.log('Day\'s CSS classes', e.target.classList.toString());
     console.log('Day\'s modifiers', modifiers);
   }

--- a/examples/src/examples/CSSModules.js
+++ b/examples/src/examples/CSSModules.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import DayPicker from '../../../src';
+
+import styles from '../styles/cssmodules.css';
+
+export default function CSSModules() {
+  return (
+    <DayPicker
+      classNames={ styles }
+
+      enableOutsideDays
+      initialMonth={ new Date(2017, 1) }
+      selectedDays={ new Date(2017, 1, 23) }
+      disabledDays={ [new Date(2017, 1, 20), new Date(2018, 1, 28)] }
+      modifiers={ {
+        [styles.sunday]: day => day.getDay() === 0,
+        [styles.green]: new Date(2017, 1, 10),
+      } }
+    />
+  );
+}

--- a/examples/src/examples/DisabledDays.js
+++ b/examples/src/examples/DisabledDays.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import DayPicker, { DateUtils } from '../../../src';
+import DayPicker from '../../../src';
 
 import '../../../src/style.css';
 

--- a/examples/src/styles/cssmodules.css
+++ b/examples/src/styles/cssmodules.css
@@ -1,0 +1,127 @@
+/* DayPicker styles */
+
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  position: relative;
+  padding: 1rem 0;
+  user-select: none;
+}
+
+.month {
+  display: table;
+  border-collapse: collapse;
+  border-spacing: 0;
+  user-select: none;
+  margin: 0 1rem;
+}
+
+  .navBar {
+    position: absolute;
+    left: 0;
+    right: 0;
+    padding: 0 .5rem;
+  }
+
+  .navButton {
+    position: absolute;
+    width: 1.5rem;
+    height: 1.5rem;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
+    cursor: pointer;
+  }
+
+    .navButtonPrev {
+      composes: navButton;
+      left: 1rem;
+      background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjxzdmcgd2lkdGg9IjI2cHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDI2IDUwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbG5zOnNrZXRjaD0iaHR0cDovL3d3dy5ib2hlbWlhbmNvZGluZy5jb20vc2tldGNoL25zIj4KICAgIDwhLS0gR2VuZXJhdG9yOiBTa2V0Y2ggMy4zLjIgKDEyMDQzKSAtIGh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaCAtLT4KICAgIDx0aXRsZT5wcmV2PC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGRlZnM+PC9kZWZzPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc2tldGNoOnR5cGU9Ik1TUGFnZSI+CiAgICAgICAgPGcgaWQ9InByZXYiIHNrZXRjaDp0eXBlPSJNU0xheWVyR3JvdXAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDEzLjM5MzE5MywgMjUuMDAwMDAwKSBzY2FsZSgtMSwgMSkgdHJhbnNsYXRlKC0xMy4zOTMxOTMsIC0yNS4wMDAwMDApIHRyYW5zbGF0ZSgwLjg5MzE5MywgMC4wMDAwMDApIiBmaWxsPSIjNTY1QTVDIj4KICAgICAgICAgICAgPHBhdGggZD0iTTAsNDkuMTIzNzMzMSBMMCw0NS4zNjc0MzQ1IEwyMC4xMzE4NDU5LDI0LjcyMzA2MTIgTDAsNC4yMzEzODMxNCBMMCwwLjQ3NTA4NDQ1OSBMMjUsMjQuNzIzMDYxMiBMMCw0OS4xMjM3MzMxIEwwLDQ5LjEyMzczMzEgWiIgaWQ9InJpZ2h0IiBza2V0Y2g6dHlwZT0iTVNTaGFwZUdyb3VwIj48L3BhdGg+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4K");
+    }
+
+    .navButtonNext {
+      composes: navButton;
+      right: 1rem;
+      background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjxzdmcgd2lkdGg9IjI2cHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDI2IDUwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbG5zOnNrZXRjaD0iaHR0cDovL3d3dy5ib2hlbWlhbmNvZGluZy5jb20vc2tldGNoL25zIj4KICAgIDwhLS0gR2VuZXJhdG9yOiBTa2V0Y2ggMy4zLjIgKDEyMDQzKSAtIGh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaCAtLT4KICAgIDx0aXRsZT5uZXh0PC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGRlZnM+PC9kZWZzPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc2tldGNoOnR5cGU9Ik1TUGFnZSI+CiAgICAgICAgPGcgaWQ9Im5leHQiIHNrZXRjaDp0eXBlPSJNU0xheWVyR3JvdXAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAuOTUxNDUxLCAwLjAwMDAwMCkiIGZpbGw9IiM1NjVBNUMiPgogICAgICAgICAgICA8cGF0aCBkPSJNMCw0OS4xMjM3MzMxIEwwLDQ1LjM2NzQzNDUgTDIwLjEzMTg0NTksMjQuNzIzMDYxMiBMMCw0LjIzMTM4MzE0IEwwLDAuNDc1MDg0NDU5IEwyNSwyNC43MjMwNjEyIEwwLDQ5LjEyMzczMzEgTDAsNDkuMTIzNzMzMSBaIiBpZD0icmlnaHQiIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPgo=");
+    }
+
+
+  .caption {
+    display: table-caption;
+    height: 1.5rem;
+    text-align: center;
+  }
+
+  .weekdays {
+    display: table-header-group;
+  }
+
+    .weekdaysRow {
+      display: table-row;
+    }
+
+      .weekday {
+        display: table-cell;
+        padding: .5rem;
+        font-size: .875em;
+        text-align: center;
+        color: #8b9898;
+      }
+
+  .body {
+    display: table-row-group;
+  }
+
+    .week {
+      display: table-row;
+    }
+
+      .day {
+        display: table-cell;
+        padding: .5rem;
+        border: 1px solid #eaecec;
+        text-align: center;
+        cursor: pointer;
+        vertical-align: middle;
+      }
+
+/* Default modifiers */
+
+.today {
+  color: #d0021b;
+  font-weight: 500;
+}
+
+.disabled {
+  color: #dce0e0;
+  cursor: default;
+  background-color: #eff1f1;
+}
+
+.outside {
+  cursor: default;
+  color: #dce0e0;
+}
+
+.selected:not(.disabled):not(.outside) {
+  color: #FFF;
+  background-color: #4A90E2;
+}
+
+/* Example of custom modifiers */
+
+.sunday {
+  border: 1px solid #4A90E2;
+}
+
+.sunday:not(.outside) {
+  color: #4A90E2;
+}
+
+.green {
+  color:springgreen;
+  font-weight: bold;
+  position: relative;
+  z-index: 1;
+}

--- a/examples/webpack.config.dev.js
+++ b/examples/webpack.config.dev.js
@@ -44,9 +44,19 @@ export default {
       ],
       loader: 'babel-loader?cacheDirectory&plugins=react-hot-loader/babel',
     }, {
+      include: [
+        path.join(__dirname, './src/styles/cssmodules.css'),
+      ],
+      loaders: ['style-loader', 'css-loader?modules=true&localIdentName=[hash:base64:5]', 'autoprefixer-loader?browsers=last 2 version'],
+    },
+    {
       test: /\.css$/,
+      exclude: [
+        path.join(__dirname, './src/styles/cssmodules.css'),
+      ],
       loaders: ['style-loader', 'css-loader', 'autoprefixer-loader?browsers=last 2 version'],
-    }, {
+    },
+    {
       test: /\.svg$/,
       loader: 'url-loader?limit=100000&mimetype=image/svg+xml',
     }],

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -20,10 +20,21 @@ module.exports = {
         path.join(__dirname, '../lib'),
       ],
       loaders: ['babel-loader'],
-    }, {
+    },
+    {
+      include: [
+        path.join(__dirname, './src/styles/cssmodules.css'),
+      ],
+      loaders: ['style-loader', 'css-loader?modules=true&localIdentName=[hash:base64:5]', 'autoprefixer-loader?browsers=last 2 version'],
+    },
+    {
       test: /\.css$/,
+      exclude: [
+        path.join(__dirname, './src/styles/cssmodules.css'),
+      ],
       loaders: ['style-loader', 'css-loader', 'autoprefixer-loader?browsers=last 2 version'],
-    }],
+    },
+    ],
   },
 
   plugins: [

--- a/src/Caption.js
+++ b/src/Caption.js
@@ -1,9 +1,9 @@
 import React, { PropTypes } from 'react';
 import DayPickerPropTypes from './PropTypes';
 
-export default function Caption({ date, months, locale, localeUtils, onClick }) {
+export default function Caption({ classNames, date, months, locale, localeUtils, onClick }) {
   return (
-    <div className="DayPicker-Caption" onClick={ onClick } role="heading">
+    <div className={ classNames.caption } onClick={ onClick } role="heading">
       { months ?
         `${months[date.getMonth()]} ${date.getFullYear()}` :
         localeUtils.formatMonthTitle(date, locale)
@@ -18,4 +18,7 @@ Caption.propTypes = {
   locale: PropTypes.string,
   localeUtils: DayPickerPropTypes.localeUtils,
   onClick: PropTypes.func,
+  classNames: PropTypes.shape({
+    caption: PropTypes.string.isRequired,
+  }).isRequired,
 };

--- a/src/Day.js
+++ b/src/Day.js
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions, react/forbid-prop-types */
 
 import React, { PropTypes } from 'react';
+import defaultClassNames from './classNames';
 
 function handleEvent(handler, day, modifiers) {
   if (!handler) {
@@ -12,6 +13,7 @@ function handleEvent(handler, day, modifiers) {
   };
 }
 export default function Day({
+  classNames,
   day,
   tabIndex,
   empty,
@@ -28,8 +30,13 @@ export default function Day({
   ariaSelected,
   children,
 }) {
-  let className = 'DayPicker-Day';
-  className += Object.keys(modifiers).map(modifier => ` ${className}--${modifier}`).join('');
+  let className = classNames.day;
+  if (classNames !== defaultClassNames) {
+    // When using CSS modules prefix the modifier as required by the BEM syntax
+    className += ` ${Object.keys(modifiers).join(' ')}`;
+  } else {
+    className += Object.keys(modifiers).map(modifier => ` ${className}--${modifier}`).join('');
+  }
   if (empty) {
     return <div role="gridcell" aria-disabled className={ className } />;
   }
@@ -55,6 +62,11 @@ export default function Day({
 }
 
 Day.propTypes = {
+
+  classNames: PropTypes.shape({
+    day: PropTypes.string.isRequired,
+  }).isRequired,
+
   day: PropTypes.instanceOf(Date).isRequired,
   children: PropTypes.node.isRequired,
 

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -8,6 +8,7 @@ import Weekday from './Weekday';
 import * as Helpers from './Helpers';
 import * as DateUtils from './DateUtils';
 import * as LocaleUtils from './LocaleUtils';
+import classNames from './classNames';
 
 import keys from './keys';
 import DayPickerPropTypes, { ModifierPropType } from './PropTypes';
@@ -16,6 +17,20 @@ export default class DayPicker extends Component {
   static VERSION = '5.0.0';
 
   static propTypes = {
+
+    classNames: PropTypes.shape({
+      body: PropTypes.string,
+      container: PropTypes.string,
+      interactionDisabled: PropTypes.string,
+      month: PropTypes.string,
+      navBar: PropTypes.string,
+      week: PropTypes.string,
+      outside: PropTypes.string.isRequired,
+      today: PropTypes.string.isRequired,
+      selected: PropTypes.string.isRequired,
+      disabled: PropTypes.string.isRequired,
+    }),
+
     initialMonth: PropTypes.instanceOf(Date),
     numberOfMonths: PropTypes.number,
 
@@ -75,6 +90,7 @@ export default class DayPicker extends Component {
   };
 
   static defaultProps = {
+    classNames,
     tabIndex: 0,
     initialMonth: new Date(),
     numberOfMonths: 1,
@@ -87,8 +103,8 @@ export default class DayPicker extends Component {
     pagedNavigation: false,
     renderDay: day => day.getDate(),
     weekdayElement: <Weekday />,
-    navbarElement: <Navbar />,
-    captionElement: <Caption />,
+    navbarElement: <Navbar classNames={ classNames } />,
+    captionElement: <Caption classNames={ classNames } />,
   };
 
   constructor(props) {
@@ -357,8 +373,10 @@ export default class DayPicker extends Component {
     ...attributes } = this.props;
 
     if (!canChangeMonth) return null;
+
     const props = {
-      className: 'DayPicker-NavBar',
+      classNames: this.props.classNames,
+      className: this.props.classNames.navBar,
       nextMonth: this.getNextNavigableMonth(),
       previousMonth: this.getPreviousNavigableMonth(),
       showPreviousButton: this.allowPreviousMonth(),
@@ -374,10 +392,10 @@ export default class DayPicker extends Component {
   renderDayInMonth(day, month) {
     let dayModifiers = [];
     if (DateUtils.isSameDay(day, new Date())) {
-      dayModifiers.push('today');
+      dayModifiers.push(this.props.classNames.today);
     }
     if (day.getMonth() !== month.getMonth()) {
-      dayModifiers.push('outside');
+      dayModifiers.push(this.props.classNames.outside);
     }
     dayModifiers = [
       ...dayModifiers,
@@ -400,6 +418,7 @@ export default class DayPicker extends Component {
     return (
       <Day
         key={ `${isOutside ? 'outside-' : ''}${key}` }
+        classNames={ this.props.classNames }
         day={ day }
         modifiers={ modifiers }
         empty={ isOutside && !this.props.enableOutsideDays && !this.props.fixedWeeks }
@@ -433,21 +452,24 @@ export default class DayPicker extends Component {
       months.push(
         <Month
           key={ i }
+          classNames={ this.props.classNames }
+
           month={ month }
           months={ this.props.months }
+
+          weekdayElement={ this.props.weekdayElement }
+          captionElement={
+            React.cloneElement(this.props.captionElement, {
+              classNames: this.props.classNames,
+            })
+          }
+          fixedWeeks={ this.props.fixedWeeks }
+
           weekdaysShort={ this.props.weekdaysShort }
           weekdaysLong={ this.props.weekdaysLong }
           locale={ this.props.locale }
           localeUtils={ this.props.localeUtils }
           firstDayOfWeek={ firstDayOfWeek }
-          fixedWeeks={ this.props.fixedWeeks }
-
-          className="DayPicker-Month"
-          wrapperClassName="DayPicker-Body"
-          weekClassName="DayPicker-Week"
-
-          weekdayElement={ this.props.weekdayElement }
-          captionElement={ this.props.captionElement }
 
           onCaptionClick={ this.props.onCaptionClick }
         >
@@ -462,10 +484,10 @@ export default class DayPicker extends Component {
   }
 
   render() {
-    let className = 'DayPicker';
+    let className = this.props.classNames.container;
 
     if (!this.props.onDayClick) {
-      className = `${className} DayPicker--interactionDisabled`;
+      className = `${className} ${this.props.classNames.interactionDisabled}`;
     }
     if (this.props.className) {
       className = `${className} ${this.props.className}`;

--- a/src/Helpers.js
+++ b/src/Helpers.js
@@ -23,10 +23,10 @@ export function getDaysInMonth(d) {
 export function getModifiersFromProps(props) {
   const modifiers = { ...props.modifiers };
   if (props.selectedDays) {
-    modifiers.selected = props.selectedDays;
+    modifiers[props.classNames.selected] = props.selectedDays;
   }
   if (props.disabledDays) {
-    modifiers.disabled = props.disabledDays;
+    modifiers[props.classNames.disabled] = props.disabledDays;
   }
   return modifiers;
 }

--- a/src/Month.js
+++ b/src/Month.js
@@ -4,21 +4,23 @@ import Weekdays from './Weekdays';
 import { getWeekArray } from './Helpers';
 
 export default function Month({
+  classNames,
+
   month,
   months,
-  weekdaysLong,
-  weekdaysShort,
+
+  fixedWeeks,
+  captionElement,
+  weekdayElement,
+
   locale,
   localeUtils,
-  captionElement,
+  weekdaysLong,
+  weekdaysShort,
+  firstDayOfWeek,
+
   onCaptionClick,
   children,
-  firstDayOfWeek,
-  className,
-  wrapperClassName,
-  weekClassName,
-  weekdayElement,
-  fixedWeeks,
 }) {
   const captionProps = {
     date: month,
@@ -29,9 +31,10 @@ export default function Month({
   };
   const weeks = getWeekArray(month, firstDayOfWeek, fixedWeeks);
   return (
-    <div className={ className }>
+    <div className={ classNames.month }>
       {React.cloneElement(captionElement, captionProps)}
       <Weekdays
+        classNames={ classNames }
         weekdaysShort={ weekdaysShort }
         weekdaysLong={ weekdaysLong }
         firstDayOfWeek={ firstDayOfWeek }
@@ -39,10 +42,10 @@ export default function Month({
         localeUtils={ localeUtils }
         weekdayElement={ weekdayElement }
       />
-      <div className={ wrapperClassName } role="grid">
+      <div className={ classNames.body } role="grid">
         {
           weeks.map((week, j) =>
-            <div key={ j } className={ weekClassName } role="gridcell">
+            <div key={ j } className={ classNames.week } role="gridcell">
               {week.map(day => children(day, month))}
             </div>,
         )}
@@ -52,19 +55,26 @@ export default function Month({
 }
 
 Month.propTypes = {
+  classNames: PropTypes.shape({
+    month: PropTypes.string.isRequired,
+    body: PropTypes.string.isRequired,
+    week: PropTypes.string.isRequired,
+  }).isRequired,
+
   month: PropTypes.instanceOf(Date).isRequired,
   months: React.PropTypes.arrayOf(React.PropTypes.string),
+
+  fixedWeeks: PropTypes.bool,
   captionElement: PropTypes.node.isRequired,
-  firstDayOfWeek: PropTypes.number.isRequired,
-  weekdaysLong: PropTypes.arrayOf(PropTypes.string),
-  weekdaysShort: PropTypes.arrayOf(PropTypes.string),
+  weekdayElement: PropTypes.element,
+
   locale: PropTypes.string.isRequired,
   localeUtils: DayPickerPropTypes.localeUtils.isRequired,
+  weekdaysLong: PropTypes.arrayOf(PropTypes.string),
+  weekdaysShort: PropTypes.arrayOf(PropTypes.string),
+  firstDayOfWeek: PropTypes.number.isRequired,
+
   onCaptionClick: PropTypes.func,
+
   children: PropTypes.func.isRequired,
-  className: PropTypes.string,
-  wrapperClassName: PropTypes.string,
-  weekClassName: PropTypes.string,
-  weekdayElement: PropTypes.element,
-  fixedWeeks: PropTypes.bool,
 };

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -1,14 +1,15 @@
 import React, { PropTypes } from 'react';
 
-const buttonBaseClass = 'DayPicker-NavButton DayPicker-NavButton';
+import defaultClassNames from './classNames';
 
 export default function Navbar({
+  classNames,
   className,
   showPreviousButton,
   showNextButton,
   onPreviousClick,
   onNextClick,
-  dir,
+  dir = 'ltr',
 }) {
   const previousClickHandler = dir === 'rtl' ? onNextClick : onPreviousClick;
   const nextClickHandler = dir === 'rtl' ? onPreviousClick : onNextClick;
@@ -17,7 +18,7 @@ export default function Navbar({
     <span
       role="button"
       key="previous"
-      className={ `${buttonBaseClass}--prev` }
+      className={ classNames.navButtonPrev }
       onClick={ () => previousClickHandler() }
     />;
 
@@ -25,18 +26,23 @@ export default function Navbar({
     <span
       role="button"
       key="right"
-      className={ `${buttonBaseClass}--next` }
+      className={ classNames.navButtonNext }
       onClick={ () => nextClickHandler() }
     />;
 
   return (
-    <div className={ className }>
+    <div className={ className || classNames.navBar }>
       {dir === 'rtl' ? [nextButton, previousButton] : [previousButton, nextButton]}
     </div>
   );
 }
 
 export const NavbarPropTypes = {
+  classNames: PropTypes.shape({
+    navBar: PropTypes.string.isRequired,
+    navButtonPrev: PropTypes.string.isRequired,
+    navButtonNext: PropTypes.string.isRequired,
+  }),
   className: PropTypes.string,
   showPreviousButton: PropTypes.bool,
   showNextButton: PropTypes.bool,
@@ -48,7 +54,7 @@ export const NavbarPropTypes = {
 Navbar.propTypes = NavbarPropTypes;
 
 Navbar.defaultProps = {
-  className: 'DayPicker-NavBar',
+  classNames: defaultClassNames,
   dir: 'ltr',
   showPreviousButton: true,
   showNextButton: true,

--- a/src/Weekdays.js
+++ b/src/Weekdays.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 import DayPickerPropTypes from './PropTypes';
 
 export default function Weekdays({
+  classNames,
   firstDayOfWeek,
   weekdaysLong,
   weekdaysShort,
@@ -14,7 +15,7 @@ export default function Weekdays({
     const weekday = (i + firstDayOfWeek) % 7;
     const elementProps = {
       key: i,
-      className: 'DayPicker-Weekday',
+      className: classNames.weekday,
       weekday,
       weekdaysLong,
       weekdaysShort,
@@ -26,15 +27,22 @@ export default function Weekdays({
   }
 
   return (
-    <div className="DayPicker-Weekdays" role="rowgroup">
-      <div className="DayPicker-WeekdaysRow" role="columnheader">
-        {days}
+    <div className={ classNames.weekdays } role="rowgroup">
+      <div className={ classNames.weekdaysRow } role="columnheader">
+        { days }
       </div>
     </div>
   );
 }
 
 Weekdays.propTypes = {
+
+  classNames: PropTypes.shape({
+    weekday: PropTypes.string.isRequired,
+    weekdays: PropTypes.string.isRequired,
+    weekdaysRow: PropTypes.string.isRequired,
+  }).isRequired,
+
   firstDayOfWeek: PropTypes.number.isRequired,
   weekdaysLong: PropTypes.arrayOf(PropTypes.string),
   weekdaysShort: PropTypes.arrayOf(PropTypes.string),

--- a/src/classNames.js
+++ b/src/classNames.js
@@ -1,0 +1,24 @@
+// Proxy object to map classnames when css modules are not used
+
+export default {
+  container: 'DayPicker',
+  interactionDisabled: 'DayPicker--interactionDisabled',
+  month: 'DayPicker-Month',
+  navBar: 'DayPicker-NavBar',
+  navButtonPrev: 'DayPicker-NavButton DayPicker-NavButton--prev',
+  navButtonNext: 'DayPicker-NavButton DayPicker-NavButton--next',
+  caption: 'DayPicker-Caption',
+  weekdays: 'DayPicker-Weekdays',
+  weekdaysRow: 'DayPicker-WeekdaysRow',
+  weekday: 'DayPicker-Weekday',
+  body: 'DayPicker-Body',
+  week: 'DayPicker-Week',
+  day: 'DayPicker-Day',
+
+  // default modifiers
+  today: 'today',
+  selected: 'selected',
+  disabled: 'disabled',
+  outside: 'outside',
+
+};

--- a/test/daypicker/rendering.js
+++ b/test/daypicker/rendering.js
@@ -6,6 +6,8 @@ import { shallow, mount, render } from 'enzyme';
 import { spy } from 'sinon';
 
 import DayPicker from '../../src/DayPicker';
+import classNames from '../../src/classNames';
+
 
 describe('DayPicker’s rendering', () => {
   it('should have default props', () => {
@@ -42,7 +44,7 @@ describe('DayPicker’s rendering', () => {
       .to.equal(1);
   });
   it('should render multiple months', () => {
-    const wrapper = shallow(<DayPicker numberOfMonths={ 12 } />);
+    const wrapper = mount(<DayPicker numberOfMonths={ 12 } />);
     expect(wrapper.find('.DayPicker-Month')).to.have.length(12);
   });
   it('should render multiple months, reversed', () => {
@@ -162,5 +164,21 @@ describe('DayPicker’s rendering', () => {
       <DayPicker enableOutsideDays fixedWeeks initialMonth={ new Date(2015, 1) } />,
     );
     expect(wrapper.find('.DayPicker-Day')).to.have.length(42);
+  });
+  it('should use the specified class names', () => {
+    const wrapper = mount(
+      <DayPicker
+        enableOutsideDays
+        initialMonth={ new Date(2015, 1) }
+        classNames={ {
+          ...classNames,
+          day: 'foo',
+        } }
+        modifiers={ {
+          bar: new Date(2015, 1, 10),
+        } }
+      />);
+    expect(wrapper.find('.foo')).to.have.length(28);
+    expect(wrapper.find('.bar')).to.have.length(1);
   });
 });


### PR DESCRIPTION
This PR adds a new `classNames` prop to customize the name of the CSS classes used when rendering the component. 

By specifying the `className` for each element, the original BEM syntax can be skipped. The styles can be imported then with CSS Modules. The expected classnames are specified in the proptypes.

To keep the original BEM syntax, the components adopt [an object](https://github.com/gpbl/react-day-picker/compare/css-modules?expand=1#diff-fcd9c1bdd72f16fc0609bdb823042f37) mapping the previous class names. If the `classNames` object is the same as the default, [it will switch](https://github.com/gpbl/react-day-picker/compare/css-modules?expand=1#diff-fa00567f82a050a0ef4e10d8a54c4900R33) to the original behavior.