### PR TITLE
Fix typo on selected-range-enter.js example file

### DIFF
--- a/docs/src/code-samples/examples/selected-range-enter.js
+++ b/docs/src/code-samples/examples/selected-range-enter.js
@@ -21,9 +21,9 @@ export default class Example extends React.Component {
     };
   }
   isSelectingFirstDay(from, to, day) {
-    const isBeforeFirtDay = from && DateUtils.isDayBefore(day, from);
+    const isBeforeFirstDay = from && DateUtils.isDayBefore(day, from);
     const isRangeSelected = from && to;
-    return !from || isBeforeFirtDay || isRangeSelected;
+    return !from || isBeforeFirstDay || isRangeSelected;
   }
   handleDayClick(day) {
     const { from, to } = this.state;


### PR DESCRIPTION
Just fixed a minor typo on an example file.