### PR TITLE
Updated display style property for .DayPicker-Footer

### DIFF
--- a/lib/style.css
+++ b/lib/style.css
@@ -123,7 +123,7 @@
 }
 
 .DayPicker-Footer {
-  display: table-caption;
+  display: table-footer-group;
   caption-side: bottom;
   padding-top: .5rem;
 }


### PR DESCRIPTION
The today button isn't showing up for me and I was able to track the problem down to said line in the stylesheet. 

On another page: It would be useful to be able to switch between the today button behaving like a footer and a (working) caption.