### PR TITLE
Fix modifiers when using classNames

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -374,6 +374,16 @@ export default class DayPickerInput extends React.Component {
       formatDate,
       format,
     } = this.props;
+    
+    if (dayPickerProps.classNames) {
+        Object.keys(dayPickerProps.classNames).map(function (key) {
+            let value = dayPickerProps.classNames[key];
+            if (modifiers[value]) {
+                modifiers[key] = modifiers[value];
+            }
+        })
+    }
+
     if (dayPickerProps.onDayClick) {
       dayPickerProps.onDayClick(day, modifiers, e);
     }


### PR DESCRIPTION
If using classNames modifiers is not correct working.

For example contains key "src-css-daypicker__disabled--21D2D" key instead of "disabled"

Issue: https://github.com/gpbl/react-day-picker/issues/689