### PR TITLE
Add style prop to DayPickerInput

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -108,6 +108,7 @@ export default class DayPickerInput extends React.Component {
     component: PropTypes.any,
     overlayComponent: PropTypes.any,
 
+    style: PropTypes.any,
     classNames: PropTypes.shape({
       container: PropTypes.string,
       overlayWrapper: PropTypes.string,
@@ -561,7 +562,7 @@ export default class DayPickerInput extends React.Component {
     const Input = this.props.component;
     const { inputProps } = this.props;
     return (
-      <div className={this.props.classNames.container}>
+      <div className={this.props.classNames.container} style={this.props.style}>
         <Input
           ref={el => (this.input = el)}
           placeholder={this.props.placeholder}

--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -108,7 +108,7 @@ export default class DayPickerInput extends React.Component {
     component: PropTypes.any,
     overlayComponent: PropTypes.any,
 
-    style: PropTypes.any,
+    style: PropTypes.object,
     classNames: PropTypes.shape({
       container: PropTypes.string,
       overlayWrapper: PropTypes.string,


### PR DESCRIPTION
I found it would be useful to have `style` prop passed down to container div of `DayPickerInput`. Sometimes it's much more handy to just apply some small inline styles instead of creating or modifying css classes.

```javascript
// for example if you want to make only this one specific `DatePickerInput` fluid
<DayPickerInput style={{ width: '100%' }} />
```