### PR TITLE
Update DayPickerInputAPI.md

### DIFF
--- a/docs/DayPickerInputAPI.md
+++ b/docs/DayPickerInputAPI.md
@@ -58,7 +58,7 @@ The object expects the following keys:
 
 ### component
 
-**Type**: `String|Function|React.Component` | **Default**: `input`
+**Type**: `String|React.Component` | **Default**: `input`
 
 The component to render the input field. 
 


### PR DESCRIPTION
Custom components must have an instance. To manage focus is used `ref` prop, but as wrote [on React documentation about refs](https://facebook.github.io/react/docs/refs-and-the-dom.html#refs-and-functional-components) in order to use `ref` you should use a Class component.
So documentation should not tell that the component can be of type `function`.