### PR TITLE
Fix keyboard navigation with custom classNames

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -68,6 +68,7 @@ export default class DayPicker extends Component {
       today: PropTypes.string.isRequired,
       selected: PropTypes.string.isRequired,
       disabled: PropTypes.string.isRequired,
+      day: PropTypes.string.isRequired,
     }),
     className: PropTypes.string,
     containerProps: PropTypes.object,
@@ -152,7 +153,17 @@ export default class DayPicker extends Component {
   }
 
   getDayNodes() {
-    return this.dayPicker.querySelectorAll('.DayPicker-Day:not(.DayPicker-Day--outside)');
+    const createQuery = classes => `.${classes.replace(/ /g, '.')}`;
+    const hasDefaultClassNames = () => this.props.classNames === classNames;
+    const getOutsideClassNames = (classes) => {
+      if (hasDefaultClassNames()) {
+        return `${classes.day}--${classes.outside}`;
+      }
+      return classes.outside;
+    };
+    const dayQuery = createQuery(this.props.classNames.day);
+    const outsideDayQuery = createQuery(getOutsideClassNames(this.props.classNames));
+    return this.dayPicker.querySelectorAll(`${dayQuery}:not(${outsideDayQuery})`);
   }
 
   getNextNavigableMonth() {

--- a/test/daypicker/navigation.js
+++ b/test/daypicker/navigation.js
@@ -18,25 +18,17 @@ describe('DayPicker’s navigation', () => {
     expect(wrapper.instance().allowPreviousMonth()).to.be.false;
   });
   it('should not allow the previous month when cannot change months', () => {
-    const wrapper = shallow(
-      <DayPicker canChangeMonth={ false } />,
-    );
+    const wrapper = shallow(<DayPicker canChangeMonth={ false } />);
     expect(wrapper.instance().allowPreviousMonth()).to.be.false;
   });
   it('should not allow the next month when the last month is the last allowed one', () => {
     const wrapper = shallow(
-      <DayPicker
-        initialMonth={ new Date(2015, 7) }
-        toMonth={ new Date(2015, 9) }
-        numberOfMonths={ 3 }
-      />,
+      <DayPicker initialMonth={ new Date(2015, 7) } toMonth={ new Date(2015, 9) } numberOfMonths={ 3 } />, // eslint-disable-line max-len
     );
     expect(wrapper.instance().allowNextMonth()).to.be.false;
   });
   it('should not allow the next month when cannot change months', () => {
-    const wrapper = shallow(
-      <DayPicker canChangeMonth={ false } />,
-    );
+    const wrapper = shallow(<DayPicker canChangeMonth={ false } />);
     expect(wrapper.instance().allowNextMonth()).to.be.false;
   });
   it('should show the next month when clicking the next button', () => {
@@ -73,9 +65,7 @@ describe('DayPicker’s navigation', () => {
     expect(instance.state.currentMonth.getMonth()).to.equal(6);
   });
   it('should not allow changing to the year when cannot change months', () => {
-    const wrapper = shallow(
-      <DayPicker canChangeMonth={ false } />,
-    );
+    const wrapper = shallow(<DayPicker canChangeMonth={ false } />);
     expect(wrapper.instance().allowYearChange()).to.be.false;
   });
   it('should call `showNextMonth()` when the RIGHT key is pressed', () => {
@@ -162,5 +152,62 @@ describe('DayPicker’s navigation', () => {
     expect(instance.state.currentMonth.getFullYear()).to.equal(2015);
     expect(instance.state.currentMonth.getMonth()).to.equal(5);
     expect(instance.state.currentMonth.getDate()).to.equal(1);
+  });
+
+  describe('with custom classNames', () => {
+    const getDaysInMonth = wrapper =>
+      wrapper
+        .find('.day.another-day-class')
+        .filterWhere(
+          node => !node.hasClass('othermonth') && !node.hasClass('another-othermonth-class'),
+        );
+    const classes = {
+      container: 'datepicker',
+      interactionDisabled: 'interaction-disabled',
+      navBar: 'navbar',
+      navButtonPrev: 'prev',
+      navButtonNext: 'next',
+      month: 'month',
+      caption: 'caption',
+      weekdays: 'weekdays',
+      weekdaysRow: 'weekdaysRow',
+      weekday: 'weekday',
+      body: 'body',
+      week: 'week',
+      day: 'day another-day-class',
+      today: 'today',
+      selected: 'selected',
+      outside: 'othermonth another-othermonth-class',
+      disabled: 'disabled',
+    };
+
+    it('should call `focusNextDay()` when the RIGHT key is pressed on a day', () => {
+      const wrapper = mount(<DayPicker classNames={ classes } />);
+      const focusNextDay = spy(wrapper.instance(), 'focusNextDay');
+      getDaysInMonth(wrapper).first().simulate('keyDown', { keyCode: keys.RIGHT });
+      expect(focusNextDay).to.have.been.calledOnce;
+      focusNextDay.restore();
+    });
+    it('should call `focusPreviousDay()` when the LEFT key is pressed on a day', () => {
+      const wrapper = mount(<DayPicker classNames={ classes } />);
+      const focusPreviousDay = spy(wrapper.instance(), 'focusPreviousDay');
+      getDaysInMonth(wrapper).first().simulate('keyDown', { keyCode: keys.LEFT });
+      expect(focusPreviousDay).to.have.been.calledOnce;
+      focusPreviousDay.restore();
+    });
+    it('should call `focusNextWeek()` when the DOWN key is pressed on a day', () => {
+      const wrapper = mount(<DayPicker classNames={ classes } />);
+      const focusNextWeek = spy(wrapper.instance(), 'focusNextWeek');
+      getDaysInMonth(wrapper).first().simulate('keyDown', { keyCode: keys.DOWN });
+      expect(focusNextWeek).to.have.been.calledOnce;
+      focusNextWeek.restore();
+    });
+    it('should call `focusPreviousWeek()` when the UP key is pressed on a day', () => {
+      const wrapper = mount(<DayPicker classNames={ classes } />);
+      const focusPreviousWeek = spy(wrapper.instance(), 'focusPreviousWeek');
+      getDaysInMonth(wrapper).last().simulate('keyDown', { keyCode: keys.UP });
+      expect(focusPreviousWeek).to.have.been.calledOnce;
+      focusPreviousWeek.restore();
+    });
   });
 });


### PR DESCRIPTION
Fixes #268 

**Changes:**
This will remove the assumptions about the CSS classes in the DayPicker.getDayNodes method.  Since users can pass in multiple, space delimited classes, we'll need to be a bit careful about how we build up the query.  Also relevant to note: This is tied really tightly to the implementation details of modifiers (sometimes it's a combination of the day and modifier, sometimes it's not).  Not sure if that's the best way going forward, but I wanted to keep changes tightly scoped for this patch.

Also added some tests for the custom classNames use case.  They're basically copies of existing tests with the selectors changed up to match the custom classNames being passed in.

cc @gpbl 
