### PR TITLE
Update code to ensure IE11 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "webpack": "^2.6.1"
   },
   "dependencies": {
+    "object-assign": "^4.1.1",
     "prop-types": "^15.5.10"
   },
   "precommit": "lint-staged",

--- a/src/Day.js
+++ b/src/Day.js
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions, react/forbid-prop-types */
 
 import React, { Component } from 'react';
+import assign from 'object-assign';
 import defaultClassNames from './classNames';
 import PropTypes from './PropTypes';
 
@@ -86,7 +87,7 @@ export default class Day extends Component {
       Object.keys(modifiers)
         .filter(modifier => !!modifiersStyles[modifier])
         .forEach(modifier => {
-          style = Object.assign({}, style, modifiersStyles[modifier]);
+          style = assign({}, style, modifiersStyles[modifier]);
         });
     }
 

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -272,7 +272,7 @@ export default class DayPicker extends Component {
 
   focusPreviousDay(dayNode) {
     const dayNodes = Helpers.getDayNodes(this.dayPicker, this.props.classNames);
-    const dayNodeIndex = [...dayNodes].indexOf(dayNode);
+    const dayNodeIndex = Helpers.nodeListToArray(dayNodes).indexOf(dayNode);
 
     if (dayNodeIndex === 0) {
       this.showPreviousMonth(() => this.focusLastDayOfMonth());
@@ -283,7 +283,7 @@ export default class DayPicker extends Component {
 
   focusNextDay(dayNode) {
     const dayNodes = Helpers.getDayNodes(this.dayPicker, this.props.classNames);
-    const dayNodeIndex = [...dayNodes].indexOf(dayNode);
+    const dayNodeIndex = Helpers.nodeListToArray(dayNodes).indexOf(dayNode);
 
     if (dayNodeIndex === dayNodes.length - 1) {
       this.showNextMonth(() => this.focusFirstDayOfMonth());
@@ -294,7 +294,7 @@ export default class DayPicker extends Component {
 
   focusNextWeek(dayNode) {
     const dayNodes = Helpers.getDayNodes(this.dayPicker, this.props.classNames);
-    const dayNodeIndex = [...dayNodes].indexOf(dayNode);
+    const dayNodeIndex = Helpers.nodeListToArray(dayNodes).indexOf(dayNode);
     const isInLastWeekOfMonth = dayNodeIndex > dayNodes.length - 8;
 
     if (isInLastWeekOfMonth) {
@@ -312,7 +312,7 @@ export default class DayPicker extends Component {
 
   focusPreviousWeek(dayNode) {
     const dayNodes = Helpers.getDayNodes(this.dayPicker, this.props.classNames);
-    const dayNodeIndex = [...dayNodes].indexOf(dayNode);
+    const dayNodeIndex = Helpers.nodeListToArray(dayNodes).indexOf(dayNode);
     const isInFirstWeekOfMonth = dayNodeIndex <= 6;
 
     if (isInFirstWeekOfMonth) {

--- a/src/Helpers.js
+++ b/src/Helpers.js
@@ -136,3 +136,7 @@ export function getDayNodes(node, classNames) {
   const selector = `.${dayQuery}:not(.${outsideDayQuery})`;
   return node.querySelectorAll(selector);
 }
+
+export function nodeListToArray(nodeList) {
+  return Array.prototype.slice.call(nodeList, 0);
+}


### PR DESCRIPTION
**Bug:**
Fixes #403 

As mentioned in the issue, this library breaks in IE11 due to missing polyfills.  You could just document the polyfill requirements for this library, but since IE 11 is still [over 2% of browser usage](http://caniuse.com/usage-table) and this is a library, it'd be a good idea to remove code that's incompatible with IE11.

Unfortunately, some babel plugins also add code that's incompatible by default.  The main culprit here is the use of the spread operator to clone a NodeList to an array.  Babel uses a helper for the spread operator, and that helper uses `Array.from`.  Therefore, using the spread operator to clone an array isn't something that can be done here any more.

**Notes:**
[Babel documentation](http://babeljs.io/docs/plugins/transform-runtime/) on the plugins I'm using and dependencies I added.

**Changes:**
- Install the `object-assign` ponyfill and use it instead of `Object.assign`
- Replace all usages of the `[...dayNodes].indexOf(...)` code with something equivalent, but more IE friendly.

cc: @gpbl 