### PR TITLE
IE11: Update babel config to use the runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,12 @@
 {
   "presets": ["react", "es2015", "stage-1"],
+  "plugins": [
+    ["transform-runtime", {
+      "helpers": true,
+      "polyfill": true,
+      "regenerator": false
+    }]
+  ],
   "env": {
     "production": {
       "plugins": ["transform-react-remove-prop-types"]

--- a/package.json
+++ b/package.json
@@ -63,9 +63,6 @@
     "url": "https://github.com/gpbl/react-day-picker/issues"
   },
   "homepage": "https://react-day-picker.js.org",
-  "peerDependencies": {
-    "react": "~0.13.x || ~0.14.x || ^15.0.0"
-  },
   "devDependencies": {
     "@types/react": "^15.0.27",
     "autoprefixer": "^7.1.1",
@@ -74,6 +71,7 @@
     "babel-eslint": "7.2.3",
     "babel-loader": "7.0.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.5",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "6.24.1",
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-1": "6.24.1",
@@ -113,7 +111,9 @@
     "webpack": "^2.6.1"
   },
   "dependencies": {
-    "prop-types": "^15.5.10"
+    "babel-runtime": "^6.23.0",
+    "prop-types": "^15.5.10",
+    "react": "~0.13.x || ~0.14.x || ^15.0.0"
   },
   "precommit": "lint-staged",
   "lint-staged": {


### PR DESCRIPTION
**Bug:**
Fixes #403 

As mentioned in the issue, this library breaks in IE11 due to missing polyfills.  You could just document the polyfill requirements for this library, but since IE 11 is still [over 2% of browser usage](http://caniuse.com/usage-table) and this is a library, I think it'd be a good idea to set up babel to use polyfills and helpers.

I also had issues testing changes to the library.  When I ran `npm link` to test my changes, I kept getting errors saying that webpack could not find the "react" library.  I looked and saw that React is listed as a peerDependency.  However, since React is imported by the library's code and is required in order for this library to compile properly, I'm thinking it should be a dependency.

**Notes:**
[Babel documentation](http://babeljs.io/docs/plugins/transform-runtime/) on the plugins I'm using and dependencies I added.

**Changes:**
- Add the transform-runtime plugin configured to use the helpers and polyfills.
- Add a dependency on the babel-runtime.
- Moved React from a peerDependency to a dependency.

cc: @gpbl 