### PR TITLE
Don't overrides DayPickerInput selectedDays prop

### DIFF
--- a/test/daypickerinput/events.js
+++ b/test/daypickerinput/events.js
@@ -265,6 +265,26 @@ describe('DayPickerInput', () => {
         expect(wrapper.find('input')).toHaveProp('value', '');
         expect(wrapper.find('.DayPicker-Day--selected')).toHaveLength(0);
       });
+      it('should unselect the clicked day if already selected', () => {
+        const wrapper = mount(
+          <DayPickerInput
+            value="02/08/2017"
+            clickUnselectsDay
+            dayPickerProps={{
+              month: new Date(2017, 1),
+              selectedDays: [new Date(2017, 1, 8), new Date(2017, 1, 9)],
+            }}
+          />
+        );
+        wrapper.instance().showDayPicker();
+        wrapper.update();
+        wrapper
+          .find('.DayPicker-Day')
+          .at(10)
+          .simulate('click');
+        expect(wrapper.find('input')).toHaveProp('value', '');
+        expect(wrapper.find('.DayPicker-Day--selected')).toHaveLength(1);
+      });
       it('should call `onDayChange` when clicking a selected day', () => {
         const onDayChange = jest.fn();
         const wrapper = mount(
@@ -310,7 +330,6 @@ describe('DayPickerInput', () => {
           .simulate('click');
         expect(onDayChange).not.toHaveBeenCalled();
       });
-
       it('should use `dayPickerProps.selectedDays` after clicking a day', () => {
         const wrapper = mount(
           <DayPickerInput
@@ -331,7 +350,6 @@ describe('DayPickerInput', () => {
         expect(selectedDays.at(0)).toHaveText('8');
         expect(selectedDays.at(1)).toHaveText('9');
       });
-
       it('should use `dayPickerProps.selectedDays` after typing a valid day', () => {
         const wrapper = mount(
           <DayPickerInput

--- a/test/daypickerinput/events.js
+++ b/test/daypickerinput/events.js
@@ -310,6 +310,47 @@ describe('DayPickerInput', () => {
           .simulate('click');
         expect(onDayChange).not.toHaveBeenCalled();
       });
+
+      it('should use `dayPickerProps.selectedDays` after clicking a day', () => {
+        const wrapper = mount(
+          <DayPickerInput
+            dayPickerProps={{
+              month: new Date(2017, 1),
+              selectedDays: [new Date(2017, 1, 8), new Date(2017, 1, 9)],
+            }}
+          />
+        );
+        wrapper.instance().showDayPicker();
+        wrapper.update();
+        wrapper
+          .find('.DayPicker-Day')
+          .at(9)
+          .simulate('click');
+        const selectedDays = wrapper.find('.DayPicker-Day--selected');
+        expect(selectedDays).toHaveLength(2);
+        expect(selectedDays.at(0)).toHaveText('8');
+        expect(selectedDays.at(1)).toHaveText('9');
+      });
+
+      it('should use `dayPickerProps.selectedDays` after typing a valid day', () => {
+        const wrapper = mount(
+          <DayPickerInput
+            dayPickerProps={{
+              month: new Date(2017, 1),
+              selectedDays: [new Date(2017, 1, 8), new Date(2017, 1, 9)],
+            }}
+          />
+        );
+        wrapper.instance().showDayPicker();
+        wrapper.update();
+        wrapper
+          .find('input')
+          .simulate('change', { target: { value: '02/07/2017' } });
+        const selectedDays = wrapper.find('.DayPicker-Day--selected');
+        expect(selectedDays).toHaveLength(2);
+        expect(selectedDays.at(0)).toHaveText('8');
+        expect(selectedDays.at(1)).toHaveText('9');
+      });
     });
   });
 });

--- a/test/daypickerinput/rendering.js
+++ b/test/daypickerinput/rendering.js
@@ -174,21 +174,5 @@ describe('DayPickerInput', () => {
       expect(spy).toHaveBeenCalledTimes(3);
       spy.mockRestore();
     });
-
-    it('should use `selectedDays` from DayPickerInput props', () => {
-      const wrapper = mount(
-        <DayPickerInput
-          selectedDays={new Date(2017, 1, 8)}
-          dayPickerProps={{
-            month: new Date(2017, 1),
-            selectedDays: new Date(2017, 1, 9),
-          }}
-        />
-      );
-      wrapper.instance().showDayPicker();
-      wrapper.update();
-      expect(wrapper.find('.DayPicker-Day--selected')).toHaveLength(1);
-      expect(wrapper.find('.DayPicker-Day--selected').at(0)).toHaveText('8');
-    });
   });
 });

--- a/test/daypickerinput/rendering.js
+++ b/test/daypickerinput/rendering.js
@@ -174,5 +174,21 @@ describe('DayPickerInput', () => {
       expect(spy).toHaveBeenCalledTimes(3);
       spy.mockRestore();
     });
+
+    it('should use `selectedDays` from DayPickerInput props', () => {
+      const wrapper = mount(
+        <DayPickerInput
+          selectedDays={new Date(2017, 1, 8)}
+          dayPickerProps={{
+            month: new Date(2017, 1),
+            selectedDays: new Date(2017, 1, 9),
+          }}
+        />
+      );
+      wrapper.instance().showDayPicker();
+      wrapper.update();
+      expect(wrapper.find('.DayPicker-Day--selected')).toHaveLength(1);
+      expect(wrapper.find('.DayPicker-Day--selected').at(0)).toHaveText('8');
+    });
   });
 });


### PR DESCRIPTION
This PR for #521. `dayPickerProps` moved after `selectedDays` so DayPickerInput's `selectedDays` won't be overridden.