### PR TITLE
Replace env with production to fix umd crashing in runtime

### DIFF
--- a/DayPicker.dist.js
+++ b/DayPicker.dist.js
@@ -5,7 +5,6 @@
 /* eslint-disable no-var */
 /* eslint-env node */
 
-var DayPicker = require('./src/DayPicker').default;
-DayPicker.Input = require('./src/DayPickerInput').default;
+var DayPicker = require('./src').default;
 
 module.exports = DayPicker;

--- a/DayPicker.js
+++ b/DayPicker.js
@@ -5,18 +5,12 @@
 /* eslint-disable no-var */
 /* eslint-env node */
 
-var DayPicker = require('./lib/src/DayPicker');
-var DateUtils = require('./lib/src/DateUtils');
-var LocaleUtils = require('./lib/src/LocaleUtils');
-var ModifiersUtils = require('./lib/src/ModifiersUtils');
+var DayPicker = require('./lib/src');
 var Weekday = require('./lib/src/Weekday');
 var Navbar = require('./lib/src/Navbar');
 var PropTypes = require('./lib/src/PropTypes');
 
 module.exports = DayPicker;
-module.exports.DateUtils = DateUtils;
-module.exports.LocaleUtils = LocaleUtils;
-module.exports.ModifiersUtils = ModifiersUtils;
 module.exports.WeekdayPropTypes = Weekday.propTypes;
 module.exports.NavbarPropTypes = Navbar.propTypes;
 module.exports.PropTypes = PropTypes;

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -569,7 +569,3 @@ export default class DayPicker extends Component {
     );
   }
 }
-
-DayPicker.DateUtils = DateUtils;
-DayPicker.LocaleUtils = LocaleUtils;
-DayPicker.ModifiersUtils = ModifiersUtils;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,12 @@
-export default from './DayPicker';
-export DateUtils from './DateUtils';
-export LocaleUtils from './LocaleUtils';
-export ModifiersUtils from './ModifiersUtils';
+import DayPicker from './DayPicker';
+import Input from './DayPickerInput';
+import * as DateUtils from './DateUtils';
+import * as LocaleUtils from './LocaleUtils';
+import * as ModifiersUtils from './ModifiersUtils';
+
+DayPicker.Input = Input;
+DayPicker.DateUtils = DateUtils;
+DayPicker.LocaleUtils = LocaleUtils;
+DayPicker.ModifiersUtils = ModifiersUtils;
+
+export default DayPicker;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,8 @@
 /* eslint global-require: 0, import/no-extraneous-dependencies: 0 */
 /* eslint-env node */
 
+const webpack = require('webpack');
+
 const isProduction = process.env.NODE_ENV === 'production';
 
 module.exports = {
@@ -29,6 +31,11 @@ module.exports = {
       },
     ],
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify('production')
+    })
+  ],
   externals: {
     react: {
       root: 'React',


### PR DESCRIPTION
Ref #632 

Currently umd bundle just doesn't work.

- added `Input` component everywhere
- replace `process.env.NODE_ENV` with production to prevent crashing in umd bundle because prop types package does not exists.
- simplified all entry points in favor of src/index.js

I think this can be published as minor.

before
  daypicker.js 102.1K
  daypicker.min.js 39.27K

after
  daypicker.js 95.68K
  daypicker.min.js 39.27K
