### PR TITLE
Fix timezone dependant keys

### DIFF
--- a/src/Month.js
+++ b/src/Month.js
@@ -180,9 +180,12 @@ export default class Month extends Component {
             if (showWeekNumbers) {
               weekNumber = DateUtils.getWeekNumber(week[6]);
             }
+            const dateWithoutOffset = new Date(
+              week[0].getTime() - week[0].getTimezoneOffset() * 60000
+            );
             return (
               <div
-                key={week[0].getTime()}
+                key={dateWithoutOffset.getTime()}
                 className={classNames.week}
                 role="row"
               >

--- a/test/daypicker/__snapshots__/rendering.js.snap
+++ b/test/daypicker/__snapshots__/rendering.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Month's rendering should render same key for same date no matter what local tz is set 1`] = `"1530439200000"`;
+exports[`Month's rendering should render same key for same date no matter what local tz is set 1`] = `"1530446400000"`;

--- a/test/daypicker/__snapshots__/rendering.js.snap
+++ b/test/daypicker/__snapshots__/rendering.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Month's rendering should render same key for same date no matter what local tz is set 1`] = `"1530439200000"`;

--- a/test/daypicker/rendering.js
+++ b/test/daypicker/rendering.js
@@ -11,7 +11,7 @@ import Month from '../../src/Month';
 import { LocaleUtils } from '../../DayPicker';
 import Weekday from '../../src/Weekday';
 import Navbar from '../../src/Navbar';
-import Caption from '../../src/Caption';
+import ActualCaption from '../../src/Caption';
 
 describe('DayPicker’s rendering', () => {
   it('should have default props', () => {
@@ -483,7 +483,7 @@ describe("Month's rendering", () => {
       localeUtils: LocaleUtils,
       weekdayElement: <Weekday />,
       navbarElement: <Navbar classNames={classNames} />,
-      captionElement: <Caption classNames={classNames} />,
+      captionElement: <ActualCaption classNames={classNames} />,
     };
 
     const monthWithLocalizedTZ = mount(

--- a/test/daypicker/rendering.js
+++ b/test/daypicker/rendering.js
@@ -7,6 +7,11 @@ import { shallow, mount, render } from 'enzyme';
 import DayPicker from '../../src/DayPicker';
 import Day from '../../src/Day';
 import classNames from '../../src/classNames';
+import Month from '../../src/Month';
+import { LocaleUtils } from '../../DayPicker';
+import Weekday from '../../src/Weekday';
+import Navbar from '../../src/Navbar';
+import Caption from '../../src/Caption';
 
 describe('DayPicker’s rendering', () => {
   it('should have default props', () => {
@@ -461,5 +466,35 @@ describe('Day.shouldComponentUpdate', () => {
     ).instance();
     const newProps = Object.assign({}, day.props, { onKeyDown: () => {} });
     expect(day.shouldComponentUpdate(newProps)).toBeTruthy();
+  });
+});
+
+describe("Month's rendering", () => {
+  it('should render same key for same date no matter what local tz is set', () => {
+    const monthProps = {
+      selectedDays: new Date(2018, 6, 0),
+      toMonth: new Date(2018, 11, 0),
+      classNames,
+      numberOfMonths: 1,
+      firstDayOfWeek: 0,
+      renderDay: day => day.getDate(),
+      renderWeek: weekNumber => weekNumber,
+      locale: 'en',
+      localeUtils: LocaleUtils,
+      weekdayElement: <Weekday />,
+      navbarElement: <Navbar classNames={classNames} />,
+      captionElement: <Caption classNames={classNames} />,
+    };
+
+    const monthWithLocalizedTZ = mount(
+      <Month {...monthProps} month={new Date(2018, 6, 1, 18, 0, 0)} />
+    );
+
+    const localizedKey = monthWithLocalizedTZ
+      .find('.DayPicker-Week')
+      .first()
+      .key();
+
+    expect(localizedKey).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
relates to #130

Currently, the keys used for the `Week`components in the `Month` component are different depending on the timezone of the engine that compiles the code.

This causes a problem when creating snapshots of the day-picker, since they may be compared between machines with different timezones.

to demonstrate this behavior, i've added a snapshot test that just snapshots the `key` prop of the first week of a given month. the snapshot was recorded using UTC time,and it will fail on any machine running the test suite with a different timezone.

the actual implementation consists of stripping the timezone away from the date before converting it to a timestamp and using it as a key.

this method could be implemented for any other dates as well. i am using it together with https://www.npmjs.com/package/jest-date-serializer to have full utc snapshotting.