### PR TITLE
Added `renderWeek` prop to render a custom element for week box

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -89,6 +89,7 @@ export default class DayPicker extends Component {
 
     // Custom elements
     renderDay: PropTypes.func,
+    renderWeek: PropTypes.func,
     weekdayElement: PropTypes.oneOfType([
       PropTypes.element,
       PropTypes.func,
@@ -141,6 +142,7 @@ export default class DayPicker extends Component {
     pagedNavigation: false,
     showWeekNumbers: false,
     renderDay: day => day.getDate(),
+    renderWeek: weekNumber => weekNumber,
     weekdayElement: <Weekday />,
     navbarElement: <Navbar classNames={classNames} />,
     captionElement: <Caption classNames={classNames} />,

--- a/src/Month.js
+++ b/src/Month.js
@@ -27,6 +27,7 @@ export default class Month extends Component {
     enableOutsideDays: PropTypes.bool,
 
     renderDay: PropTypes.func.isRequired,
+    renderWeek: PropTypes.func.isRequired,
 
     captionElement: PropTypes.oneOfType([
       PropTypes.element,
@@ -190,7 +191,7 @@ export default class Month extends Component {
                     role="gridcell"
                     onClick={e => onWeekClick(weekNumber, week, e)}
                   >
-                    {weekNumber}
+                    {this.props.renderWeek(weekNumber, week)}
                   </div>
                 )}
                 {week.map(this.renderDay)}


### PR DESCRIPTION
I needed a way to render a custom element for week boxes on the left.
Following the `renderDay` implementation I created a `renderWeek` prop.
It defaults to the current behavior, rendering the weekNumber.