### PR TITLE
(fix typing) typescript default export

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,4 +3,4 @@
 import { DayPicker } from "./DayPicker";
 // We need to use 'export =' to be compatible with the 'module.exports = DayPicker.default || DayPicker' syntax
 // in DayPicker.js in the final NPM package.
-export = DayPicker;
+export default DayPicker;


### PR DESCRIPTION
This PR fixes typescript default import.
For more details see issue https://github.com/gpbl/react-day-picker/issues/533

regards
Tristan