### PR TITLE
change week aria role to row

### DIFF
--- a/src/Month.js
+++ b/src/Month.js
@@ -52,7 +52,7 @@ export default function Month({
           <div
             key={week[0].getTime()}
             className={classNames.week}
-            role="gridcell"
+            role="row"
           >
             {week.map(day => children(day, month))}
           </div>


### PR DESCRIPTION
Hey all! 👋 

First off - this module is wonderful! 🎉 👍 

Just running some accessibility audits on our app over at Buffer - we're using react-day-picker and we're getting a few errors when testing with axe-core! Nothing major, but the Week `div` should have a `role="row"` instead of `role="gridcell"` as it is a child of a `role="rowgroup"` and has children with `role="gridcell"`

Current role structure:
Month (grid) → Weekdays & Body (rowgroup) → Week (gridcell)→ Day (gridcell)

Proposed role structure:
Month (grid) → Weekdays & Body (rowgroup) → Week (row)→ Day (gridcell)

More on  the rowgroup role in the Web Accessibility Initiative – Accessible Rich Internet Applications standards: https://www.w3.org/TR/wai-aria/roles#rowgroup

Let me know if you have any questions! 😸 thanks again!