### PR TITLE
Roles prop

### DIFF
--- a/src/Caption.js
+++ b/src/Caption.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import LocaleUtils from './LocaleUtils';
 
 import { ENTER } from './keys';
-import { RoleTypesShape } from './DayPicker';
+import { RoleTypesShape, defaultRoles } from './DayPicker';
 
 export default class Caption extends Component {
   static propTypes = {
@@ -21,6 +21,7 @@ export default class Caption extends Component {
 
   static defaultProps = {
     localeUtils: LocaleUtils,
+    roles: defaultRoles,
   };
 
   constructor(props) {

--- a/src/Caption.js
+++ b/src/Caption.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import LocaleUtils from './LocaleUtils';
 
 import { ENTER } from './keys';
+import { RoleTypesShape } from './DayPicker';
 
 export default class Caption extends Component {
   static propTypes = {
@@ -15,6 +16,7 @@ export default class Caption extends Component {
     classNames: PropTypes.shape({
       caption: PropTypes.string.isRequired,
     }).isRequired,
+    roles: PropTypes.shape(RoleTypesShape),
   };
 
   static defaultProps = {
@@ -49,9 +51,10 @@ export default class Caption extends Component {
       locale,
       localeUtils,
       onClick,
+      roles,
     } = this.props;
     return (
-      <div className={classNames.caption} role="heading">
+      <div className={classNames.caption} role={roles.caption}>
         <div onClick={onClick} onKeyUp={this.handleKeyUp}>
           {months
             ? `${months[date.getMonth()]} ${date.getFullYear()}`

--- a/src/Caption.js
+++ b/src/Caption.js
@@ -21,6 +21,7 @@ export default class Caption extends Component {
 
   static defaultProps = {
     localeUtils: LocaleUtils,
+    roles: defaultRoles,
   };
 
   constructor(props) {
@@ -51,7 +52,7 @@ export default class Caption extends Component {
       locale,
       localeUtils,
       onClick,
-      roles = defaultRoles,
+      roles,
     } = this.props;
     return (
       <div className={classNames.caption} role={roles.caption}>

--- a/src/Caption.js
+++ b/src/Caption.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import LocaleUtils from './LocaleUtils';
 
 import { ENTER } from './keys';
-import { RoleTypesShape, defaultRoles } from './DayPicker';
+import { RoleTypesShape, defaultRoles } from './PropTypes';
 
 export default class Caption extends Component {
   static propTypes = {
@@ -21,7 +21,6 @@ export default class Caption extends Component {
 
   static defaultProps = {
     localeUtils: LocaleUtils,
-    roles: defaultRoles,
   };
 
   constructor(props) {
@@ -52,7 +51,7 @@ export default class Caption extends Component {
       locale,
       localeUtils,
       onClick,
-      roles,
+      roles = defaultRoles,
     } = this.props;
     return (
       <div className={classNames.caption} role={roles.caption}>

--- a/src/Day.js
+++ b/src/Day.js
@@ -6,6 +6,7 @@ import { isSameDay } from './DateUtils';
 import { hasOwnProp } from './Helpers';
 
 import defaultClassNames from './classNames';
+import { RoleTypesShape } from './DayPicker';
 
 function handleEvent(handler, day, modifiers) {
   if (!handler) {
@@ -42,6 +43,7 @@ export default class Day extends Component {
     onTouchStart: PropTypes.func,
     onFocus: PropTypes.func,
     tabIndex: PropTypes.number,
+    roles: PropTypes.shape(RoleTypesShape),
   };
 
   static defaultProps = {
@@ -106,6 +108,7 @@ export default class Day extends Component {
       ariaLabel,
       ariaDisabled,
       ariaSelected,
+      roles,
       children,
     } = this.props;
 
@@ -136,7 +139,8 @@ export default class Day extends Component {
         className={className}
         tabIndex={tabIndex}
         style={style}
-        role="gridcell"
+        role={ariaDisabled ? roles.disabledDay : roles.day}
+        aria-hidden={!!ariaDisabled}
         aria-label={ariaLabel}
         aria-disabled={ariaDisabled}
         aria-selected={ariaSelected}

--- a/src/Day.js
+++ b/src/Day.js
@@ -48,12 +48,10 @@ export default class Day extends Component {
 
   static defaultProps = {
     tabIndex: -1,
-  };
-
-  static defaultProps = {
     modifiers: {},
     modifiersStyles: {},
     empty: false,
+    roles: defaultRoles,
   };
 
   shouldComponentUpdate(nextProps) {
@@ -108,7 +106,7 @@ export default class Day extends Component {
       ariaLabel,
       ariaDisabled,
       ariaSelected,
-      roles = defaultRoles,
+      roles,
       children,
     } = this.props;
 

--- a/src/Day.js
+++ b/src/Day.js
@@ -6,7 +6,7 @@ import { isSameDay } from './DateUtils';
 import { hasOwnProp } from './Helpers';
 
 import defaultClassNames from './classNames';
-import { RoleTypesShape, defaultRoles } from './DayPicker';
+import { RoleTypesShape, defaultRoles } from './PropTypes';
 
 function handleEvent(handler, day, modifiers) {
   if (!handler) {

--- a/src/Day.js
+++ b/src/Day.js
@@ -6,7 +6,7 @@ import { isSameDay } from './DateUtils';
 import { hasOwnProp } from './Helpers';
 
 import defaultClassNames from './classNames';
-import { RoleTypesShape } from './DayPicker';
+import { RoleTypesShape, defaultRoles } from './DayPicker';
 
 function handleEvent(handler, day, modifiers) {
   if (!handler) {
@@ -108,7 +108,7 @@ export default class Day extends Component {
       ariaLabel,
       ariaDisabled,
       ariaSelected,
-      roles,
+      roles = defaultRoles,
       children,
     } = this.props;
 

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -13,30 +13,7 @@ import * as ModifiersUtils from './ModifiersUtils';
 import classNames from './classNames';
 
 import { ENTER, SPACE, LEFT, UP, DOWN, RIGHT } from './keys';
-
-export const RoleTypesShape = {
-  caption: PropTypes.string,
-  month: PropTypes.string,
-  body: PropTypes.string,
-  weeknumber: PropTypes.string,
-  week: PropTypes.string,
-  weekday: PropTypes.string,
-  weekdays: PropTypes.string,
-  weekdaysRow: PropTypes.string,
-  day: PropTypes.string,
-  disabledDay: PropTypes.string,
-};
-
-export const defaultRoles = {
-  caption: 'heading',
-  weeknumber: 'gridrow',
-  weekdays: 'rowgroup',
-  month: 'grid',
-  body: 'rowgroup',
-  week: 'row',
-  day: 'gridcell',
-  disabledDay: 'gridcell',
-};
+import { RoleTypesShape, defaultRoles } from './PropTypes';
 
 export default class DayPicker extends Component {
   static VERSION = '7.1.4';

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -27,6 +27,17 @@ export const RoleTypesShape = {
   disabledDay: PropTypes.string,
 };
 
+export const defaultRoles = {
+  caption: 'heading',
+  weeknumber: 'gridrow',
+  weekdays: 'rowgroup',
+  month: 'grid',
+  body: 'rowgroup',
+  week: 'row',
+  day: 'gridcell',
+  disabledDay: 'gridcell',
+};
+
 export default class DayPicker extends Component {
   static VERSION = '7.1.4';
 
@@ -169,16 +180,7 @@ export default class DayPicker extends Component {
     weekdayElement: <Weekday />,
     navbarElement: <Navbar classNames={classNames} />,
     captionElement: <Caption classNames={classNames} />,
-    roles: {
-      caption: 'heading',
-      weeknumber: 'gridrow',
-      weekdays: 'rowgroup',
-      month: 'grid',
-      body: 'rowgroup',
-      week: 'row',
-      day: 'gridcell',
-      disabledDay: 'gridcell',
-    },
+    roles: defaultRoles,
   };
 
   constructor(props) {

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -14,6 +14,19 @@ import classNames from './classNames';
 
 import { ENTER, SPACE, LEFT, UP, DOWN, RIGHT } from './keys';
 
+export const RoleTypesShape = {
+  caption: PropTypes.string,
+  month: PropTypes.string,
+  body: PropTypes.string,
+  weeknumber: PropTypes.string,
+  week: PropTypes.string,
+  weekday: PropTypes.string,
+  weekdays: PropTypes.string,
+  weekdaysRow: PropTypes.string,
+  day: PropTypes.string,
+  disabledDay: PropTypes.string,
+};
+
 export default class DayPicker extends Component {
   static VERSION = '7.1.4';
 
@@ -110,6 +123,9 @@ export default class DayPicker extends Component {
       PropTypes.instanceOf(Component),
     ]),
 
+    // Roles
+    roles: PropTypes.shape(RoleTypesShape),
+
     // Events
     onBlur: PropTypes.func,
     onFocus: PropTypes.func,
@@ -153,6 +169,16 @@ export default class DayPicker extends Component {
     weekdayElement: <Weekday />,
     navbarElement: <Navbar classNames={classNames} />,
     captionElement: <Caption classNames={classNames} />,
+    roles: {
+      caption: 'heading',
+      weeknumber: 'gridrow',
+      weekdays: 'rowgroup',
+      month: 'grid',
+      body: 'rowgroup',
+      week: 'row',
+      day: 'gridcell',
+      disabledDay: 'gridcell',
+    },
   };
 
   constructor(props) {

--- a/src/Month.js
+++ b/src/Month.js
@@ -8,7 +8,7 @@ import { ENTER } from './keys';
 import * as ModifiersUtils from './ModifiersUtils';
 import * as Helpers from './Helpers';
 import * as DateUtils from './DateUtils';
-import { RoleTypesShape, defaultRoles } from './PropTypes';
+import { RoleTypesShape } from './PropTypes';
 
 export default class Month extends Component {
   static propTypes = {
@@ -148,7 +148,7 @@ export default class Month extends Component {
       showWeekNumbers,
       showWeekDays,
       onWeekClick,
-      roles = defaultRoles,
+      roles,
     } = this.props;
 
     const captionProps = {

--- a/src/Month.js
+++ b/src/Month.js
@@ -8,7 +8,7 @@ import { ENTER } from './keys';
 import * as ModifiersUtils from './ModifiersUtils';
 import * as Helpers from './Helpers';
 import * as DateUtils from './DateUtils';
-import { RoleTypesShape } from './DayPicker';
+import { RoleTypesShape, defaultRoles } from './DayPicker';
 
 export default class Month extends Component {
   static propTypes = {
@@ -148,7 +148,7 @@ export default class Month extends Component {
       showWeekNumbers,
       showWeekDays,
       onWeekClick,
-      roles,
+      roles = defaultRoles,
     } = this.props;
 
     const captionProps = {

--- a/src/Month.js
+++ b/src/Month.js
@@ -8,7 +8,7 @@ import { ENTER } from './keys';
 import * as ModifiersUtils from './ModifiersUtils';
 import * as Helpers from './Helpers';
 import * as DateUtils from './DateUtils';
-import { RoleTypesShape, defaultRoles } from './DayPicker';
+import { RoleTypesShape, defaultRoles } from './PropTypes';
 
 export default class Month extends Component {
   static propTypes = {

--- a/src/Month.js
+++ b/src/Month.js
@@ -8,6 +8,7 @@ import { ENTER } from './keys';
 import * as ModifiersUtils from './ModifiersUtils';
 import * as Helpers from './Helpers';
 import * as DateUtils from './DateUtils';
+import { RoleTypesShape } from './DayPicker';
 
 export default class Month extends Component {
   static propTypes = {
@@ -62,6 +63,8 @@ export default class Month extends Component {
     onDayTouchEnd: PropTypes.func,
     onDayTouchStart: PropTypes.func,
     onWeekClick: PropTypes.func,
+
+    roles: PropTypes.shape(RoleTypesShape),
   };
 
   renderDay = day => {
@@ -116,6 +119,7 @@ export default class Month extends Component {
         onMouseUp={this.props.onDayMouseUp}
         onTouchEnd={this.props.onDayTouchEnd}
         onTouchStart={this.props.onDayTouchStart}
+        roles={this.props.roles}
       >
         {this.props.renderDay(day, modifiers)}
       </Day>
@@ -144,6 +148,7 @@ export default class Month extends Component {
       showWeekNumbers,
       showWeekDays,
       onWeekClick,
+      roles,
     } = this.props;
 
     const captionProps = {
@@ -152,6 +157,7 @@ export default class Month extends Component {
       months,
       localeUtils,
       locale,
+      roles,
       onClick: onCaptionClick ? e => onCaptionClick(month, e) : undefined,
     };
     const caption = React.isValidElement(captionElement)
@@ -160,7 +166,7 @@ export default class Month extends Component {
 
     const weeks = Helpers.getWeekArray(month, firstDayOfWeek, fixedWeeks);
     return (
-      <div className={classNames.month} role="grid">
+      <div className={classNames.month} role={roles.month}>
         {caption}
         {showWeekDays && (
           <Weekdays
@@ -172,9 +178,10 @@ export default class Month extends Component {
             locale={locale}
             localeUtils={localeUtils}
             weekdayElement={weekdayElement}
+            roles={roles}
           />
         )}
-        <div className={classNames.body} role="rowgroup">
+        <div className={classNames.body} role={roles.body}>
           {weeks.map(week => {
             let weekNumber;
             if (showWeekNumbers) {
@@ -184,13 +191,14 @@ export default class Month extends Component {
               <div
                 key={week[0].getTime()}
                 className={classNames.week}
-                role="row"
+                role={roles.week}
               >
                 {showWeekNumbers && (
                   <div
                     className={classNames.weekNumber}
-                    tabIndex={0}
-                    role="gridcell"
+                    /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
+                    tabIndex={onWeekClick ? 0 : undefined}
+                    role={roles.weeknumber}
                     onClick={
                       onWeekClick
                         ? e => onWeekClick(weekNumber, week, e)

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -27,4 +27,28 @@ export const ModifierPropType = PropTypes.oneOfType([
   PropTypes.array,
 ]);
 
+export const RoleTypesShape = {
+  caption: PropTypes.string,
+  month: PropTypes.string,
+  body: PropTypes.string,
+  weeknumber: PropTypes.string,
+  week: PropTypes.string,
+  weekday: PropTypes.string,
+  weekdays: PropTypes.string,
+  weekdaysRow: PropTypes.string,
+  day: PropTypes.string,
+  disabledDay: PropTypes.string,
+};
+
+export const defaultRoles = {
+  caption: 'heading',
+  weeknumber: 'gridrow',
+  weekdays: 'rowgroup',
+  month: 'grid',
+  body: 'rowgroup',
+  week: 'row',
+  day: 'gridcell',
+  disabledDay: 'gridcell',
+};
+
 export default PrimitiveTypes;

--- a/src/Weekday.js
+++ b/src/Weekday.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { RoleTypesShape } from './DayPicker';
 
 export default class Weekday extends Component {
   static propTypes = {
@@ -10,6 +11,8 @@ export default class Weekday extends Component {
 
     weekdaysLong: PropTypes.arrayOf(PropTypes.string),
     weekdaysShort: PropTypes.arrayOf(PropTypes.string),
+
+    roles: PropTypes.shape(RoleTypesShape),
   };
   shouldComponentUpdate(nextProps) {
     return this.props !== nextProps;
@@ -22,6 +25,7 @@ export default class Weekday extends Component {
       weekdaysShort,
       localeUtils,
       locale,
+      roles,
     } = this.props;
     let title;
     if (weekdaysLong) {
@@ -37,7 +41,7 @@ export default class Weekday extends Component {
     }
 
     return (
-      <div className={className} role="columnheader">
+      <div className={className} role={roles.columnHeader}>
         <abbr title={title}>{content}</abbr>
       </div>
     );

--- a/src/Weekday.js
+++ b/src/Weekday.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { RoleTypesShape } from './DayPicker';
+import { RoleTypesShape, defaultRoles } from './DayPicker';
 
 export default class Weekday extends Component {
   static propTypes = {
@@ -14,6 +14,7 @@ export default class Weekday extends Component {
 
     roles: PropTypes.shape(RoleTypesShape),
   };
+
   shouldComponentUpdate(nextProps) {
     return this.props !== nextProps;
   }
@@ -25,7 +26,7 @@ export default class Weekday extends Component {
       weekdaysShort,
       localeUtils,
       locale,
-      roles,
+      roles = defaultRoles,
     } = this.props;
     let title;
     if (weekdaysLong) {

--- a/src/Weekday.js
+++ b/src/Weekday.js
@@ -15,6 +15,10 @@ export default class Weekday extends Component {
     roles: PropTypes.shape(RoleTypesShape),
   };
 
+  static defaultProps = {
+    roles: defaultRoles,
+  };
+
   shouldComponentUpdate(nextProps) {
     return this.props !== nextProps;
   }
@@ -26,7 +30,7 @@ export default class Weekday extends Component {
       weekdaysShort,
       localeUtils,
       locale,
-      roles = defaultRoles,
+      roles,
     } = this.props;
     let title;
     if (weekdaysLong) {

--- a/src/Weekday.js
+++ b/src/Weekday.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { RoleTypesShape, defaultRoles } from './DayPicker';
+import { RoleTypesShape, defaultRoles } from './PropTypes';
 
 export default class Weekday extends Component {
   static propTypes = {

--- a/src/Weekdays.js
+++ b/src/Weekdays.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { RoleTypesShape, defaultRoles } from './PropTypes';
+import { RoleTypesShape } from './PropTypes';
 
 export default class Weekdays extends Component {
   static propTypes = {
@@ -21,7 +21,7 @@ export default class Weekdays extends Component {
       PropTypes.func,
       PropTypes.instanceOf(React.Component),
     ]),
-    roles: PropTypes.shape(RoleTypesShape),
+    roles: PropTypes.shape(RoleTypesShape).isRequired,
   };
 
   shouldComponentUpdate(nextProps) {
@@ -37,7 +37,7 @@ export default class Weekdays extends Component {
       locale,
       localeUtils,
       weekdayElement,
-      roles = defaultRoles,
+      roles,
     } = this.props;
     const days = [];
     for (let i = 0; i < 7; i += 1) {

--- a/src/Weekdays.js
+++ b/src/Weekdays.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { RoleTypesShape } from './DayPicker';
 
 export default class Weekdays extends Component {
   static propTypes = {
@@ -20,6 +21,7 @@ export default class Weekdays extends Component {
       PropTypes.func,
       PropTypes.instanceOf(React.Component),
     ]),
+    roles: PropTypes.shape(RoleTypesShape),
   };
   shouldComponentUpdate(nextProps) {
     return this.props !== nextProps;
@@ -34,6 +36,7 @@ export default class Weekdays extends Component {
       locale,
       localeUtils,
       weekdayElement,
+      roles,
     } = this.props;
     const days = [];
     for (let i = 0; i < 7; i += 1) {
@@ -46,6 +49,7 @@ export default class Weekdays extends Component {
         weekdaysShort,
         localeUtils,
         locale,
+        roles,
       };
       const element = React.isValidElement(weekdayElement)
         ? React.cloneElement(weekdayElement, elementProps)
@@ -54,8 +58,12 @@ export default class Weekdays extends Component {
     }
 
     return (
-      <div className={classNames.weekdays} role="rowgroup">
-        <div className={classNames.weekdaysRow} role="row">
+      <div
+        className={classNames.weekdays}
+        role={roles.weekdays}
+        aria-hidden={roles.weekdays === 'presentation'}
+      >
+        <div className={classNames.weekdaysRow} role={roles.weekdaysRow}>
           {showWeekNumbers && <div className={classNames.weekday} />}
           {days}
         </div>

--- a/src/Weekdays.js
+++ b/src/Weekdays.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { RoleTypesShape } from './DayPicker';
+import { RoleTypesShape, defaultRoles } from './DayPicker';
 
 export default class Weekdays extends Component {
   static propTypes = {
@@ -23,6 +23,7 @@ export default class Weekdays extends Component {
     ]),
     roles: PropTypes.shape(RoleTypesShape),
   };
+
   shouldComponentUpdate(nextProps) {
     return this.props !== nextProps;
   }
@@ -36,7 +37,7 @@ export default class Weekdays extends Component {
       locale,
       localeUtils,
       weekdayElement,
-      roles,
+      roles = defaultRoles,
     } = this.props;
     const days = [];
     for (let i = 0; i < 7; i += 1) {

--- a/src/Weekdays.js
+++ b/src/Weekdays.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { RoleTypesShape, defaultRoles } from './DayPicker';
+import { RoleTypesShape, defaultRoles } from './PropTypes';
 
 export default class Weekdays extends Component {
   static propTypes = {

--- a/test/daypicker/rendering.js
+++ b/test/daypicker/rendering.js
@@ -26,6 +26,18 @@ describe('DayPicker’s rendering', () => {
     expect(typeof dayPicker.props.navbarElement).toBe('object');
     expect(dayPicker.props.tabIndex).toBe(0);
   });
+  it('should have default roles', () => {
+    const wrapper = mount(<DayPicker />);
+    expect(wrapper.find('.DayPicker-Month')).toHaveProp('role', 'grid');
+    expect(wrapper.find('.DayPicker-Caption')).toHaveProp('role', 'heading');
+    expect(wrapper.find('.DayPicker-Weekdays')).toHaveProp('role', 'rowgroup');
+    expect(wrapper.find('.DayPicker-Body')).toHaveProp('role', 'rowgroup');
+    expect(wrapper.find('.DayPicker-Week').at(0)).toHaveProp('role', 'row');
+    expect(wrapper.find('.DayPicker-Day[tabIndex=0]').at(0)).toHaveProp(
+      'role',
+      'gridcell'
+    );
+  });
   it('should have the right CSS classes and attributes', () => {
     const wrapper = shallow(<DayPicker />);
     expect(wrapper).toHaveClassName('DayPicker');

--- a/test/daypicker/rendering.js
+++ b/test/daypicker/rendering.js
@@ -6,7 +6,6 @@ import { shallow, mount, render } from 'enzyme';
 
 import DayPicker from '../../src/DayPicker';
 import Day from '../../src/Day';
-import Month from '../../src/Month';
 import classNames from '../../src/classNames';
 import { defaultRoles } from '../../src/PropTypes';
 

--- a/test/daypicker/rendering.js
+++ b/test/daypicker/rendering.js
@@ -6,6 +6,7 @@ import { shallow, mount, render } from 'enzyme';
 
 import DayPicker from '../../src/DayPicker';
 import Day from '../../src/Day';
+import Month from '../../src/Month';
 import classNames from '../../src/classNames';
 import { defaultRoles } from '../../src/PropTypes';
 
@@ -27,18 +28,6 @@ describe('DayPicker’s rendering', () => {
     expect(typeof dayPicker.props.navbarElement).toBe('object');
     expect(dayPicker.props.tabIndex).toBe(0);
     expect(dayPicker.props.roles).toBe(defaultRoles);
-  });
-  it('should have default roles', () => {
-    const wrapper = mount(<DayPicker />);
-    expect(wrapper.find('.DayPicker-Month')).toHaveProp('role', 'grid');
-    expect(wrapper.find('.DayPicker-Caption')).toHaveProp('role', 'heading');
-    expect(wrapper.find('.DayPicker-Weekdays')).toHaveProp('role', 'rowgroup');
-    expect(wrapper.find('.DayPicker-Body')).toHaveProp('role', 'rowgroup');
-    expect(wrapper.find('.DayPicker-Week').at(0)).toHaveProp('role', 'row');
-    expect(wrapper.find('.DayPicker-Day[tabIndex=0]').at(0)).toHaveProp(
-      'role',
-      'gridcell'
-    );
   });
   it('should have the right CSS classes and attributes', () => {
     const wrapper = shallow(<DayPicker />);
@@ -473,5 +462,22 @@ describe('Day.shouldComponentUpdate', () => {
     ).instance();
     const newProps = Object.assign({}, day.props, { onKeyDown: () => {} });
     expect(day.shouldComponentUpdate(newProps)).toBeTruthy();
+  });
+  describe('should use roles', () => {
+    it('datepicker should have default roles', () => {
+      const wrapper = mount(<DayPicker />);
+      expect(wrapper.find('.DayPicker-Month')).toHaveProp('role', 'grid');
+      expect(wrapper.find('.DayPicker-Caption')).toHaveProp('role', 'heading');
+      expect(wrapper.find('.DayPicker-Weekdays')).toHaveProp(
+        'role',
+        'rowgroup'
+      );
+      expect(wrapper.find('.DayPicker-Body')).toHaveProp('role', 'rowgroup');
+      expect(wrapper.find('.DayPicker-Week').at(0)).toHaveProp('role', 'row');
+      expect(wrapper.find('.DayPicker-Day[tabIndex=0]').at(0)).toHaveProp(
+        'role',
+        'gridcell'
+      );
+    });
   });
 });

--- a/test/daypicker/rendering.js
+++ b/test/daypicker/rendering.js
@@ -7,6 +7,7 @@ import { shallow, mount, render } from 'enzyme';
 import DayPicker from '../../src/DayPicker';
 import Day from '../../src/Day';
 import classNames from '../../src/classNames';
+import { defaultRoles } from '../../src/PropTypes';
 
 describe('DayPicker’s rendering', () => {
   it('should have default props', () => {
@@ -25,6 +26,7 @@ describe('DayPicker’s rendering', () => {
     expect(typeof dayPicker.props.weekdayElement).toBe('object');
     expect(typeof dayPicker.props.navbarElement).toBe('object');
     expect(dayPicker.props.tabIndex).toBe(0);
+    expect(dayPicker.props.roles).toBe(defaultRoles);
   });
   it('should have default roles', () => {
     const wrapper = mount(<DayPicker />);

--- a/types/DayPicker.d.ts
+++ b/types/DayPicker.d.ts
@@ -8,6 +8,7 @@ import {
   NavbarElementProps,
   WeekdayElementProps,
   DayPickerProps,
+  RoleTypesShape,
 } from './props';
 
 export default class DayPicker extends React.Component<DayPickerProps, any> {

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -39,14 +39,14 @@ export interface WeekdayElementProps {
 export interface DayPickerProps {
   canChangeMonth?: boolean;
   captionElement?:
-  | React.ReactElement<Partial<CaptionElementProps>>
-  | React.ComponentClass<CaptionElementProps>
-  | React.SFC<CaptionElementProps>;
+    | React.ReactElement<Partial<CaptionElementProps>>
+    | React.ComponentClass<CaptionElementProps>
+    | React.SFC<CaptionElementProps>;
   className?: string;
   classNames?: ClassNames;
   containerProps?: React.DetailedHTMLProps<
-  React.HTMLAttributes<HTMLDivElement>,
-  HTMLDivElement
+    React.HTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
   >;
   disabledDays?: Modifier | Modifier[];
   showOutsideDays?: boolean;
@@ -76,9 +76,9 @@ export interface DayPickerProps {
     string
   ];
   navbarElement?:
-  | React.ReactElement<Partial<NavbarElementProps>>
-  | React.ComponentClass<NavbarElementProps>
-  | React.SFC<NavbarElementProps>;
+    | React.ReactElement<Partial<NavbarElementProps>>
+    | React.ComponentClass<NavbarElementProps>
+    | React.SFC<NavbarElementProps>;
   numberOfMonths?: number;
   onBlur?(e: React.FocusEvent<HTMLDivElement>): void;
   onCaptionClick?(month: Date, e: React.MouseEvent<HTMLDivElement>): void;
@@ -138,6 +138,7 @@ export interface DayPickerProps {
   pagedNavigation?: boolean;
   renderDay?(date: Date, modifiers: Modifiers): React.ReactNode;
   renderWeek?(weekNumber: number, week: Date[], month: Date): React.ReactNode;
+  roles?: RoleTypesShape;
   reverseMonths?: boolean;
   selectedDays?: Modifier | Modifier[];
   showWeekNumbers?: boolean;
@@ -145,9 +146,9 @@ export interface DayPickerProps {
   todayButton?: string;
   toMonth?: Date;
   weekdayElement?:
-  | React.ReactElement<Partial<WeekdayElementProps>>
-  | React.ComponentClass<WeekdayElementProps>
-  | React.SFC<WeekdayElementProps>;
+    | React.ReactElement<Partial<WeekdayElementProps>>
+    | React.ComponentClass<WeekdayElementProps>
+    | React.SFC<WeekdayElementProps>;
   weekdaysLong?: [string, string, string, string, string, string, string];
   weekdaysShort?: [string, string, string, string, string, string, string];
 }
@@ -180,4 +181,17 @@ export interface DayPickerInputProps {
   onFocus?(e: React.FocusEvent<HTMLDivElement>): void;
   onBlur?(e: React.FocusEvent<HTMLDivElement>): void;
   onKeyUp?(e: React.FocusEvent<HTMLDivElement>): void;
+}
+
+export interface RoleTypesShape {
+  caption?: 'heading' | string;
+  month?: 'grid' | string;
+  body?: 'rowgroup' | string;
+  weeknumber?: 'gridrow' | string;
+  week?: 'row' | string;
+  weekday?: 'columnheader' | string;
+  weekdays?: 'rowgroup' | string;
+  weekdaysRow?: 'row' | string;
+  day?: 'gridcell' | string;
+  disabledDay?: 'gridcell' | string;
 }


### PR DESCRIPTION
Purpose: Introduce a DayPicker prop which makes is possible to override the roles set on the different parts of the calendar.

This might be a bit opinionated PR, but it makes us able to override the different roles in the calendar to meet the wishes of our accessibility people. Unfortunately it introduces some logic a few places, but I have tried to make them as small as possible.

See this as a first shot on how to solve issue #674. 