### PR TITLE
Add example for selecting an entire week

### DIFF
--- a/docs/src/code-samples/examples/selected-week.js
+++ b/docs/src/code-samples/examples/selected-week.js
@@ -1,0 +1,132 @@
+import React from 'react';
+import Helmet from 'react-helmet';
+import moment from 'moment';
+import DayPicker from 'react-day-picker';
+import 'react-day-picker/lib/style.css';
+
+export default class Example extends React.Component {
+  state = {
+    hoverRange: null,
+    selectedDays: [],
+  };
+
+  daysFromWeek = weekStart => [
+    weekStart,
+    moment(weekStart)
+      .add(1, 'days')
+      .toDate(),
+    moment(weekStart)
+      .add(2, 'days')
+      .toDate(),
+    moment(weekStart)
+      .add(3, 'days')
+      .toDate(),
+    moment(weekStart)
+      .add(4, 'days')
+      .toDate(),
+    moment(weekStart)
+      .add(5, 'days')
+      .toDate(),
+    moment(weekStart)
+      .add(6, 'days')
+      .toDate(),
+  ];
+
+  weekFromDay = date => ({
+    from: moment(date)
+      .startOf('week')
+      .toDate(),
+    to: moment(date)
+      .endOf('week')
+      .toDate(),
+  });
+
+  handelDayChange = date => {
+    this.setState(prevState => ({
+      ...prevState,
+      selectedDays: this.daysFromWeek(this.weekFromDay(date).from),
+    }));
+  };
+
+  handleDayEnter = date => {
+    this.setState(prevState => ({
+      ...prevState,
+      hoverRange: this.weekFromDay(date),
+    }));
+  };
+
+  handleDayLeave = () => {
+    this.setState(prevState => ({
+      ...prevState,
+      hoverRange: null,
+    }));
+  };
+
+  render() {
+    const { hoverRange, selectedDays } = this.state;
+
+    const daysAreSelected = selectedDays.length > 0;
+
+    const modifiers = {
+      hoverRange,
+      selectedRange: daysAreSelected && {
+        from: selectedDays[0],
+        to: selectedDays[6],
+      },
+      hoverRangeStart: hoverRange && hoverRange.from,
+      hoverRangeEnd: hoverRange && hoverRange.to,
+      selectedRangeStart: daysAreSelected && selectedDays[0],
+      selectedRangeEnd: daysAreSelected && selectedDays[6],
+    };
+
+    return (
+      <div>
+        <DayPicker
+          selectedDays={selectedDays}
+          onDayClick={this.handelDayChange}
+          onDayMouseEnter={this.handleDayEnter}
+          onDayMouseLeave={this.handleDayLeave}
+          modifiers={modifiers}
+        />
+        <Helmet>
+          <style>{`
+            .DayPicker-Day--hoverRange {
+              background-color: rgb(209, 238, 248) !important;
+            }
+
+            .DayPicker-Day--selectedRange {
+              background-color: lightblue !important;
+            }
+
+            .DayPicker-Day--hoverRangeStart,
+            .DayPicker-Day--selectedRangeStart {
+              border-top-left-radius: 5px;
+              border-bottom-left-radius: 5px;
+            }
+
+            .DayPicker-Day--hoverRangeEnd,
+            .DayPicker-Day--selectedRangeEnd {
+              border-top-right-radius: 5px;
+              border-bottom-right-radius: 5px;
+            }
+
+            .DayPicker-Day--selectedRangeStart,
+            .DayPicker-Day--selectedRangeEnd {
+              background-color: lightskyblue !important;
+            }
+
+            .DayPicker-Day--selectedRange.DayPicker-Day--selected,
+            .DayPicker-Day--hoverRange.DayPicker-Day--selected {
+              border-radius: 0 !important;
+              color: black !important;
+            }
+
+            .DayPicker-Day--hoverRange:hover {
+              border-radius: 0 !important;
+            }
+          `}</style>
+        </Helmet>
+      </div>
+    );
+  }
+}

--- a/docs/src/containers/ExamplePage.js
+++ b/docs/src/containers/ExamplePage.js
@@ -70,6 +70,7 @@ export default function ExamplePage({ children, title }) {
               <Menu.Item to="/examples/selected-range-enter">
                 Select range on mouse enter
               </Menu.Item>
+              <Menu.Item to="/examples/selected-week">Select a week</Menu.Item>
             </Menu>
             <Menu subtitle="Disabling days">
               <Menu.Item to="/examples/disabled">

--- a/docs/src/pages/examples/selected-week.js
+++ b/docs/src/pages/examples/selected-week.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import ExamplePage from '../../containers/ExamplePage';
+import CodeSample from '../../ui/CodeSample';
+
+export default () => (
+  <ExamplePage title="Selecting a week">
+    <p>
+      This example shows how to use the component’s state and{' '}
+      <code>selectedDays</code> to allow the selection amd hihlighting of a
+      week.
+    </p>
+    <CodeSample name="examples/selected-week" />
+  </ExamplePage>
+);


### PR DESCRIPTION
I finally had the time to extract https://github.com/gpbl/react-day-picker/issues/686 into the example section.

The implementation slightly differs from the codebox example I previously build.


![week](https://user-images.githubusercontent.com/3099581/39962193-04d1a7f4-5648-11e8-87a0-6bb8eff95424.gif)

