### PR TITLE
Add example using date-fns to format and parse dates

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "babel-preset-flow": "6.23.0",
+    "date-fns": "^1.29.0",
     "eslint": "4.18.2",
     "gatsby": "1.9.223",
     "gatsby-link": "^1.6.38",

--- a/docs/src/code-samples/examples/input-date-fns.js
+++ b/docs/src/code-samples/examples/input-date-fns.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import DayPickerInput from 'react-day-picker/DayPickerInput';
+import 'react-day-picker/lib/style.css';
+
+import format from 'date-fns/format';
+import parse from 'date-fns/parse';
+
+export default function Example() {
+  const FORMAT = 'M/D/YYYY';
+  return (
+    <DayPickerInput
+      formatDate={format}
+      format={FORMAT}
+      parseDate={parse}
+      placeholder={`${format(new Date(), FORMAT)}`}
+    />
+  );
+}

--- a/docs/src/pages/docs/input.js
+++ b/docs/src/pages/docs/input.js
@@ -67,5 +67,11 @@ export default () => (
     </p>
 
     <CodeSample name="examples/input-moment" />
+
+    <h3>Use date-fns to parse and format dates</h3>
+    <p>
+      If you are using <a href="http://date-fns.org">date-fns</a>, see{' '}
+      <Link to="/examples/input-date-fns">this example</Link>.
+    </p>
   </DocPage>
 );

--- a/docs/src/pages/examples/input-date-fns.js
+++ b/docs/src/pages/examples/input-date-fns.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import Link from 'gatsby-link';
+
+import ExamplePage from '../../containers/ExamplePage';
+import CodeSample from '../../ui/CodeSample';
+
+export default () => (
+  <ExamplePage title="Using date-fns to parse and format dates">
+    <p>
+      Use the{' '}
+      <Link to="/api/DayPickerInput#parseDate">
+        <code>parseDate</code>
+      </Link>{' '}
+      prop to parse the input typed by the user, and the{' '}
+      <Link to="/api/DayPickerInput#formatDate">
+        <code>formatDate</code>
+      </Link>{' '}
+      prop to format them.
+    </p>
+    <p>
+      In the following example, we are importing{' '}
+      <a href="https://date-fns.org/v1.29.0/docs/parse">parse</a> and{' '}
+      <a href="https://date-fns.org/v1.29.0/docs/format">format</a> from
+      date-fns.
+    </p>
+    <CodeSample name="examples/input-date-fns" />
+  </ExamplePage>
+);

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2242,6 +2242,10 @@ data-uri-to-buffer@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-0.0.4.tgz#46e13ab9da8e309745c8d01ce547213ebdb2fe3f"
 
+date-fns@^1.29.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -6643,7 +6647,7 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     strip-json-comments "~2.0.1"
 
 react-day-picker@../:
-  version "7.1.0"
+  version "7.1.4"
   dependencies:
     prop-types "^15.6.1"
 


### PR DESCRIPTION
I added a small example for how to use the new `formatDate` and `parseDate` props with [date-fns](https://date-fns.org/).

I think this might be able to close https://github.com/gpbl/react-day-picker/issues/342.