### PR TITLE
Add DayPickerInput.d.ts to npm bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "files": [
     "DayPicker.js",
     "DayPickerInput.js",
+    "DayPickerInput.d.ts",
     "lib",
     "moment.js",
     "utils.js",


### PR DESCRIPTION
This PR adds the TypeScript definition file added by #762 to the npm bundle.
Ref #586 