### PR TITLE
Added numbers formatting feature

### DIFF
--- a/src/Caption.js
+++ b/src/Caption.js
@@ -50,6 +50,12 @@ export default class Caption extends Component {
       localeUtils,
       onClick,
     } = this.props;
+
+    let caption = months ? `${months[date.getMonth()]} ${date.getFullYear()}` : localeUtils.formatMonthTitle(date, locale);
+
+    if (numbers)
+      caption = localeUtils.formatNumbers(caption, numbers)
+
     return (
       <div className={classNames.caption} role="heading">
         <div onClick={onClick} onKeyUp={this.handleKeyUp}>

--- a/src/Caption.js
+++ b/src/Caption.js
@@ -9,6 +9,7 @@ export default class Caption extends Component {
   static propTypes = {
     date: PropTypes.instanceOf(Date),
     months: PropTypes.arrayOf(PropTypes.string),
+    numbers: PropTypes.arrayOf(PropTypes.string),
     locale: PropTypes.string,
     localeUtils: PropTypes.object,
     onClick: PropTypes.func,
@@ -52,8 +53,7 @@ export default class Caption extends Component {
       onClick,
     } = this.props;
     let caption = months
-      ? `${months[date.getMonth()]} ${date.getFullYear()}`
-     :
+      ? `${months[date.getMonth()]} ${date.getFullYear()}` :
       localeUtils.formatMonthTitle(date, locale);
 
     if (numbers) caption = localeUtils.formatNumbers(caption, numbers);

--- a/src/Caption.js
+++ b/src/Caption.js
@@ -51,18 +51,15 @@ export default class Caption extends Component {
       localeUtils,
       onClick,
     } = this.props;
-
     let caption = months ? `${months[date.getMonth()]} ${date.getFullYear()}` : localeUtils.formatMonthTitle(date, locale);
 
     if (numbers)
-      caption = localeUtils.formatNumbers(caption, numbers)
+      caption = localeUtils.formatNumbers(caption, numbers);
 
     return (
       <div className={classNames.caption} role="heading">
         <div onClick={onClick} onKeyUp={this.handleKeyUp}>
-          {months
-            ? `${months[date.getMonth()]} ${date.getFullYear()}`
-            : localeUtils.formatMonthTitle(date, locale)}
+          {caption}
         </div>
       </div>
     );

--- a/src/Caption.js
+++ b/src/Caption.js
@@ -51,10 +51,12 @@ export default class Caption extends Component {
       localeUtils,
       onClick,
     } = this.props;
-    let caption = months ? `${months[date.getMonth()]} ${date.getFullYear()}` : localeUtils.formatMonthTitle(date, locale);
+    let caption = months
+      ? `${months[date.getMonth()]} ${date.getFullYear()}`
+     :
+      localeUtils.formatMonthTitle(date, locale);
 
-    if (numbers)
-      caption = localeUtils.formatNumbers(caption, numbers);
+    if (numbers) caption = localeUtils.formatNumbers(caption, numbers);
 
     return (
       <div className={classNames.caption} role="heading">

--- a/src/Caption.js
+++ b/src/Caption.js
@@ -46,6 +46,7 @@ export default class Caption extends Component {
       classNames,
       date,
       months,
+      numbers,
       locale,
       localeUtils,
       onClick,

--- a/src/LocaleUtils.js
+++ b/src/LocaleUtils.js
@@ -30,9 +30,7 @@ export function formatDay(day) {
 }
 
 export function formatNumbers(number, numbersFormat) {
-  return number
-    .toString()
-    .replace(/\d/g, x => numbersFormat[x]);
+  return number.toString().replace(/\d/g, x => numbersFormat[x]);
 }
 
 export function formatMonthTitle(d) {

--- a/src/LocaleUtils.js
+++ b/src/LocaleUtils.js
@@ -29,6 +29,12 @@ export function formatDay(day) {
   return day.toDateString();
 }
 
+export function formatNumbers(number, numbersFormat) {
+  return number
+    .toString()
+    .replace(/\d/g, x => numbersFormat[x]);
+}
+
 export function formatMonthTitle(d) {
   return `${MONTHS[d.getMonth()]} ${d.getFullYear()}`;
 }

--- a/src/Month.js
+++ b/src/Month.js
@@ -141,6 +141,7 @@ export default class Month extends Component {
       weekdaysLong,
       weekdaysShort,
       firstDayOfWeek,
+      numbers,
 
       onCaptionClick,
 
@@ -153,6 +154,7 @@ export default class Month extends Component {
       date: month,
       classNames,
       months,
+      numbers,
       localeUtils,
       locale,
       onClick: onCaptionClick ? e => onCaptionClick(month, e) : undefined,

--- a/src/Month.js
+++ b/src/Month.js
@@ -22,6 +22,7 @@ export default class Month extends Component {
 
     month: PropTypes.instanceOf(Date).isRequired,
     months: PropTypes.arrayOf(PropTypes.string),
+    numbers: PropTypes.arrayOf(PropTypes.string),
 
     modifiersStyles: PropTypes.object,
 
@@ -117,10 +118,11 @@ export default class Month extends Component {
         onTouchEnd={this.props.onDayTouchEnd}
         onTouchStart={this.props.onDayTouchStart}
       >
-        {this.props.numbers ? this.props.localeUtils.formatNumbers(
-            this.props.renderDay(day, modifiers),
-            this.props.numbers
-          ):
+        {
+          this.props.numbers ? this.props.localeUtils.formatNumbers(
+              this.props.renderDay(day, modifiers),
+              this.props.numbers
+          ) :
           this.props.renderDay(day, modifiers)}
       </Day>
     );

--- a/src/Month.js
+++ b/src/Month.js
@@ -120,8 +120,7 @@ export default class Month extends Component {
         {this.props.numbers ? this.props.localeUtils.formatNumbers(
             this.props.renderDay(day, modifiers),
             this.props.numbers
-          )
-          :
+          ):
           this.props.renderDay(day, modifiers)}
       </Day>
     );

--- a/src/Month.js
+++ b/src/Month.js
@@ -117,8 +117,10 @@ export default class Month extends Component {
         onTouchEnd={this.props.onDayTouchEnd}
         onTouchStart={this.props.onDayTouchStart}
       >
-        {this.props.numbers ?
-          this.props.localeUtils.formatNumbers(this.props.renderDay(day, modifiers), this.props.numbers)
+        {this.props.numbers ? this.props.localeUtils.formatNumbers(
+            this.props.renderDay(day, modifiers),
+            this.props.numbers
+          )
           :
           this.props.renderDay(day, modifiers)}
       </Day>

--- a/src/Month.js
+++ b/src/Month.js
@@ -117,7 +117,10 @@ export default class Month extends Component {
         onTouchEnd={this.props.onDayTouchEnd}
         onTouchStart={this.props.onDayTouchStart}
       >
-        {this.props.renderDay(day, modifiers)}
+        {this.props.numbers ?
+          this.props.localeUtils.formatNumbers(this.props.renderDay(day, modifiers), this.props.numbers)
+          :
+          this.props.renderDay(day, modifiers)}
       </Day>
     );
   };


### PR DESCRIPTION
We use the locale feature to change months and weekdays language, but we also wanted to change numbers format.

**Code Example:**
<DayPicker numbers={['٠', '١', '٢', '٣', '٤', '٥', '٦', '٧', '٨', '٩']} />

**Result:**
**Before:**
![before](https://user-images.githubusercontent.com/44771740/47995898-7d673c00-e0ff-11e8-8216-3f53585aefc1.png)
**After:**
![after](https://user-images.githubusercontent.com/44771740/47995905-8526e080-e0ff-11e8-9ade-a1b4cef7f2b4.png)


