### PR TITLE
Do not call `input.focus` if not defined

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -365,7 +365,7 @@ export default class DayPickerInput extends React.Component {
   handleOverlayFocus(e) {
     e.preventDefault();
     this.overlayHasFocus = true;
-    if (!this.props.keepFocus) {
+    if (!this.props.keepFocus || typeof this.input.focus !== 'function') {
       return;
     }
     this.input.focus();

--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -365,7 +365,11 @@ export default class DayPickerInput extends React.Component {
   handleOverlayFocus(e) {
     e.preventDefault();
     this.overlayHasFocus = true;
-    if (!this.props.keepFocus || typeof this.input.focus !== 'function') {
+    if (
+      !this.props.keepFocus ||
+      !this.input ||
+      typeof this.input.focus !== 'function'
+    ) {
       return;
     }
     this.input.focus();


### PR DESCRIPTION
See https://github.com/gpbl/react-day-picker/issues/746#issuecomment-403203664. This closes #742.