### PR TITLE
Added missing default entries to ClassNames

### DIFF
--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -15,9 +15,12 @@ export interface ClassNames {
   weekdays: string;
   weekdaysRow: string;
   weekday: string;
+  weekNumber: string;
   body: string;
   week: string;
   day: string;
+  footer: string;
+  todayButton: string;
 
   today: string;
   selected: string;


### PR DESCRIPTION
Added 3 missing entries from 
```
https://github.com/gpbl/react-day-picker/blob/master/src/classNames.js
```
to the definition.