### PR TITLE
Fix TypeScript type for DayPicker.dayPicker

### DIFF
--- a/types/DayPicker.d.ts
+++ b/types/DayPicker.d.ts
@@ -11,13 +11,13 @@ import {
 } from './props';
 
 export default class DayPicker extends React.Component<DayPickerProps, any> {
-  static dayPicker: HTMLDivElement;
   static VERSION: string;
   static LocaleUtils: LocaleUtils;
   static DateUtils: DateUtils;
   static ModifiersUtils: ModifiersUtils;
   static DayModifiers: DayModifiers;
   static Modifiers: Modifiers;
+  readonly dayPicker: HTMLDivElement;
   showMonth(month: Date): void;
   showPreviousMonth(): void;
   showNextMonth(): void;


### PR DESCRIPTION
The `dayPicker` property was specified incorrectly as a static property
on the `DayPicker` class when it actually exists for the component instance.
