### PR TITLE
Fix unit tests with moment 2.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "istanbul": "1.1.0-alpha.1",
     "jsdom": "9.0.0",
     "mocha": "^3.2.0",
-    "moment": "^2.17.1",
+    "moment": "^2.18.1",
     "postcss-cli": "2.6.0",
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",

--- a/test/addons/MomentLocaleUtils.js
+++ b/test/addons/MomentLocaleUtils.js
@@ -8,7 +8,7 @@ describe('MomentLocaleUtils', () => {
       const formattedDate = MomentLocaleUtils.formatDay(date);
       expect(formattedDate).to.equal('Sun Dec 20, 2015');
       const formattedDateIT = MomentLocaleUtils.formatDay(date, 'it');
-      expect(formattedDateIT).to.equal('Dom 20 dic 2015');
+      expect(formattedDateIT).to.equal('dom 20 dic 2015');
     });
   });
 
@@ -25,14 +25,14 @@ describe('MomentLocaleUtils', () => {
   describe('formatWeekdayShort', () => {
     it('should return the short day name as string', () => {
       expect(MomentLocaleUtils.formatWeekdayShort(0)).to.equal('Su');
-      expect(MomentLocaleUtils.formatWeekdayShort(0, 'it')).to.equal('Do');
+      expect(MomentLocaleUtils.formatWeekdayShort(0, 'it')).to.equal('do');
     });
   });
 
   describe('formatWeekdayLong', () => {
     it('should return the long day name as string', () => {
       expect(MomentLocaleUtils.formatWeekdayLong(0)).to.equal('Sunday');
-      expect(MomentLocaleUtils.formatWeekdayLong(0, 'it')).to.equal('Domenica');
+      expect(MomentLocaleUtils.formatWeekdayLong(0, 'it')).to.equal('domenica');
     });
   });
 


### PR DESCRIPTION
It seems that an update of moment has changed the way Italian dates are formatted. See https://github.com/moment/moment/commit/f2af24d53ec8bb2ad61626509e529d339217ff96#diff-0dbfeab7e62c031ad1b2c328b10e2d89 for details. The previously required version of moment was ^2.17.1, which would result in 2.18.1 being installed on a fresh `npm install`. Under 2.18.1 the old unit tests would fail.

This commit updates the required version of moment, and makes sure the unit tests pass with that version.