### PR TITLE
Add React 16 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "homepage": "https://react-day-picker.js.org",
   "peerDependencies": {
-    "react": "~0.13.x || ~0.14.x || ^15.0.0"
+    "react": "~0.13.x || ~0.14.x || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "@types/react": "15.0.30",


### PR DESCRIPTION
I didn't see an open issue/PR regarding React 16. All the tests passed and I didn't see any errors when using react-day-picker with React 16 in my app. 