### PR TITLE
Fixed render of months when toMonth and numberOfMonth are passed

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -173,6 +173,14 @@ export default class DayPicker extends Component {
         props.fromMonth,
         Math.floor(diffInMonths / props.numberOfMonths) * props.numberOfMonths
       );
+    } else if (props.toMonth && props.numberOfMonths > 1) {
+      const diffInMonths = Helpers.getMonthsDiff(props.toMonth, currentMonth);
+      if (diffInMonths <= 0) {
+        currentMonth = DateUtils.addMonths(
+          props.toMonth,
+          1 - this.props.numberOfMonths
+        );
+      }
     }
     return { currentMonth };
   };

--- a/test/daypicker/navigation.js
+++ b/test/daypicker/navigation.js
@@ -235,6 +235,18 @@ describe('DayPicker’s navigation', () => {
     expect(instance.state.currentMonth.getMonth()).toBe(5);
     expect(instance.state.currentMonth.getDate()).toBe(1);
   });
+  it('should set the currentMonth to the first rendered month if toMonth equals current month', () => {
+    const instance = shallow(
+      <DayPicker
+        initialMonth={new Date(2015, 7)}
+        toMonth={new Date(2015, 7)}
+        numberOfMonths={3}
+      />
+    ).instance();
+    expect(instance.state.currentMonth.getFullYear()).toBe(2015);
+    expect(instance.state.currentMonth.getMonth()).toBe(5);
+    expect(instance.state.currentMonth.getDate()).toBe(1);
+  });
 
   describe('with custom classNames', () => {
     const getDaysInMonth = wrapper =>


### PR DESCRIPTION
This PR for #543. In case when `toMonth` and `numberOfMonth` are passed to `DayPicker` and `toMonth` earlier or equals  `currentMonth` moves `currentMonth` so `toMonth` rendered last.