### PR TITLE
Revert "(fix typing) typescript default export"

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,4 +3,4 @@
 import { DayPicker } from "./DayPicker";
 // We need to use 'export =' to be compatible with the 'module.exports = DayPicker.default || DayPicker' syntax
 // in DayPicker.js in the final NPM package.
-export default DayPicker;
+export = DayPicker;


### PR DESCRIPTION
Reverts gpbl/react-day-picker#539

This is a breaking change for typescript consumers.