### PR TITLE
[Types] renderDay function, modifiers argument

### DIFF
--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -137,7 +137,7 @@ export interface DayPickerProps {
     e: React.MouseEvent<HTMLDivElement>
   ): void;
   pagedNavigation?: boolean;
-  renderDay?(date: Date, modifiers: Modifiers): React.ReactNode;
+  renderDay?(date: Date, modifiers: DayModifiers): React.ReactNode;
   renderWeek?(weekNumber: number, week: Date[], month: Date): React.ReactNode;
   reverseMonths?: boolean;
   selectedDays?: Modifier | Modifier[];


### PR DESCRIPTION
The second argument of function `renderDay(date, modifiers)` should be of type `DayModifiers` instead of type `Modifiers`.