### PR TITLE
Fix text wrapping on DayPicker-Day

### DIFF
--- a/lib/style.css
+++ b/lib/style.css
@@ -128,6 +128,7 @@
   vertical-align: middle;
   text-align: center;
   cursor: pointer;
+  white-space: nowrap;
 }
 
 .DayPicker-WeekNumber {


### PR DESCRIPTION
The days in the calendar shouldn't wrap when they're in a small container.

This is what it looks like currently:
![without nowrap](https://imgur.com/mTweHXm.jpg)

With the fix:
![with nowrap](https://imgur.com/LHOMAXa.jpg)