### PR TITLE
Add missing utils export in TS definitions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,3 +5,4 @@ export default DayPicker;
 
 export * from './common';
 export * from './props';
+export * from './utils';


### PR DESCRIPTION
At the moment it's not possible to import `LocaleUtils`, `DateUtils`, `ModifiersUtils` in Typescript projects, because the utils export is missing in the definition file.
Fixes #812;

![image](https://user-images.githubusercontent.com/992674/49155614-abfdbe80-f31b-11e8-8d7d-35ea6e4ea24f.png)
