### PR TITLE
Add missing props from weekdayElement and caption Element

### DIFF
--- a/docs/src/pages/api/DayPicker.js
+++ b/docs/src/pages/api/DayPicker.js
@@ -67,9 +67,8 @@ export default () => (
 
     <h4>Event handlers</h4>
     <p>
-      <a href="#onBlur">onBlur</a>, <a href="#onCaptionClick">onCaptionClick</a>
-      , <a href="#onDayClick">onDayClick</a>,{' '}
-      <a href="#onDayFocus">onDayFocus</a>,{' '}
+      <a href="#onBlur">onBlur</a>, <a href="#onCaptionClick">onCaptionClick</a>,{' '}
+      <a href="#onDayClick">onDayClick</a>, <a href="#onDayFocus">onDayFocus</a>,{' '}
       <a href="#onDayKeyDown">onDayKeyDown</a>,{' '}
       <a href="#onDayMouseDown">onDayMouseDown</a>,{' '}
       <a href="#onDayMouseEnter">onDayMouseEnter</a>,{' '}
@@ -126,10 +125,6 @@ export default () => (
         <li>
           <code>onClick</code> The <a href="#onCaptionClick">onCaptionClick</a>{' '}
           function, if specified.
-        </li>
-        <li>
-          <code>months: string[]</code> The <a href="#months">months</a> if
-          specified.
         </li>
       </ul>
       <p>
@@ -253,8 +248,7 @@ export default () => (
         with the days before it. See also{' '}
         <a href="#toMonth">
           <code>toMonth</code>
-        </a>
-        .
+        </a>.
       </p>
       <h3>
         <Anchor id="initialMonth" />
@@ -391,8 +385,7 @@ export default () => (
       </h3>
       <p>
         Returns the content of a day cell. As default it returns{' '}
-        <code>day</code>
-        ’s current date.
+        <code>day</code>’s current date.
       </p>
       <h3>
         <Anchor id="renderWeek" />
@@ -441,9 +434,9 @@ export default () => (
         showWeekNumbers <code>boolean = false</code>
       </h3>
       <p>
-        Display the year’s week number next to each week (
-        <Link to="/examples/customization-week-numbers">example</Link>
-        ).
+        Display the year’s week number next to each week (<Link to="/examples/customization-week-numbers">
+          example
+        </Link>).
       </p>
       <h3>
         <Anchor id="todayButton" />
@@ -462,8 +455,7 @@ export default () => (
         the days after it. See also{' '}
         <a href="#fromMonth">
           <code>fromMonth</code>
-        </a>
-        .
+        </a>.
       </p>
 
       <h3>
@@ -488,15 +480,8 @@ export default () => (
         <li>
           locale <code>string</code>
         </li>
-        <li>
-          weekdaysShort <code>string[]</code> The{' '}
-          <a href="#weekdaysShort">weekdaysShort</a> if specified.
-        </li>
-        <li>
-          weekdaysLong <code>string[]</code> The{' '}
-          <a href="#weekdaysLong">weekdaysLong</a> if specified.
-        </li>
       </ul>
+
       <h3>
         <Anchor id="weekdaysLong" />
         weekdaysLong <code>string[]</code>
@@ -642,8 +627,7 @@ export default () => (
       <p>
         Event hander when the user clicks on a week number (when{' '}
         <a href="#showWeekNumbers">showWeekNumbers</a> is set to{' '}
-        <code>true</code>
-        ).
+        <code>true</code>).
       </p>
       <h3>
         <Anchor id="onTodayButtonClick" />

--- a/docs/src/pages/api/DayPicker.js
+++ b/docs/src/pages/api/DayPicker.js
@@ -67,8 +67,9 @@ export default () => (
 
     <h4>Event handlers</h4>
     <p>
-      <a href="#onBlur">onBlur</a>, <a href="#onCaptionClick">onCaptionClick</a>,{' '}
-      <a href="#onDayClick">onDayClick</a>, <a href="#onDayFocus">onDayFocus</a>,{' '}
+      <a href="#onBlur">onBlur</a>, <a href="#onCaptionClick">onCaptionClick</a>
+      , <a href="#onDayClick">onDayClick</a>,{' '}
+      <a href="#onDayFocus">onDayFocus</a>,{' '}
       <a href="#onDayKeyDown">onDayKeyDown</a>,{' '}
       <a href="#onDayMouseDown">onDayMouseDown</a>,{' '}
       <a href="#onDayMouseEnter">onDayMouseEnter</a>,{' '}
@@ -125,6 +126,10 @@ export default () => (
         <li>
           <code>onClick</code> The <a href="#onCaptionClick">onCaptionClick</a>{' '}
           function, if specified.
+        </li>
+        <li>
+          <code>months: string[]</code> The <a href="#months">months</a> if
+          specified.
         </li>
       </ul>
       <p>
@@ -248,7 +253,8 @@ export default () => (
         with the days before it. See also{' '}
         <a href="#toMonth">
           <code>toMonth</code>
-        </a>.
+        </a>
+        .
       </p>
       <h3>
         <Anchor id="initialMonth" />
@@ -385,7 +391,8 @@ export default () => (
       </h3>
       <p>
         Returns the content of a day cell. As default it returns{' '}
-        <code>day</code>’s current date.
+        <code>day</code>
+        ’s current date.
       </p>
       <h3>
         <Anchor id="renderWeek" />
@@ -434,9 +441,9 @@ export default () => (
         showWeekNumbers <code>boolean = false</code>
       </h3>
       <p>
-        Display the year’s week number next to each week (<Link to="/examples/customization-week-numbers">
-          example
-        </Link>).
+        Display the year’s week number next to each week (
+        <Link to="/examples/customization-week-numbers">example</Link>
+        ).
       </p>
       <h3>
         <Anchor id="todayButton" />
@@ -455,7 +462,8 @@ export default () => (
         the days after it. See also{' '}
         <a href="#fromMonth">
           <code>fromMonth</code>
-        </a>.
+        </a>
+        .
       </p>
 
       <h3>
@@ -480,8 +488,15 @@ export default () => (
         <li>
           locale <code>string</code>
         </li>
+        <li>
+          weekdaysShort <code>string[]</code> The{' '}
+          <a href="#weekdaysShort">weekdaysShort</a> if specified.
+        </li>
+        <li>
+          weekdaysLong <code>string[]</code> The{' '}
+          <a href="#weekdaysLong">weekdaysLong</a> if specified.
+        </li>
       </ul>
-
       <h3>
         <Anchor id="weekdaysLong" />
         weekdaysLong <code>string[]</code>
@@ -627,7 +642,8 @@ export default () => (
       <p>
         Event hander when the user clicks on a week number (when{' '}
         <a href="#showWeekNumbers">showWeekNumbers</a> is set to{' '}
-        <code>true</code>).
+        <code>true</code>
+        ).
       </p>
       <h3>
         <Anchor id="onTodayButtonClick" />

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -64,7 +64,20 @@ export interface DayPickerProps {
   modifiers?: Partial<Modifiers>;
   modifiersStyles?: object;
   month?: Date;
-  months?: string[];
+  months?: [
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string
+  ];
   navbarElement?:
     | React.ReactElement<Partial<NavbarElementProps>>
     | React.ComponentClass<NavbarElementProps>
@@ -138,8 +151,8 @@ export interface DayPickerProps {
     | React.ReactElement<Partial<WeekdayElementProps>>
     | React.ComponentClass<WeekdayElementProps>
     | React.SFC<WeekdayElementProps>;
-  weekdaysLong?: string[];
-  weekdaysShort?: string[];
+  weekdaysLong?: [string, string, string, string, string, string, string];
+  weekdaysShort?: [string, string, string, string, string, string, string];
 }
 
 export interface DayPickerInputProps {

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -10,7 +10,7 @@ export interface CaptionElementProps {
   classNames: ClassNames;
   localeUtils: LocaleUtils;
   locale: string;
-  months: undefined;
+  months?: string[];
   onClick?: React.MouseEventHandler<HTMLElement>;
 }
 
@@ -35,6 +35,8 @@ export interface WeekdayElementProps {
   className: string;
   localeUtils: LocaleUtils;
   locale: string;
+  weekdaysLong?: string[];
+  weekdaysShort?: string[];
 }
 
 export interface DayPickerProps {
@@ -62,20 +64,7 @@ export interface DayPickerProps {
   modifiers?: Partial<Modifiers>;
   modifiersStyles?: object;
   month?: Date;
-  months?: [
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string
-  ];
+  months?: string[];
   navbarElement?:
     | React.ReactElement<Partial<NavbarElementProps>>
     | React.ComponentClass<NavbarElementProps>
@@ -149,8 +138,8 @@ export interface DayPickerProps {
     | React.ReactElement<Partial<WeekdayElementProps>>
     | React.ComponentClass<WeekdayElementProps>
     | React.SFC<WeekdayElementProps>;
-  weekdaysLong?: [string, string, string, string, string, string, string];
-  weekdaysShort?: [string, string, string, string, string, string, string];
+  weekdaysLong?: string[];
+  weekdaysShort?: string[];
 }
 
 export interface DayPickerInputProps {


### PR DESCRIPTION
Changes:

I think the typings on `captionElement` and `weekdayElement` are wrong, and I think the documentation is wrong too. Looking at the default props that `DayPicker` receives, it's clear that the `months` `weekdaysShort` and `weekdaysLong` are passed through to those elements if they are specified on the `DayPicker`. This makes sense, how else will those elements be localized correctly. Therefore if I provide my own elements for the caption or weekday they'll need those props too.

They actually get them :+1: so the only thing that's missing is to update the types. which I've done

I'd also would've updated the docs, but the template advised against that. I will volunteer to update them though :).