### PR TITLE
Accessibility: Days should have a negative tabIndex by default

### DIFF
--- a/src/Day.js
+++ b/src/Day.js
@@ -40,6 +40,10 @@ export default class Day extends Component {
   };
 
   static defaultProps = {
+    tabIndex: -1,
+  };
+
+  static defaultProps = {
     modifiers: {},
     empty: false,
   };
@@ -96,7 +100,7 @@ export default class Day extends Component {
     return (
       <div
         className={className}
-        tabIndex={tabIndex || 0}
+        tabIndex={tabIndex}
         style={style}
         role="gridcell"
         aria-label={ariaLabel}

--- a/src/Month.js
+++ b/src/Month.js
@@ -77,13 +77,10 @@ export default class Month extends Component {
     }
 
     const isOutside = day.getMonth() !== monthNumber;
-    let tabIndex = null;
-    if (this.props.onDayClick && !isOutside) {
-      tabIndex = -1;
-      // Focus on the first day of the month
-      if (day.getDate() === 1) {
-        tabIndex = this.props.tabIndex;
-      }
+    let tabIndex = -1;
+    // Focus on the first day of the month
+    if (this.props.onDayClick && !isOutside && day.getDate() === 1) {
+      tabIndex = this.props.tabIndex;
     }
     const key = `${day.getFullYear()}${day.getMonth()}${day.getDate()}`;
     const modifiers = {};

--- a/test/daypicker/rendering.js
+++ b/test/daypicker/rendering.js
@@ -308,6 +308,14 @@ describe('DayPicker’s rendering', () => {
     expect(wrapper.find('.DayPicker-Day').at(1)).to.have.text('29');
     expect(wrapper.find('.DayPicker-Day').at(2)).to.have.text('30');
   });
+  it('should not allow tabbing to outside days', () => {
+    const wrapper = mount(
+      <DayPicker enableOutsideDays initialMonth={new Date(2015, 6)} />
+    );
+    expect(wrapper.find('.DayPicker-Day').at(0).prop('tabIndex')).to.equal(-1);
+    expect(wrapper.find('.DayPicker-Day').at(1).prop('tabIndex')).to.equal(-1);
+    expect(wrapper.find('.DayPicker-Day').at(2).prop('tabIndex')).to.equal(-1);
+  });
   it('should render the fixed amount of weeks', () => {
     const wrapper = mount(
       <DayPicker


### PR DESCRIPTION
Fixes #400

**Bug:**
To properly control tab behavior, only one of the days should have a tabIndex > -1.  However, when a user first tabs to a calendar with `enableOtherDays` set, focus initially lands on the first day in another month.

**Root Cause:**
Since the Month component only explicitly sets a tabIndex for days in the current month and the Day component defaults the tabIndex to 0, days in other months can be tabbed to.

**Changes:**
- Always pass a tabIndex to the Day component.  Default it to -1.
- Remove the `tabIndex|| 0` when outputting the day, and add a defaultProp which sets the tabIndex to -1.
- Add a test.

cc: @gpbl 