### PR TITLE
Add undefined and null as allowed modifier types

### DIFF
--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -50,7 +50,9 @@ export type Modifier =
   | AfterModifier
   | BeforeAfterModifier
   | DaysOfWeekModifier
-  | FunctionModifier;
+  | FunctionModifier
+  | undefined
+  | null;
 
 export interface Modifiers {
   today: Modifier | Modifier[];


### PR DESCRIPTION
Examples like: https://react-day-picker.js.org/examples/selected-range-enter/ show that modifiers are in fact supported as undefined or nullable. They do not work in typescript without some fair amount of work to ensure the value isn't null, when in fact the library does handle those types.