### PR TITLE
include renderMonths typing

### DIFF
--- a/types/DayPicker.d.ts
+++ b/types/DayPicker.d.ts
@@ -10,7 +10,7 @@ import {
   DayPickerProps,
 } from './props';
 
-export default class DayPicker extends React.Component<DayPickerProps, any> {
+export default class DayPicker<T> extends React.Component<DayPickerProps, any> {
   static dayPicker: HTMLDivElement;
   static VERSION: string;
   static LocaleUtils: LocaleUtils;

--- a/types/DayPicker.d.ts
+++ b/types/DayPicker.d.ts
@@ -23,4 +23,5 @@ export default class DayPicker extends React.Component<DayPickerProps, any> {
   showNextMonth(): void;
   showPreviousYear(): void;
   showNextYear(): void;
+  renderMonths(): React.ReactElement<any> | null;
 }

--- a/types/DayPickerInput.d.ts
+++ b/types/DayPickerInput.d.ts
@@ -8,6 +8,6 @@ import DayPicker from './DayPicker';
 export class DayPickerInput extends React.Component<DayPickerInputProps, any> {
   showDayPicker(): void;
   hideDayPicker(): void;
-  getDayPicker(): DayPicker;
+  getDayPicker(): DayPicker<{}>;
   getInput(): any;
 }


### PR DESCRIPTION
Hey, we're using your awesome library along with TypeScript, but we were missing a typing for renderMonths function/method/whatever. Looking forward to your response. :v: