### PR TITLE
a11y: Set week number tabIndex to -1 if onWeekClick is not defined

### DIFF
--- a/src/Month.js
+++ b/src/Month.js
@@ -189,7 +189,7 @@ export default class Month extends Component {
                 {showWeekNumbers && (
                   <div
                     className={classNames.weekNumber}
-                    tabIndex={0}
+                    tabIndex={onWeekClick ? 0 : -1}
                     role="gridcell"
                     onClick={
                       onWeekClick


### PR DESCRIPTION
If `showWeekNumbers` prop is specified, while `onWeekClick` is not defined, this means that the week numbers are only supposed to be rendered for their visual purpose, not to be interacted with. It seems like tabIndex is left at 0 regardless, which means you have to tab through them even though they cannot be interacted with.

This PR sets tabIndex to -1 on the week numbers if `onWeekClick` is not defined, so that the visually impaired won't have to cycle through the non-interactive elements.

Tests, coverage and linting has run successfully.