### PR TITLE
add month parameter to renderWeek

### DIFF
--- a/src/Month.js
+++ b/src/Month.js
@@ -194,7 +194,7 @@ export default class Month extends Component {
                     onKeyUp={e =>
                       e.keyCode === ENTER && onWeekClick(weekNumber, week, e)}
                   >
-                    {this.props.renderWeek(weekNumber, week)}
+                    {this.props.renderWeek(weekNumber, week, month)}
                   </div>
                 )}
                 {week.map(this.renderDay)}


### PR DESCRIPTION
In addition to the pull request #497 I require an additional parameter to distinguish weeks outside of the current month (enableOutsideDays & fixedWeeks set to true) and handle those weeks differently.
