### PR TITLE
Adds onDayPickerShow to complement onDayPickerHide

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -116,6 +116,7 @@ export default class DayPickerInput extends React.Component {
 
     onDayChange: PropTypes.func,
     onDayPickerHide: PropTypes.func,
+    onDayPickerShow: PropTypes.func,
     onChange: PropTypes.func,
     onClick: PropTypes.func,
     onFocus: PropTypes.func,
@@ -303,10 +304,15 @@ export default class DayPickerInput extends React.Component {
     const month = value
       ? parseDate(value, format, dayPickerProps.locale) // Use the month in the input field
       : this.getInitialMonthFromProps(this.props); // Restore the month from the props
-    this.setState(state => ({
-      showOverlay: true,
-      month: month || state.month,
-    }));
+    this.setState(
+      state => ({
+        showOverlay: true,
+        month: month || state.month,
+      }),
+      () => {
+        if (this.props.onDayPickerShow) this.props.onDayPickerShow();
+      }
+    );
   }
 
   /**

--- a/test/daypickerinput/events.js
+++ b/test/daypickerinput/events.js
@@ -31,6 +31,16 @@ describe('DayPickerInput', () => {
         wrapper.find('input').simulate('click');
         expect(onClick).toHaveBeenCalledTimes(1);
       });
+      it('should call the onDayPickerShow callback', () => {
+        const onDayPickerShow = jest.fn();
+        const wrapper = mount(
+          <DayPickerInput onDayPickerShow={onDayPickerShow} />
+        );
+
+        wrapper.find('input').simulate('click');
+
+        expect(onDayPickerShow).toHaveBeenCalledTimes(1);
+      });
     });
 
     describe('focus', () => {
@@ -44,6 +54,16 @@ describe('DayPickerInput', () => {
         const wrapper = mount(<DayPickerInput inputProps={{ onFocus }} />);
         wrapper.find('input').simulate('focus');
         expect(onFocus).toHaveBeenCalledTimes(1);
+      });
+      it('should call the onDayPickerShow callback', () => {
+        const onDayPickerShow = jest.fn();
+        const wrapper = mount(
+          <DayPickerInput onDayPickerShow={onDayPickerShow} />
+        );
+
+        wrapper.find('input').simulate('focus');
+
+        expect(onDayPickerShow).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -194,6 +214,19 @@ describe('DayPickerInput', () => {
         wrapper.find('input').simulate('keydown', { keyCode: keys.TAB });
         expect(wrapper.state('showOverlay')).toBe(false);
       });
+      it('should show the overlay and call onDayPickerShow on any other key', () => {
+        const onDayPickerShow = jest.fn();
+        const wrapper = mount(
+          <DayPickerInput onDayPickerShow={onDayPickerShow} />
+        );
+
+        expect(wrapper.state('showOverlay')).toBe(false);
+
+        wrapper.find('input').simulate('keydown');
+
+        expect(wrapper.state('showOverlay')).toBe(true);
+        expect(onDayPickerShow).toHaveBeenCalledTimes(1);
+      });
       it('should call `onKeyDown` event handler', () => {
         const onKeyDown = jest.fn();
         const wrapper = mount(<DayPickerInput inputProps={{ onKeyDown }} />);
@@ -208,6 +241,19 @@ describe('DayPickerInput', () => {
         wrapper.update();
         wrapper.find('input').simulate('keyup', { keyCode: keys.ESC });
         expect(wrapper.state('showOverlay')).toBe(false);
+      });
+      it('should show the overlay and call onDayPickerShow on any other key', () => {
+        const onDayPickerShow = jest.fn();
+        const wrapper = mount(
+          <DayPickerInput onDayPickerShow={onDayPickerShow} />
+        );
+
+        expect(wrapper.state('showOverlay')).toBe(false);
+
+        wrapper.find('input').simulate('keyup');
+
+        expect(wrapper.state('showOverlay')).toBe(true);
+        expect(onDayPickerShow).toHaveBeenCalledTimes(1);
       });
       it('should call `onKeyUp` event handler', () => {
         const onKeyUp = jest.fn();

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -181,6 +181,7 @@ export interface DayPickerInputProps {
     dayPickerInput: DayPickerInput
   ): void;
   onDayPickerHide?(): void;
+  onDayPickerShow?(): void;
   onChange?(e: React.FocusEvent<HTMLDivElement>): void;
   onClick?(e: React.FocusEvent<HTMLDivElement>): void;
   onFocus?(e: React.FocusEvent<HTMLDivElement>): void;


### PR DESCRIPTION
👋 Hello.

While working with `react-day-picker`, I ran into a situation where I wanted to know whether the day picker was open. To help with figuring that out, this PR exposes an `onDayPickerShow` callback to complement the `onDayPickerHide` callback that already exists.

Typically I'd instead opt for keeping the `showOverlay` state local to my own component and use this as a controlled component, but it doesn't look like that is possible (if we'd rather have the ability to do that, I'm willing to open a PR or modify this one to support that instead, but I think we'd still need this callback to know when to set that state to `true`)