### PR TITLE
Feature/fix day picker type

### DIFF
--- a/types/DayPicker.d.ts
+++ b/types/DayPicker.d.ts
@@ -6,6 +6,7 @@ import { ClassNames, DayModifiers, Modifier, Modifiers } from "./common";
 import { CaptionElementProps, NavbarElementProps, WeekdayElementProps, DayPickerProps } from "./props";
 
 export class DayPicker extends React.Component<DayPickerProps, any> {
+  static dayPicker: HTMLDivElement;
   static VERSION: string;
   static LocaleUtils: LocaleUtils;
   static DateUtils: DateUtils;

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -43,7 +43,7 @@ export interface DayPickerProps {
     | React.SFC<CaptionElementProps>;
   className?: string;
   classNames?: ClassNames;
-  containerProps?: React.HTMLAttributes<HTMLDivElement>;
+  containerProps?: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>,HTMLDivElement>;
   disabledDays?: Modifier | Modifier[];
   enableOutsideDays?: boolean;
   firstDayOfWeek?: number;

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -43,7 +43,7 @@ export interface DayPickerProps {
     | React.SFC<CaptionElementProps>;
   className?: string;
   classNames?: ClassNames;
-  containerProps?: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>,HTMLDivElement>;
+  containerProps?: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
   disabledDays?: Modifier | Modifier[];
   enableOutsideDays?: boolean;
   firstDayOfWeek?: number;


### PR DESCRIPTION
Added dayPicker to generic DayPicker instance types so you can do this.dayPicker without getting 'undefined / any type' typescript error message