### PR TITLE
Allow 'today' modifier to override default

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -421,11 +421,11 @@ export default class DayPicker extends Component {
     return React.cloneElement(navbarElement, props);
   }
   renderDayInMonth(day, month) {
-    const { today } = this.props.classNames;
     const propModifiers = Helpers.getModifiersFromProps(this.props);
     const dayModifiers = Helpers.getModifiersForDay(day, propModifiers);
-    if (DateUtils.isSameDay(day, new Date()) && !propModifiers.hasOwnProperty(today)) {
-      dayModifiers.push(today);
+    if (DateUtils.isSameDay(day, new Date()) &&
+        !Object.prototype.hasOwnProperty.call(propModifiers, this.props.classNames.today)) {
+      dayModifiers.push(this.props.classNames.today);
     }
     if (day.getMonth() !== month.getMonth()) {
       dayModifiers.push(this.props.classNames.outside);

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -421,17 +421,15 @@ export default class DayPicker extends Component {
     return React.cloneElement(navbarElement, props);
   }
   renderDayInMonth(day, month) {
-    let dayModifiers = [];
-    if (DateUtils.isSameDay(day, new Date())) {
-      dayModifiers.push(this.props.classNames.today);
+    const { today } = this.props.classNames;
+    const propModifiers = Helpers.getModifiersFromProps(this.props);
+    const dayModifiers = Helpers.getModifiersForDay(day, propModifiers);
+    if (DateUtils.isSameDay(day, new Date()) && !propModifiers.hasOwnProperty(today)) {
+      dayModifiers.push(today);
     }
     if (day.getMonth() !== month.getMonth()) {
       dayModifiers.push(this.props.classNames.outside);
     }
-    dayModifiers = [
-      ...dayModifiers,
-      ...Helpers.getModifiersForDay(day, Helpers.getModifiersFromProps(this.props)),
-    ];
 
     const isOutside = day.getMonth() !== month.getMonth();
     let tabIndex = null;

--- a/test/daypicker/modifiers.js
+++ b/test/daypicker/modifiers.js
@@ -65,4 +65,20 @@ describe('DayPicker’s day modifiers', () => {
     expect(wrapper.find('.DayPicker-Day--none')).to.have.length(0);
     expect(wrapper.find('.DayPicker-Day--all')).to.have.length(35);
   });
+  it('should show "today" as something other than the current day', () => {
+    const newToday = new Date();
+    newToday.setDate((new Date()).getDate() + 1);
+    newToday.setMonth((new Date()).getMonth());
+
+    const modifiers = {
+      today: newToday,
+    };
+    const wrapper = mount(
+      <DayPicker
+        initialMonth={ new Date() }
+        modifiers={ modifiers }
+      />,
+    );
+    expect(wrapper.find('.DayPicker-Day--today')).to.have.text(newToday.getDate());
+  });
 });


### PR DESCRIPTION
The product I am working on allows users to specify a timezone other than that of their browsers, and in doing so might cause what the day picker component thinks `today` is to be different from what the user expects. This change simply allows me to override the `today` modifier with a custom function that could use other references, such as `moment-timezone` objects.

This was run with `test`, `cover`, and `lint`, but if there are other modifications necessary, please let me know.

Thanks, and I welcome your feedback!