### PR TITLE
Fixed invisible text selection in website code snippets in Firefox

### DIFF
--- a/css/prism.css
+++ b/css/prism.css
@@ -30,6 +30,7 @@ pre[class*="language-"] ::-moz-selection,
 code[class*="language-"]::-moz-selection,
 code[class*="language-"] ::-moz-selection {
   text-shadow: none;
+  background: #b3d4fc;
 }
 
 pre[class*="language-"]::selection,


### PR DESCRIPTION
This fix makes the text selection visible in Firefox when selecting code inside website snippets.

Right now it is invisible because no background colour is specified for `-moz-selection`. I don't know why it is missing, in Prism.js source it is **[clearly there](https://github.com/PrismJS/prism/blob/22cb0187331d9e7239b23431178981bdcc8e1064/themes/prism.css#L30)**.
