### PR TITLE
Add top-level type definition for DayPickerInput

### DIFF
--- a/DayPickerInput.d.ts
+++ b/DayPickerInput.d.ts
@@ -1,0 +1,2 @@
+import { DayPickerInput } from './types/DayPickerInput'
+export default DayPickerInput


### PR DESCRIPTION
This allows importing from `'react-day-picker/DayPickerInput'` from TypeScript.
Fixes https://github.com/gpbl/react-day-picker/issues/586

I chose to keep the existing type definitions for `DayPickerInput` in the `types` folder and only reference them from the new top-level definition file. Alternatively, the existing definition file could be moved up to the top level as well, but this would be a breaking change for TypeScript consumers.

The new file also takes care of exporting the `DayPickerInput` correctly as default export (see https://github.com/gpbl/react-day-picker/issues/586#issuecomment-372713868)