### PR TITLE
install guide added to repo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@
   </a>
 </p>
 
+## Run the website locally
+
+The website is built with [Jekyll](https://jekyllrb.com).
+
+```bash
+$ git clone https://github.com/gpbl/react-day-picker.git
+$ cd react-day-picker/docs
+$ bundle install
+$ jekyll serve
+```
+
 ## Get support
 
 Please fork and use [https://codesandbox.io/s/XDAE3x0W8](https://codesandbox.io/s/XDAE3x0W8) to reproduce your problem.


### PR DESCRIPTION
I was looking to troubleshoot the application on local dev server and I was not able to locate install guide in the main README file. Only when I opened docs directory, I was able to locate install guide. I suggest that install guide should be placed in main README file of the repository.