### PR TITLE
Fixed 'any' type on onDayChange second argument

### DIFF
--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -174,7 +174,7 @@ export interface DayPickerInputProps {
 
   classNames?: ClassNames;
 
-  onDayChange?(day: Date, DayModifiers): void;
+  onDayChange?(day: Date, DayModifiers: DayModifiers): void;
   onChange?(e: React.FocusEvent<HTMLDivElement>): void;
   onClick?(e: React.FocusEvent<HTMLDivElement>): void;
   onFocus?(e: React.FocusEvent<HTMLDivElement>): void;


### PR DESCRIPTION
Fixed error TS7006: Parameter 'DayModifiers' implicitly has an 'any' type.