### PR TITLE
Fix wrong type definition on LocaleUtils

### DIFF
--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -3,13 +3,13 @@
 import { RangeModifier, Modifier } from "./common";
 
 export interface LocaleUtils {
-  formatDay(day: Date, locale: string): string;
-  formatMonthTitle(month: Date, locale: string): string;
-  formatWeekdayLong(weekday: number, locale: string): string;
-  formatWeekdayShort(weekday: number, locale: string): string;
-  getFirstDayOfWeek(locale: string): number;
+  formatDay(day: Date, locale?: string): string;
+  formatMonthTitle(month: Date, locale?: string): string;
+  formatWeekdayLong(weekday: number, locale?: string): string;
+  formatWeekdayShort(weekday: number, locale?: string): string;
+  getFirstDayOfWeek(locale?: string): number;
   getMonths(
-    locale: string
+    locale?: string
   ): [
     string,
     string,


### PR DESCRIPTION
Every `locale` has `en` as the default value so they're optional. Source: https://github.com/gpbl/react-day-picker/blob/master/src/addons/MomentLocaleUtils.js#L5