### PR TITLE
When DayPicker input state is controlled, correctly set the input text on 'value' prop updates

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -486,10 +486,13 @@ export default class DayPickerInput extends React.Component {
       } else if (selectedDays) {
         selectedDays = null;
       }
+
       this.setState(
-        { value: '', typedValue: undefined, selectedDays },
+        { value: '', typedValue: '', selectedDays },
         this.hideAfterDayClick
       );
+
+
       if (onDayChange) {
         onDayChange(undefined, modifiers, this);
       }
@@ -566,7 +569,7 @@ export default class DayPickerInput extends React.Component {
           ref={el => (this.input = el)}
           placeholder={this.props.placeholder}
           {...inputProps}
-          value={this.state.typedValue || this.state.value}
+          value={this.state.value || this.state.typedValue}
           onChange={this.handleInputChange}
           onFocus={this.handleInputFocus}
           onBlur={this.handleInputBlur}

--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -126,6 +126,7 @@ export default class DayPickerInput extends React.Component {
   static defaultProps = {
     dayPickerProps: {},
     value: '',
+    typedValue: '',
     placeholder: 'YYYY-M-D',
     format: 'L',
     formatDate: defaultFormat,
@@ -235,13 +236,15 @@ export default class DayPickerInput extends React.Component {
   }
 
   getInitialStateFromProps(props) {
-    const { dayPickerProps, formatDate, format } = props;
+    const { dayPickerProps, formatDate, format, typedValue } = props;
     let { value } = props;
     if (props.value && isDate(props.value)) {
       value = formatDate(props.value, format, dayPickerProps.locale);
     }
+
     return {
       value,
+      typedValue,
       month: this.getInitialMonthFromProps(props),
       selectedDays: dayPickerProps.selectedDays,
     };
@@ -265,7 +268,7 @@ export default class DayPickerInput extends React.Component {
    */
   updateState(day, value, callback) {
     const { dayPickerProps, onDayChange } = this.props;
-    this.setState({ month: day, value, typedValue: undefined }, () => {
+    this.setState({ month: day, value, typedValue: '' }, () => {
       if (callback) {
         callback();
       }
@@ -404,7 +407,7 @@ export default class DayPickerInput extends React.Component {
     }
     const { value } = e.target;
     if (value.trim() === '') {
-      this.setState({ value, typedValue: undefined });
+      this.setState({ value, typedValue: '' });
       if (onDayChange) onDayChange(undefined, {}, this);
       return;
     }
@@ -491,7 +494,6 @@ export default class DayPickerInput extends React.Component {
         { value: '', typedValue: '', selectedDays },
         this.hideAfterDayClick
       );
-
 
       if (onDayChange) {
         onDayChange(undefined, modifiers, this);

--- a/test/daypickerinput/events.js
+++ b/test/daypickerinput/events.js
@@ -176,7 +176,7 @@ describe('DayPickerInput', () => {
         });
       });
       it('should clear an invalid input value when the value prop is updated with a valid date', () => {
-        const wrapper = mount(<DayPickerInput value={"2015-7-01"} />);
+        const wrapper = mount(<DayPickerInput value="2015-7-01" />);
         wrapper
           .find('input')
           .simulate('change', { target: { value: 'an invalid date value' } });

--- a/test/daypickerinput/events.js
+++ b/test/daypickerinput/events.js
@@ -175,6 +175,15 @@ describe('DayPickerInput', () => {
           disabled: true,
         });
       });
+      it('should clear an invalid input value when the value prop is updated with a valid date', () => {
+        const wrapper = mount(<DayPickerInput value={"2015-7-01"} />);
+        wrapper
+          .find('input')
+          .simulate('change', { target: { value: 'an invalid date value' } });
+        wrapper.setProps({ value: new Date(2015, 7, 10) });
+        wrapper.update();
+        expect(wrapper.find('input')).toHaveProp('value', '2015-8-10');
+      });
     });
     describe('hide', () => {
       it('should call `onDayPickerHide` when overlay is being hid', () => {


### PR DESCRIPTION
Reported as an issue with explanation here: https://github.com/gpbl/react-day-picker/issues/815

Essentially, my issue is that when DayPickerInput is controlled (i.e. takes a 'value' prop) and an invalid date is entered into the input box, an update to the value prop does not clear/update the text within the input (even though the overlay correctly updates the state)

The main issue in this case happens here: https://github.com/gpbl/react-day-picker/blob/master/src/DayPickerInput.js#L576

In this case, this.state.typedValue is defined and remains inside the input, even though this.state.value is the correct state of the input. 

The other changes address warnings that are shown in the console as a result. This message happens when you initialize a controlled input with an undefined value: 

<img width="1197" alt="screen shot 2018-10-05 at 5 13 31 pm" src="https://user-images.githubusercontent.com/13023846/46565238-38fb3d00-c8c2-11e8-8bb2-035209f7aa3e.png">

Also, I added a test to cover this scenario. 
