### PR TITLE
Feat/toggle change month

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -108,6 +108,8 @@ export default class DayPickerInput extends React.Component {
     component: PropTypes.any,
     overlayComponent: PropTypes.any,
 
+    changeMonthOnDayClick: PropTypes.bool,
+
     classNames: PropTypes.shape({
       container: PropTypes.string,
       overlayWrapper: PropTypes.string,
@@ -142,6 +144,7 @@ export default class DayPickerInput extends React.Component {
       overlayWrapper: 'DayPickerInput-OverlayWrapper',
       overlay: 'DayPickerInput-Overlay',
     },
+    changeMonthOnDayClick: true,
   };
 
   input = null;
@@ -460,6 +463,7 @@ export default class DayPickerInput extends React.Component {
       onDayChange,
       formatDate,
       format,
+      changeMonthOnDayClick,
     } = this.props;
     if (dayPickerProps.onDayClick) {
       dayPickerProps.onDayClick(day, modifiers, e);
@@ -497,7 +501,14 @@ export default class DayPickerInput extends React.Component {
     }
 
     const value = formatDate(day, format, dayPickerProps.locale);
-    this.setState({ value, typedValue: undefined, month: day }, () => {
+
+    const newState = { value, typedValue: undefined };
+
+    if (changeMonthOnDayClick) {
+      newState.month = day;
+    }
+
+    this.setState(newState, () => {
       if (onDayChange) {
         onDayChange(day, modifiers, this);
       }

--- a/test/daypickerinput/events.js
+++ b/test/daypickerinput/events.js
@@ -150,6 +150,24 @@ describe('DayPickerInput', () => {
           'October 2015'
         );
       });
+      it('should not update the dispayled month when changeMonthOnDayClick is false', () => {
+        const wrapper = mount(
+          <DayPickerInput
+            changeMonthOnDayClick={false}
+            dayPickerProps={{ numberOfMonths: 2 }}
+          />
+        );
+        wrapper.instance().showDayPicker();
+        wrapper.update();
+        wrapper
+          .find('.DayPicker-Day')
+          .at(40)
+          .simulate('click');
+
+        expect(wrapper.find('.DayPicker-Caption').first()).toHaveText(
+          moment().format('MMMM YYYY')
+        );
+      });
       it('should call `onDayChange` with modifiers', () => {
         const onDayChange = jest.fn();
         const testDay = new Date(2015, 11, 20);


### PR DESCRIPTION
see #807 

This PR adds a new prop to DayPickerInput, changeMonthOnDayClick. The purpose of this prop is to allow the user to prevent the DayPickerInput from updating the displayed month prop on the DayPicker when a day is clicked. The prop is defaulted to true to match current functionality.

This prop is useful when using a  single DayPickerInput that displays multiple months. The automatic jump forward can be disorienting when selecting a day on the second month (although some implementations may prefer this behavior.) 

A test has been added to test the new prop, and the PR has been linted with `yarn lint`. After running `yarn test --coverage` a few lines in some files (including DayPickerInput.js) are not covered, however they are lines not touched by this PR.
