### PR TITLE
Allow users to intercept and block showMonth

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -23,6 +23,7 @@ export default class DayPicker extends Component {
     numberOfMonths: PropTypes.number,
     fromMonth: PropTypes.instanceOf(Date),
     toMonth: PropTypes.instanceOf(Date),
+    shouldMonthChange: PropTypes.func,
     canChangeMonth: PropTypes.bool,
     reverseMonths: PropTypes.bool,
     pagedNavigation: PropTypes.bool,
@@ -213,8 +214,15 @@ export default class DayPicker extends Component {
     return this.props.canChangeMonth;
   }
 
-  showMonth(d, callback) {
+  showMonth(d, callback, force) {
     if (!this.allowMonth(d)) {
+      return;
+    }
+    if (
+      !force &&
+      this.props.shouldMonthChange &&
+      !this.props.shouldMonthChange(d, callback)
+    ) {
       return;
     }
     this.setState({ currentMonth: Helpers.startOfMonth(d) }, () => {

--- a/test/daypicker/methods.js
+++ b/test/daypicker/methods.js
@@ -181,12 +181,35 @@ describe('DayPicker’s methods', () => {
   describe('showMonth()', () => {
     it('should show the specified month', () => {
       const instance = shallow(
-        <DayPicker initialMonth={new Date(2015, 5, 4)} />
+        <DayPicker initialMonth={new Date(2015, 5)} />
       ).instance();
-      instance.showMonth(new Date(2016, 1, 15));
+      instance.showMonth(new Date(2016, 1));
       expect(instance.state.currentMonth.getFullYear()).toBe(2016);
       expect(instance.state.currentMonth.getMonth()).toBe(1);
-      expect(instance.state.currentMonth.getDate()).toBe(1);
+    });
+    it('should suppress showMonth if shouldMonthChange returns false', () => {
+      const shouldMonthChange = () => false;
+      const instance = shallow(
+        <DayPicker
+          initialMonth={new Date(2017, 7)}
+          shouldMonthChange={shouldMonthChange}
+        />
+      ).instance();
+      instance.showMonth(new Date(2014, 3));
+      expect(instance.state.currentMonth.getFullYear()).toBe(2017);
+      expect(instance.state.currentMonth.getMonth()).toBe(7);
+    });
+    it('should not suppress showMonth if force is true and shouldMonthChange returns false', () => {
+      const shouldMonthChange = () => false;
+      const instance = shallow(
+        <DayPicker
+          initialMonth={new Date(2017, 7)}
+          shouldMonthChange={shouldMonthChange}
+        />
+      ).instance();
+      instance.showMonth(new Date(2014, 3), undefined, true);
+      expect(instance.state.currentMonth.getFullYear()).toBe(2014);
+      expect(instance.state.currentMonth.getMonth()).toBe(3);
     });
     it('should not change month if after `toMonth`', () => {
       const instance = shallow(


### PR DESCRIPTION
I've added a new prop of type function, called `shouldMonthChange`. This function can be used to intercept and block `showMonth`. If `shouldMonthChange` returns `false`, then `showMonth` does nothing.

In addition, a third parameter `force` has been added to `showMonth` which when truthy would result in `shouldMonthChange` being ignored.

Also, the arguments passed to `showMonth` are propagated to `shouldMonthChange`, so that if it needs to, it can call `showMonth` itself.

The use case scenario that lead me to make this pull request is described in #457.