### PR TITLE
Update utils-locale.md

### DIFF
--- a/docs/docs/utils-locale.md
+++ b/docs/docs/utils-locale.md
@@ -14,7 +14,7 @@ For example, this code renders the month's title as `M/YYYY` instead of the defa
 import DayPicker, { LocaleUtils } from "react-day-picker";
 
 function formatMonthTitle(d, locale) {
- return `${d.getMonth() + 1}/${d.getFullYear}`
+ return `${d.getMonth() + 1}/${d.getFullYear()}`
 }
 
 <DayPicker localeUtils={ { ...LocaleUtils, formatMonthTitle } } />


### PR DESCRIPTION
Modify the sample source.
Because, sample source fails to get the 'year'.

react-day-picker is very cool.
thanks!