### PR TITLE
Fix day picker for IE 11 (Also see Issue #668)

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -204,26 +204,24 @@ export default class DayPickerInput extends React.Component {
     return this.daypicker;
   }
 
+  setStateFrom(relatedTarget) {
+    this.setState({
+      showOverlay: this.overlayNode && this.overlayNode.contains(relatedTarget),
+    });
+  }
+
   isIE() {
     return /*@cc_on!@*/false || !!document.documentMode;
   }
 
-  setStateFrom(relatedTarget) {
-    this.setState({
-        showOverlay:
-          this.overlayNode && this.overlayNode.contains(relatedTarget),
-    });
-  }
-
   resetHideTimeout() {
-    if(this.hideTimeout) {
-      this.hideTimeout = setTimeout(() => { 
-          this.hideDayPicker();
-          this.hideTimeout = null;
-        }, HIDE_TIMEOUT);
+    if (this.hideTimeout) {
+      this.hideTimeout = setTimeout(() => {
+        this.hideDayPicker();
+        this.hideTimeout = null;
+      }, HIDE_TIMEOUT);
     }
   }
-
 
   input = null;
   daypicker = null;
@@ -308,11 +306,13 @@ export default class DayPickerInput extends React.Component {
   }
 
   handleInputBlur(e) {
-    if(this.isIE()) {
-        this.ieInputBlurTimeout = setTimeout(() => 
-            this.setStateFrom(e.relatedTarget), HIDE_TIMEOUT);
+    if (this.isIE()) {
+      this.ieInputBlurTimeout = setTimeout(
+        () => this.setStateFrom(e.relatedTarget),
+        HIDE_TIMEOUT
+      );
     } else {
-        this.setStateFrom(e.relatedTarget);
+      this.setStateFrom(e.relatedTarget);
     }
     if (this.props.inputProps.onBlur) {
       e.persist();
@@ -323,11 +323,11 @@ export default class DayPickerInput extends React.Component {
   handleOverlayFocus(e) {
     if (this.props.keepFocus === true) {
       e.preventDefault();
-      if(this.isIE()) {
+      if (this.isIE()) {
         this.ieInputFocusTimeout = setTimeout(() => {
-            this.input.focus();
-            this.resetHideTimeout();
-          }, HIDE_TIMEOUT);
+          this.input.focus();
+          this.resetHideTimeout();
+        }, HIDE_TIMEOUT);
       } else {
         this.input.focus();
       }

--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -168,7 +168,7 @@ export default class DayPickerInput extends React.Component {
     clearTimeout(this.clickTimeout);
     clearTimeout(this.hideTimeout);
     clearTimeout(this.ieInputFocusTimeout);
-    clearTImeout(this.ieInputBlurTimeout);
+    clearTimeout(this.ieInputBlurTimeout);
   }
 
   getStateFromProps(props) {

--- a/test/daypickerinput/rendering.js
+++ b/test/daypickerinput/rendering.js
@@ -114,7 +114,7 @@ describe('DayPickerInput', () => {
       mount(<DayPickerInput />, { attachTo: container });
       const spy = jest.spyOn(window, 'clearTimeout');
       ReactDOM.unmountComponentAtNode(container);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(4);
       spy.mockRestore();
     });
     it('should set today when clicking on today button', () => {


### PR DESCRIPTION
Fixes Day Picker IE 11 issue #668 for me.

Tested on the following browsers:
IE 11.0.56 @ Windows 10
Chrome/Chromium 65.0.3325.181 @ Windows 10, Ubuntu 18.04 LTS
Chrome 65.0.3325.109 @ Android 4.4
Edge 41.16299.248.0 @ Windows 10
Opera 52.0.2871.40 @ Windows 10
Firefox 59.0.2 @ Windows 10, Ubuntu 18.04 LTS

The proposed solution did not work for me. Therefore try to workaround this issue for IE by using setTimeout.