### PR TITLE
Add isDayAfter/isDayBefore 

### DIFF
--- a/docs/DateUtils.md
+++ b/docs/DateUtils.md
@@ -17,29 +17,29 @@ Return `d` as a new date with `n` months added. Missing days will be added to th
 
 Clone the date `d` returning a new date with the same time.
 
-### isDayAfter `(d1: ?Date, d2: ?Date) ⇒ Bool`
+### isDayAfter `(day1: ?Date, day2: ?Date) ⇒ Bool`
 
 Return `true` if the first day is after the second day.
 
-### isDayBefore `(d1: ?Date, d2: ?Date) ⇒ Bool`
+### isDayBefore `(day1: ?Date, day2: ?Date) ⇒ Bool`
 
 Return `true` if the first day is before the second day.
 
-### isSameDay `(d1: ?Date, d2: ?Date) ⇒ Bool`
+### isSameDay `(day1: ?Date, day2: ?Date) ⇒ Bool`
 
-Return `true` if the two dates `d1` and `d2` are the same day, e.g. ignoring their time.
+Return `true` if `day1` and `day2` are the same day.
 
-### isPastDay `(d: Date) ⇒ Bool`
+### isPastDay `(day: Date) ⇒ Bool`
 
-Returns `true` if `d` is in the past, e.g. is yesterday or any day before yesterday.
+Returns `true` if `day` is in the past, e.g. is yesterday or any day before yesterday.
 
-### isFutureDay `(d: Date) ⇒ Bool`
+### isFutureDay `(day: Date) ⇒ Bool`
 
-Returns `true` if `d` is in the future, e.g. is tomorrow or any day after tomorrow.
+Returns `true` if `day` is in the future, e.g. is tomorrow or any day after tomorrow.
 
-### isDayBetween `(day: Date, d1: Date, d2: Date) ⇒ Bool`
+### isDayBetween `(day: Date, day1: Date, day2: Date) ⇒ Bool`
 
-Returns `true` if `day` is between the days `d1` and `d2`, without including those days.
+Returns `true` if `day` is between the days `day1` and `day2`, without including those days.
 
 ### addDayToRange `(day: Date, range: ?object<from: ?Date, to: ?Date>) ⇒ Object<from: ?Date, to: ?Date>`
 

--- a/docs/DateUtils.md
+++ b/docs/DateUtils.md
@@ -17,6 +17,14 @@ Return `d` as a new date with `n` months added. Missing days will be added to th
 
 Clone the date `d` returning a new date with the same time.
 
+### isDayAfter `(d1: ?Date, d2: ?Date) ⇒ Bool`
+
+Return `true` if the first day is after the second day.
+
+### isDayBefore `(d1: ?Date, d2: ?Date) ⇒ Bool`
+
+Return `true` if the first day is before the second day.
+
 ### isSameDay `(d1: ?Date, d2: ?Date) ⇒ Bool`
 
 Return `true` if the two dates `d1` and `d2` are the same day, e.g. ignoring their time.

--- a/examples/src/examples/RangeAdvanced.js
+++ b/examples/src/examples/RangeAdvanced.js
@@ -13,7 +13,7 @@ const initialState = {
 
 function isSelectingFirstDay(from, to, day) {
   const firstDayIsNotSelected = !from;
-  const selectedDayIsBeforeFirstDay = day < from;
+  const selectedDayIsBeforeFirstDay = DateUtils.isDayBefore(day, from);
   const rangeIsSelected = from && to;
   return (
     firstDayIsNotSelected || selectedDayIsBeforeFirstDay || rangeIsSelected

--- a/src/DateUtils.js
+++ b/src/DateUtils.js
@@ -38,6 +38,34 @@ export function isSameDay(d1, d2) {
 }
 
 /**
+ * Returns `true` if the first day is before the second day.
+ * 
+ * @export
+ * @param {Date} d1 
+ * @param {Date} d2 
+ * @returns {Boolean}
+ */
+export function isDayBefore(d1, d2) {
+  const day1 = clone(d1).setHours(0, 0, 0, 0);
+  const day2 = clone(d2).setHours(0, 0, 0, 0);
+  return day1 < day2;
+}
+
+/**
+ * Returns `true` if the first day is after the second day.
+ * 
+ * @export
+ * @param {Date} d1 
+ * @param {Date} d2 
+ * @returns {Boolean}
+ */
+export function isDayAfter(d1, d2) {
+  const day1 = clone(d1).setHours(0, 0, 0, 0);
+  const day2 = clone(d2).setHours(0, 0, 0, 0);
+  return day1 > day2;
+}
+
+/**
  * Return `true` if a day is in the past, e.g. yesterday or any day
  * before yesterday.
  *
@@ -47,7 +75,7 @@ export function isSameDay(d1, d2) {
 export function isPastDay(d) {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
-  return d < today;
+  return isDayBefore(d, today);
 }
 
 /**

--- a/src/DateUtils.js
+++ b/src/DateUtils.js
@@ -102,13 +102,11 @@ export function isFutureDay(d) {
  */
 export function isDayBetween(d, d1, d2) {
   const date = clone(d);
-  const date1 = clone(d1);
-  const date2 = clone(d2);
-
   date.setHours(0, 0, 0, 0);
-  date1.setHours(0, 0, 0, 0);
-  date2.setHours(0, 0, 0, 0);
-  return (date1 < date && date < date2) || (date2 < date && date < date1);
+  return (
+    (isDayAfter(date, d1) && isDayBefore(date, d2)) ||
+    (isDayAfter(date, d2) && isDayBefore(date, d1))
+  );
 }
 
 /**
@@ -126,14 +124,14 @@ export function addDayToRange(day, range = { from: null, to: null }) {
   } else if (from && to && isSameDay(from, to) && isSameDay(day, from)) {
     from = null;
     to = null;
-  } else if (to && day < from) {
+  } else if (to && isDayBefore(day, from)) {
     from = day;
   } else if (to && isSameDay(day, to)) {
     from = day;
     to = day;
   } else {
     to = day;
-    if (to < from) {
+    if (isDayBefore(to, from)) {
       to = from;
       from = day;
     }

--- a/src/Helpers.js
+++ b/src/Helpers.js
@@ -1,4 +1,10 @@
-import { clone, isSameDay, isDayInRange } from './DateUtils';
+import {
+  clone,
+  isSameDay,
+  isDayInRange,
+  isDayAfter,
+  isDayBefore,
+} from './DateUtils';
 import { getFirstDayOfWeek } from './LocaleUtils';
 
 export function cancelEvent(e) {
@@ -71,10 +77,10 @@ export function getModifiersForDay(d, modifiersObj = {}) {
             return isDayInRange(d, range);
           }
           if (day.after) {
-            return d > day.after;
+            return isDayAfter(d, day.after);
           }
           if (day.before) {
-            return d < day.before;
+            return isDayBefore(d, day.before);
           }
           if (typeof day === 'function' && day(d)) {
             return true;
@@ -87,10 +93,10 @@ export function getModifiersForDay(d, modifiersObj = {}) {
     } else if (isRangeOfDates(value) && isDayInRange(d, value)) {
       // modifier's value is a range
       modifiers.push(modifier);
-    } else if (value.after && d > value.after) {
+    } else if (value.after && isDayAfter(d, value.after)) {
       // modifier's value has an after date
       modifiers.push(modifier);
-    } else if (value.before && d < value.before) {
+    } else if (value.before && isDayBefore(d, value.before)) {
       // modifier's value has an after date
       modifiers.push(modifier);
     } else if (typeof value === 'function' && value(d)) {

--- a/test/DateUtils.js
+++ b/test/DateUtils.js
@@ -29,6 +29,48 @@ describe('DateUtils', () => {
     });
   });
 
+  describe('isDayBefore', () => {
+    it('returns true when the day is before the other day', () => {
+      const day1 = new Date(2015, 10, 11, 5, 25);
+      const day2 = new Date(2015, 10, 12, 3, 40);
+      const isDayBefore = DateUtils.isDayBefore(day1, day2);
+      expect(isDayBefore).to.be.true;
+    });
+    it('returns false for the same day with different times', () => {
+      const day1 = new Date(2015, 10, 11, 5, 25);
+      const day2 = new Date(2015, 10, 11, 6, 40);
+      const isDayBefore = DateUtils.isDayBefore(day1, day2);
+      expect(isDayBefore).to.be.false;
+    });
+    it('returns false if the second day is after', () => {
+      const day1 = new Date(2015, 10, 13, 5, 25);
+      const day2 = new Date(2015, 10, 12, 1, 40);
+      const isDayBefore = DateUtils.isDayBefore(day1, day2);
+      expect(isDayBefore).to.be.false;
+    });
+  });
+
+  describe('isDayAfter', () => {
+    it('returns true when the day is after the other day', () => {
+      const day1 = new Date(2015, 10, 13, 5, 25);
+      const day2 = new Date(2015, 10, 12, 3, 40);
+      const isDayAfter = DateUtils.isDayAfter(day1, day2);
+      expect(isDayAfter).to.be.true;
+    });
+    it('returns false for the same day with different times', () => {
+      const day1 = new Date(2015, 10, 11, 5, 25);
+      const day2 = new Date(2015, 10, 11, 6, 40);
+      const isDayAfter = DateUtils.isDayAfter(day1, day2);
+      expect(isDayAfter).to.be.false;
+    });
+    it('returns false if the second day is after', () => {
+      const day1 = new Date(2015, 10, 12, 5, 25);
+      const day2 = new Date(2015, 10, 13, 1, 40);
+      const isDayAfter = DateUtils.isDayAfter(day1, day2);
+      expect(isDayAfter).to.be.false;
+    });
+  });
+
   describe('isSameDay', () => {
     it('returns true if two days differ only by time', () => {
       const day1 = new Date(2015, 10, 11, 5, 25);

--- a/test/Helpers.js
+++ b/test/Helpers.js
@@ -215,14 +215,14 @@ describe('Helpers', () => {
       expect(modifiers.indexOf('foo')).to.equal(0);
     });
     it('returns a "before" modifier', () => {
-      const afterModifier = {
+      const beforeModifier = {
         foo: {
           before: new Date(2015, 8, 15),
         },
       };
       const modifiers = Helpers.getModifiersForDay(
         new Date(2015, 8, 10),
-        afterModifier
+        beforeModifier
       );
       expect(modifiers).to.have.length(1);
       expect(modifiers.indexOf('foo')).to.equal(0);

--- a/test/Helpers.js
+++ b/test/Helpers.js
@@ -88,14 +88,14 @@ describe('Helpers', () => {
       expect(modifiers.indexOf('maybe')).to.equal(-1);
       expect(modifiers.indexOf('no')).to.equal(-1);
     });
-    it('accepts a single day', () => {
+    it('returns the modifier for a single day', () => {
       const modifiers = Helpers.getModifiersForDay(new Date(2015, 8, 19), {
         foo: new Date(2015, 8, 19),
       });
       expect(modifiers).to.have.length(1);
       expect(modifiers.indexOf('foo')).to.equal(0);
     });
-    it('ignore falsy values', () => {
+    it('ignores falsy values', () => {
       const modifiers = Helpers.getModifiersForDay(new Date(2015, 8, 19), {
         foo: null,
         bar: false,
@@ -103,7 +103,7 @@ describe('Helpers', () => {
       expect(modifiers).to.have.length(0);
       expect(modifiers.indexOf('foo')).to.equal(-1);
     });
-    it('accepts an array of days', () => {
+    it('returns the modifier for an array of days', () => {
       const modifiersObj = {
         foo: [
           new Date(2015, 8, 19),
@@ -147,7 +147,7 @@ describe('Helpers', () => {
       expect(modifiers).to.have.length(1);
       expect(modifiers.indexOf('foo')).to.be.above(-1);
     });
-    it('accepts a single range of days', () => {
+    it('returns the modifier for a range of days', () => {
       const range = {
         foo: {
           from: new Date(2015, 8, 18),
@@ -166,7 +166,7 @@ describe('Helpers', () => {
       );
       expect(modifiers2).to.have.length(0);
     });
-    it('accepts multiple ranges of days', () => {
+    it('returns the modifier for multiple ranges of days', () => {
       const ranges = {
         foo: [
           {
@@ -190,7 +190,7 @@ describe('Helpers', () => {
       );
       expect(modifiers2.indexOf('foo')).to.equal(0);
     });
-    it('accepts an "after" modifier', () => {
+    it('returns an "after" modifier', () => {
       const afterModifier = {
         foo: {
           after: new Date(2015, 8, 18),
@@ -203,7 +203,7 @@ describe('Helpers', () => {
       expect(modifiers).to.have.length(1);
       expect(modifiers.indexOf('foo')).to.equal(0);
     });
-    it('accepts an "after" modifier in an array of days', () => {
+    it('returns an "after" modifier in an array of days', () => {
       const afterModifier = {
         foo: [{ after: new Date(2015, 8, 18) }],
       };
@@ -214,7 +214,7 @@ describe('Helpers', () => {
       expect(modifiers).to.have.length(1);
       expect(modifiers.indexOf('foo')).to.equal(0);
     });
-    it('accepts a "before" modifier', () => {
+    it('returns a "before" modifier', () => {
       const afterModifier = {
         foo: {
           before: new Date(2015, 8, 15),
@@ -227,7 +227,7 @@ describe('Helpers', () => {
       expect(modifiers).to.have.length(1);
       expect(modifiers.indexOf('foo')).to.equal(0);
     });
-    it('accepts a "before" modifier in an array of days', () => {
+    it('returns a "before" modifier in an array of days', () => {
       const afterModifier = {
         foo: [{ before: new Date(2015, 8, 15) }],
       };
@@ -238,7 +238,7 @@ describe('Helpers', () => {
       expect(modifiers).to.have.length(1);
       expect(modifiers.indexOf('foo')).to.equal(0);
     });
-    it('work with a mix of functions and days', () => {
+    it('works with mixing functions and other objects', () => {
       const mixedModifiers = {
         foo: [
           { before: new Date(2015, 8, 15) },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,13 +15,13 @@ declare namespace DayPicker {
         addDayToRange(day: Date, range: RangeModifier): RangeModifier;
         addMonths(d: Date, n: number): Date;
         clone(d: Date): Date;
-        isDayAfter(d1: Date, d2: Date): boolean;
-        isDayBefore(d1: Date, d2: Date): boolean;
+        isDayAfter(day1: Date, day2: Date): boolean;
+        isDayBefore(day1: Date, day2: Date): boolean;
         isDayBetween(day: Date, begin: Date, end: Date): boolean;
         isDayInRange(day: Date, range: RangeModifier): boolean;
-        isFutureDay(d: Date): boolean;
-        isPastDay(d: Date): boolean;
-        isSameDay(d1: Date, d2: Date): boolean;
+        isFutureDay(day: Date): boolean;
+        isPastDay(day: Date): boolean;
+        isSameDay(day1: Date, day2: Date): boolean;
     }
 
     interface CaptionElementProps {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,6 +15,8 @@ declare namespace DayPicker {
         addMonths(d: Date, n: number): Date;
         clone(d: Date): Date;
         isSameDay(d1: Date, d2: Date): Date;
+        isDayBefore(d1: Date, d2: Date): boolean;
+        isDayAfter(d1: Date, d2: Date): boolean;
         isPastDay(d: Date): boolean;
         isFutureDay(d: Date): boolean;
         isDayBetween(day: Date, begin: Date, end: Date): boolean;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,16 +12,16 @@ declare namespace DayPicker {
     }
 
     interface DateUtils {
+        addDayToRange(day: Date, range: RangeModifier): RangeModifier;
         addMonths(d: Date, n: number): Date;
         clone(d: Date): Date;
-        isSameDay(d1: Date, d2: Date): boolean;
-        isDayBefore(d1: Date, d2: Date): boolean;
         isDayAfter(d1: Date, d2: Date): boolean;
-        isPastDay(d: Date): boolean;
-        isFutureDay(d: Date): boolean;
+        isDayBefore(d1: Date, d2: Date): boolean;
         isDayBetween(day: Date, begin: Date, end: Date): boolean;
-        addDayToRange(day: Date, range: RangeModifier): RangeModifier;
         isDayInRange(day: Date, range: RangeModifier): boolean;
+        isFutureDay(d: Date): boolean;
+        isPastDay(d: Date): boolean;
+        isSameDay(d1: Date, d2: Date): boolean;
     }
 
     interface CaptionElementProps {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,7 +14,7 @@ declare namespace DayPicker {
     interface DateUtils {
         addMonths(d: Date, n: number): Date;
         clone(d: Date): Date;
-        isSameDay(d1: Date, d2: Date): Date;
+        isSameDay(d1: Date, d2: Date): boolean;
         isDayBefore(d1: Date, d2: Date): boolean;
         isDayAfter(d1: Date, d2: Date): boolean;
         isPastDay(d: Date): boolean;


### PR DESCRIPTION
This PR adds two new functions to `DateUtils` to detect if a day is after/before another day, taking account different timezones. Fixes #307.