### PR TITLE
Add possibility to disable roll to prev/next month if outside day is clicked

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -66,7 +66,7 @@ export default class DayPicker extends Component {
 
     // Customization
     showOutsideDays: PropTypes.bool,
-    rollOnOutsideDays: PropTypes.bool,
+    enableOutsideDaysClick: PropTypes.bool,
     fixedWeeks: PropTypes.bool,
 
     // CSS and HTML
@@ -141,7 +141,7 @@ export default class DayPicker extends Component {
     locale: 'en',
     localeUtils: LocaleUtils,
     showOutsideDays: false,
-    rollOnOutsideDays: true,
+    enableOutsideDaysClick: true,
     fixedWeeks: false,
     canChangeMonth: true,
     reverseMonths: false,
@@ -422,7 +422,7 @@ export default class DayPicker extends Component {
     e.persist();
     if (
       modifiers[this.props.classNames.outside] &&
-      this.props.rollOnOutsideDays
+      this.props.enableOutsideDaysClick
     ) {
       this.handleOutsideDayClick(day);
     }

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -66,6 +66,7 @@ export default class DayPicker extends Component {
 
     // Customization
     showOutsideDays: PropTypes.bool,
+    rollOnOutsideDays: PropTypes.bool,
     fixedWeeks: PropTypes.bool,
 
     // CSS and HTML
@@ -140,6 +141,7 @@ export default class DayPicker extends Component {
     locale: 'en',
     localeUtils: LocaleUtils,
     showOutsideDays: false,
+    rollOnOutsideDays: true,
     fixedWeeks: false,
     canChangeMonth: true,
     reverseMonths: false,
@@ -418,7 +420,10 @@ export default class DayPicker extends Component {
 
   handleDayClick = (day, modifiers, e) => {
     e.persist();
-    if (modifiers[this.props.classNames.outside]) {
+    if (
+      modifiers[this.props.classNames.outside] &&
+      this.props.rollOnOutsideDays
+    ) {
       this.handleOutsideDayClick(day);
     }
     if (this.props.onDayClick) {

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -50,6 +50,7 @@ export interface DayPickerProps {
   >;
   disabledDays?: Modifier | Modifier[];
   showOutsideDays?: boolean;
+  rollOnOutsideDays?: boolean;
   firstDayOfWeek?: number;
   fixedWeeks?: boolean;
   fromMonth?: Date;

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -50,7 +50,7 @@ export interface DayPickerProps {
   >;
   disabledDays?: Modifier | Modifier[];
   showOutsideDays?: boolean;
-  rollOnOutsideDays?: boolean;
+  enableOutsideDaysClick?: boolean;
   firstDayOfWeek?: number;
   fixedWeeks?: boolean;
   fromMonth?: Date;


### PR DESCRIPTION
Some of my users have difficulties to understand the outside click feature.
If only one month is visible it seems to be ok, but if more then one month is rendered they find it confusing.

Thus I would like to disable this feature. 
With new property name I'm unhappy, but can't come up with a more precise phrase.