### PR TITLE
Use dayPickerProps controlled month before value.

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -179,9 +179,6 @@ export default class DayPickerInput extends React.Component {
       } else {
         day = props.parseDate(props.value, format, dayPickerProps.locale);
       }
-      if (day) {
-        month = day;
-      }
     }
 
     // Use DayPicker's controlled month. Then try the current `value`. Finally default to today.

--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -182,8 +182,9 @@ export default class DayPickerInput extends React.Component {
     }
 
     // Use DayPicker's controlled month. Then try the current `value`. Finally default to today.
-    const month = dayPickerProps.initialMonth || dayPickerProps.month || day || new Date();
-    
+    const month =
+      dayPickerProps.initialMonth || dayPickerProps.month || day || new Date();
+
     return {
       value,
       month,

--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -170,7 +170,7 @@ export default class DayPickerInput extends React.Component {
   getStateFromProps(props) {
     const { dayPickerProps, formatDate, format } = props;
     let { value } = props;
-    let month;
+
     let day;
     if (props.value) {
       if (isDate(props.value)) {
@@ -182,10 +182,11 @@ export default class DayPickerInput extends React.Component {
       if (day) {
         month = day;
       }
-    } else {
-      // Otherwise display the month coming from `dayPickerProps` or the current month
-      month = dayPickerProps.initialMonth || dayPickerProps.month || new Date();
     }
+
+    // Use DayPicker's controlled month. Then try the current `value`. Finally default to today.
+    const month = dayPickerProps.initialMonth || dayPickerProps.month || day || new Date();
+    
     return {
       value,
       month,

--- a/test/daypickerinput/events.js
+++ b/test/daypickerinput/events.js
@@ -251,7 +251,7 @@ describe('DayPickerInput', () => {
             value="2017-11-8"
             clickUnselectsDay
             dayPickerProps={{
-              month: new Date(2017, 1),
+              month: new Date(2017, 10),
               selectedDays: new Date(2017, 10, 8),
             }}
           />
@@ -271,7 +271,7 @@ describe('DayPickerInput', () => {
             value="2017-11-8"
             clickUnselectsDay
             dayPickerProps={{
-              month: new Date(2017, 1),
+              month: new Date(2017, 10),
               selectedDays: [new Date(2017, 10, 8), new Date(2017, 10, 7)],
             }}
           />

--- a/test/daypickerinput/rendering.js
+++ b/test/daypickerinput/rendering.js
@@ -145,7 +145,7 @@ describe('DayPickerInput', () => {
     it("should update the displayed month when `dayPickerProps.month`'s month is updated", () => {
       const wrapper = mount(
         <DayPickerInput
-          dayPickerProps={{ month: new Date(2017, 9) }}
+          dayPickerProps={{ month: new Date(2017, 11) }}
           value="2017-12-15"
         />
       );
@@ -163,7 +163,7 @@ describe('DayPickerInput', () => {
     it("should update the displayed month when `dayPickerProps.month`'s year is updated", () => {
       const wrapper = mount(
         <DayPickerInput
-          dayPickerProps={{ month: new Date(2018, 10) }}
+          dayPickerProps={{ month: new Date(2017, 11) }}
           value="2017-12-15"
         />
       );


### PR DESCRIPTION
Hello @gpbl !

First thank you for your time commitment to this project, it is very useful!

This change is a re-ordering of how the current month is calculated from props. I believe it should use the controlled month from `dayPickerProps.month` before it uses the current `value`.

My specific use case is a 4-month calendar using the DayPickerInput date range selection with a from/to input. In my case I want the first month in the 4 month range to show the start of the range but it will default to using the current value. Which on the `to` DayPickerInput will possibly be a different month.

Otherwise I don't think there is a way to use `DayPickerInput` as a controlled component (w/ redux-form for us) and control the month through props.

Let me know if there is anything else I can provide to make this easier!