### PR TITLE
Remove Day.shouldComponentUpdate

### DIFF
--- a/src/Day.js
+++ b/src/Day.js
@@ -42,19 +42,10 @@ export default class Day extends Component {
   };
 
   static defaultProps = {
-    tabIndex: -1,
-  };
-
-  static defaultProps = {
     modifiers: {},
     empty: false,
+    tabIndex: -1,
   };
-
-  shouldComponentUpdate(nextProps) {
-    const modifiers = Object.keys(this.props.modifiers).sort();
-    const nextModifiers = Object.keys(nextProps.modifiers).sort();
-    return modifiers.join() !== nextModifiers.join();
-  }
 
   render() {
     const {


### PR DESCRIPTION
**Bug:**
Fixes https://github.com/gpbl/react-day-picker/issues/446
TL;DR: The `Day.shouldComponentUpdate` function returns `false` too often and is probably unnecessary anyway.

**Changes:**
- Remove `Day.shouldComponentUpdate`
- The `<Day />` component had two `defaultProps` static properties, so I merged them.

cc: @gpbl 