### PR TITLE
Fixed lost input focus

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -107,6 +107,7 @@ export default class DayPickerInput extends React.Component {
   componentWillUnmount() {
     clearTimeout(this.clickTimeout);
     clearTimeout(this.hideTimeout);
+    clearTimeout(this.blurTimeout);
   }
 
   input = null;
@@ -180,7 +181,9 @@ export default class DayPickerInput extends React.Component {
     // Force input's focus if blur event was caused
     // by clicking inside the overlay
     if (this.clickedInside) {
-      this.input.focus();
+      this.blurTimeout = setTimeout(() => {
+        this.input.focus();
+      }, 0);
     }
 
     if (this.props.onBlur) {


### PR DESCRIPTION
### Issue:
1. Open Firefox (its not an issue in chrome) https://codesandbox.io/s/XDAE3x0W8
2. Click on day picker input (it shows calendar)
3. Click on navigation bar element (next, prev or nav title elements)
4. Main day picker input loses own focus and calendar stays open
5. Now when you click anywhere outside of calendar. Calendar is still open but is should close.

### Solution:
Looks like the problem in FF is just timing of `this.input.focus(); ` call. This fix is solving the issue.





