### PR TITLE
Fixes #380 logic bug for checking whether to update `month` state

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -75,7 +75,7 @@ export default class DayPickerInput extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.value !== this.state.value) {
+    if (nextProps.value !== this.state.value || nextProps.dayPickerProps.month !== this.state.month)) {
       this.setState(getStateFromProps(nextProps));
     }
   }

--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -75,7 +75,10 @@ export default class DayPickerInput extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.value !== this.state.value || nextProps.dayPickerProps.month !== this.state.month) {
+    if (
+      nextProps.value !== this.state.value ||
+      nextProps.dayPickerProps.month !== this.state.month
+    ) {
       this.setState(getStateFromProps(nextProps));
     }
   }

--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -75,7 +75,7 @@ export default class DayPickerInput extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.value !== this.state.value || nextProps.dayPickerProps.month !== this.state.month)) {
+    if (nextProps.value !== this.state.value || nextProps.dayPickerProps.month !== this.state.month) {
       this.setState(getStateFromProps(nextProps));
     }
   }


### PR DESCRIPTION
Basically, in `DayPickerInput`, updating the `dayPickerProps.month` after it mounts generally does not actually update the month. See #380 for more info.

Caused by a bug in the logic, the fix is pretty self-explanatory.