### PR TITLE
Add modifiers back to type

### DIFF
--- a/types/DayPicker.d.ts
+++ b/types/DayPicker.d.ts
@@ -11,6 +11,8 @@ export class DayPicker extends React.Component<DayPickerProps, any> {
   static LocaleUtils: LocaleUtils;
   static DateUtils: DateUtils;
   static ModifiersUtils: ModifiersUtils;
+  static DayModifiers: DayModifiers;
+  static Modifiers: Modifiers;
   showMonth(month: Date): void;
   showPreviousMonth(): void;
   showNextMonth(): void;


### PR DESCRIPTION
According to this issue https://github.com/gpbl/react-day-picker/issues/524, adding the DayModifiers and Modifiers back to type file.