### PR TITLE
Add componentWillReceiveProps

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -74,6 +74,10 @@ export default class DayPickerInput extends React.Component {
     this.state = getStateFromProps(props);
   }
 
+  componentWillReceiveProps(nextProps) {
+      this.state = getStateFromProps(nextProps);
+  }
+
   componentWillUnmount() {
     /* istanbul ignore next */
     clearTimeout(this.clickTimeout);


### PR DESCRIPTION
Hi,

When DayPickerInput gets nextProps, it doesn't change its states.
How about adding componentWillReceiveProps lifecycles?

After it mounted,
if it doesn't trigger any change events, the value state is different from value property.