### PR TITLE
Set moment in strict mode

### DIFF
--- a/src/addons/MomentLocaleUtils.js
+++ b/src/addons/MomentLocaleUtils.js
@@ -53,7 +53,7 @@ export function formatDate(date, format = 'L', locale = 'en') {
 }
 
 export function parseDate(str, format = 'L', locale = 'en') {
-  const m = moment(str, format, locale);
+  const m = moment(str, format, locale, true);
   if (m.isValid()) {
     return m.toDate();
   }

--- a/test/addons/MomentLocaleUtils.js
+++ b/test/addons/MomentLocaleUtils.js
@@ -101,5 +101,9 @@ describe('MomentLocaleUtils', () => {
       const parsed = MomentLocaleUtils.parseDate('20 foo 2018', 'LL', 'it');
       expect(parsed).toBeUndefined();
     });
+    it('returns undefined if date does not match the format', () => {
+      const parsed = MomentLocaleUtils.parseDate('20/11/201', 'DD/MM/YYYY');
+      expect(parsed).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
This will cause moment to return `undefined` when parsing a date that doesn't match the format.

 `parseDate` value will not override the input value if it doesn't match the format provided.

For: #584
