### PR TITLE
Typescript Types Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint": "eslint src test",
     "dtslint": "dtslint types",
     "test": "jest",
+    "test:types": "tsc --noEmit types/test/*",
     "check": "npm run lint && npm run dtslint && npm run test",
     "prerelease": "npm run check && npm run build",
     "build": "rimraf lib && npm run build:node && npm run build:production && npm run build:development",
@@ -56,6 +57,7 @@
     "react": "~0.13.x || ~0.14.x || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
+    "@types/react": "^15.6.6",
     "autoprefixer": "7.1.5",
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",
@@ -95,7 +97,7 @@
     "react-dom": "16.0.0",
     "react-test-renderer": "16.0.0",
     "rimraf": "2.6.2",
-    "typescript": "2.5.3",
+    "typescript": "^2.6.1",
     "webpack": "3.7.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint src test",
     "dtslint": "dtslint types",
     "test": "jest",
-    "test:types": "tsc --noEmit types/test/*",
+    "test:types": "tsc -p types/tsconfig.json",
     "check": "npm run lint && npm run dtslint && npm run test",
     "prerelease": "npm run check && npm run build",
     "build": "rimraf lib && npm run build:node && npm run build:production && npm run build:development",

--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
   },
   "homepage": "https://react-day-picker.js.org",
   "peerDependencies": {
-    "react": "~0.13.x || ~0.14.x || ^15.0.0 || ^16.0.0"
+    "react": "~0.13.x || ~0.14.x || ^15.0.0 || ^16.0.0",
+    "@types/react": "^15.6.6"
   },
   "devDependencies": {
-    "@types/react": "^15.6.6",
     "autoprefixer": "7.1.5",
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",

--- a/types/test/DayPickerComponentTest.tsx
+++ b/types/test/DayPickerComponentTest.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import DayPicker from '../';
+import Picker from '../index';
+import { DayPicker } from '../index';
 import 'react-day-picker/lib/style.css';
 
 interface Props {
@@ -7,7 +8,7 @@ interface Props {
   onCalendarSelect: (date: Date) => void;
 }
 
-export default class TestTypingsComponent extends React.Component<Props, any> {
+export default class DayPickerComponentTest extends React.Component<Props, any> {
   render() {
     return (
       <DayPicker selectedDays={this.props.selected} onDayClick={this.props.onCalendarSelect} />

--- a/types/test/DayPickerComponentTest.tsx
+++ b/types/test/DayPickerComponentTest.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import Picker from '../index';
-import { DayPicker } from '../index';
-import 'react-day-picker/lib/style.css';
+import { default as Picker , DayPicker } from '../';
 
 interface Props {
   selected: Date;

--- a/types/test/TestTypingsComponent.tsx
+++ b/types/test/TestTypingsComponent.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import DayPicker from '../';
+import 'react-day-picker/lib/style.css';
+
+interface Props {
+  selected: Date;
+  onCalendarSelect: (date: Date) => void;
+}
+
+export default class TestTypingsComponent extends React.Component<Props, any> {
+  render() {
+    return (
+      <DayPicker selectedDays={this.props.selected} onDayClick={this.props.onCalendarSelect} />
+    );
+  }
+}

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "jsx": "react",
     "lib": [
       "es6",
       "dom"
@@ -12,6 +13,7 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": [
-    "./*.d.ts"
+    "./*.d.ts",
+    "./test/TestTypingsComponent.tsx"
   ]
 }

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -14,6 +14,6 @@
   },
   "include": [
     "./*.d.ts",
-    "./test/TestTypingsComponent.tsx"
+    "./test/*"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,6 +6,10 @@
   version "6.0.88"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.88.tgz#f618f11a944f6a18d92b5c472028728a3e3d4b66"
 
+"@types/react@^15.6.6":
+  version "15.6.6"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.6.6.tgz#21c93d921d63e5c8478ad54b917f52c9abd547e2"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -5016,9 +5020,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@2.5.3:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
+typescript@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
 
 ua-parser-js@^0.7.9:
   version "0.7.14"


### PR DESCRIPTION
This PR adds Typescript types tests,
you can simply run them by running 
```javascript
yarn test:types
```
or 
```javascript
npm run test:types.
```

currently the test shows that neither **Default** or **Named Export** is working.
as i showed here: https://github.com/gpbl/react-day-picker/issues/533

Currently the Test is failing:

```bash
firsttris@ThinkpadE470 react-day-picker]$ yarn test:types
yarn run v1.3.2
$ tsc -p types/tsconfig.json
types/test/DayPickerComponentTest.tsx(2,8): error TS1192: Module '"/home/firsttris/Projects/react-day-picker/types/index"' has no default export.
types/test/DayPickerComponentTest.tsx(3,10): error TS2305: Module '"/home/firsttris/Projects/react-day-picker/types/index"' has no exported member 'DayPicker'.
types/test/DayPickerComponentTest.tsx(3,27): error TS2497: Module '"/home/firsttris/Projects/react-day-picker/types/index"' resolves to a non-module entity and cannot be imported using this construct.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
[firsttris@ThinkpadE470 react-day-picker]$
```
