### PR TITLE
Single day range + better reset behaviour

### DIFF
--- a/examples/src/examples/RangeAdvanced.js
+++ b/examples/src/examples/RangeAdvanced.js
@@ -26,7 +26,7 @@ export default class RangeAdvanced extends React.Component {
   handleDayClick = day => {
     const { from, to } = this.state;
 
-    if (DateUtils.isSameDay(day, from)) {
+    if (from && to && day >= from && day <= to) {
       this.reset();
       return;
     }


### PR DESCRIPTION
A small "fix", which I think makes the range example a bit more usable and intuitive:
- Single-day ranges can be selected
- Any click within the current range will reset the range
- Any click outside the current range will still start a new range
