### PR TITLE
Hotfixes for v6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ This major release focuses on performance, improves accessibility and fixes some
   
   * If you are using `classNames` with the `container` prop, rename the `container` className to `wrapper`.
 
+* The container element is now an `inline-block` element.
+
 * When using `fromMonth`/`toMonth` props, navigation buttons now are rendered and hidden via CSS. Before, the buttons were not rendered at all, and it was impossible to style them ([#366](https://github.com/gpbl/react-day-picker/issues/366))
 
   This is a **breaking change** if you are using those props and styling the component using your own CSS or with the `classNames` prop. 

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -394,7 +394,9 @@ export default class DayPicker extends Component {
     if (modifiers.outside) {
       this.handleOutsideDayClick(day);
     }
-    this.props.onDayClick(day, modifiers, e);
+    if (this.props.onDayClick) {
+      this.props.onDayClick(day, modifiers, e);
+    }
   };
 
   handleOutsideDayClick(day) {

--- a/src/style.css
+++ b/src/style.css
@@ -1,6 +1,7 @@
 /* DayPicker styles */
 
 .DayPicker {
+  display: inline-block;
 }
 
 .DayPicker-wrapper {

--- a/test/daypicker/events.js
+++ b/test/daypicker/events.js
@@ -8,6 +8,12 @@ import keys from '../../src/keys';
 import { formatMonthTitle } from '../../src/LocaleUtils';
 
 describe('DayPicker’s events handlers', () => {
+  it('should not throw when onDayClick is not specified', () => {
+    const wrapper = mount(<DayPicker />);
+    expect(() => {
+      wrapper.find('.DayPicker-Day').at(10).simulate('click');
+    }).not.toThrow();
+  });
   it('should call the `onCaptionClick` handler', () => {
     const handleCaptionClick = jest.fn();
     const wrapper = mount(<DayPicker onCaptionClick={handleCaptionClick} />);


### PR DESCRIPTION
* fixed an error when clicking a day without `onDayClick` set
* make the container an `inline-block` element