### PR TITLE
Add modifiers-styles

### DIFF
--- a/src/Day.js
+++ b/src/Day.js
@@ -15,6 +15,7 @@ function handleEvent(handler, day, modifiers) {
 }
 export default function Day({
   classNames,
+  modifiersStyles,
   day,
   tabIndex,
   empty,
@@ -30,7 +31,6 @@ export default function Day({
   ariaDisabled,
   ariaSelected,
   children,
-  modifiersStyles,
 }) {
   let className = classNames.day;
   if (classNames !== defaultClassNames) {
@@ -41,20 +41,25 @@ export default function Day({
       .map(modifier => ` ${className}--${modifier}`)
       .join('');
   }
-  if (empty) {
-    return <div role="gridcell" aria-disabled className={className} />;
-  }
 
-  const styles = Object.assign(
-    {},
-    ...Object.keys(modifiers).map(modifier => modifiersStyles[modifier])
-  );
+  const style =
+    modifiersStyles &&
+    Object.assign(
+      {},
+      ...Object.keys(modifiers).map(modifier => modifiersStyles[modifier])
+    );
+
+  if (empty) {
+    return (
+      <div role="gridcell" aria-disabled className={className} style={style} />
+    );
+  }
 
   return (
     <div
       className={className}
       tabIndex={tabIndex}
-      style={styles}
+      style={style}
       role="gridcell"
       aria-label={ariaLabel}
       aria-disabled={ariaDisabled.toString()}

--- a/src/Day.js
+++ b/src/Day.js
@@ -30,6 +30,7 @@ export default function Day({
   ariaDisabled,
   ariaSelected,
   children,
+  modifiersStyles,
 }) {
   let className = classNames.day;
   if (classNames !== defaultClassNames) {
@@ -43,10 +44,17 @@ export default function Day({
   if (empty) {
     return <div role="gridcell" aria-disabled className={className} />;
   }
+
+  const styles = Object.assign(
+    {},
+    ...Object.keys(modifiers).map(modifier => modifiersStyles[modifier])
+  );
+
   return (
     <div
       className={className}
       tabIndex={tabIndex}
+      style={styles}
       role="gridcell"
       aria-label={ariaLabel}
       aria-disabled={ariaDisabled.toString()}
@@ -77,6 +85,7 @@ Day.propTypes = {
   ariaSelected: PropTypes.bool,
   empty: PropTypes.bool,
   modifiers: PropTypes.object,
+  modifiersStyles: PropTypes.object,
   onClick: PropTypes.func,
   onKeyDown: PropTypes.func,
   onMouseEnter: PropTypes.func,

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -122,7 +122,6 @@ export default class DayPicker extends Component {
     canChangeMonth: true,
     reverseMonths: false,
     pagedNavigation: false,
-    modifiersStyles: {},
     renderDay: day => day.getDate(),
     weekdayElement: <Weekday />,
     navbarElement: <Navbar classNames={classNames} />,

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -37,7 +37,7 @@ export default class DayPicker extends Component {
       PropTypes.arrayOf(ModifierPropType),
     ]),
     modifiers: PropTypes.object,
-
+    modifiersStyles: PropTypes.object,
     // Localization
     dir: PropTypes.string,
     firstDayOfWeek: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6]),
@@ -122,6 +122,7 @@ export default class DayPicker extends Component {
     canChangeMonth: true,
     reverseMonths: false,
     pagedNavigation: false,
+    modifiersStyles: {},
     renderDay: day => day.getDate(),
     weekdayElement: <Weekday />,
     navbarElement: <Navbar classNames={classNames} />,
@@ -487,6 +488,7 @@ export default class DayPicker extends Component {
         classNames={this.props.classNames}
         day={day}
         modifiers={modifiers}
+        modifiersStyles={this.props.modifiersStyles}
         empty={
           isOutside && !this.props.enableOutsideDays && !this.props.fixedWeeks
         }

--- a/test/daypicker/modifiers.js
+++ b/test/daypicker/modifiers.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, render } from 'enzyme';
 import { expect } from 'chai';
 
 import DayPicker from '../../src/DayPicker';
@@ -15,6 +15,19 @@ describe('DayPicker’s day modifiers', () => {
     );
     expect(wrapper.find('.DayPicker-Day--selected')).to.have.length(35);
     expect(wrapper.find('.DayPicker-Day--foo')).to.have.length(35);
+  });
+  it('should have `red` background style on `foo` modified days', () => {
+    const wrapper = render(
+      <DayPicker
+        initialMonth={new Date(2015, 6)}
+        modifiers={{ foo: () => true }}
+        modifiersStyles={{ foo: { background: 'red' } }}
+      />
+    );
+    expect(wrapper.find('.DayPicker-Day--foo')).to.have.style(
+      'background',
+      'red'
+    );
   });
   it('should add the `aria-selected` attribute for `selected` days', () => {
     const wrapper = mount(


### PR DESCRIPTION
Thanks Giampaolo for making such a great date picker component. 

I also recently ran into the case where I wanted to add inline styles. I found that for all cases I could change the styling by importing the css file like you have in your examples. The one exception was for the day modifiers. 

I wanted to propose this as a solution to the inline styles. You would pass in an object of modifiersStyles and when you go into each day, it would go into the modifiersStyles object to see if there was a corresponding style object and apply it to the day, since you've already done the test for which modifiers should be applied :)

It's working well in my local example when I built it, so feel free to use this for inline styles for days if you find it helpful.

Cheers,
Susie
