### PR TITLE
Make months and weekdays types slightly less restrictive

### DIFF
--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -62,20 +62,7 @@ export interface DayPickerProps {
   modifiers?: Partial<Modifiers>;
   modifiersStyles?: object;
   month?: Date;
-  months?: [
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string
-  ];
+  months?: string[];
   navbarElement?:
     | React.ReactElement<Partial<NavbarElementProps>>
     | React.ComponentClass<NavbarElementProps>
@@ -149,8 +136,8 @@ export interface DayPickerProps {
     | React.ReactElement<Partial<WeekdayElementProps>>
     | React.ComponentClass<WeekdayElementProps>
     | React.SFC<WeekdayElementProps>;
-  weekdaysLong?: [string, string, string, string, string, string, string];
-  weekdaysShort?: [string, string, string, string, string, string, string];
+  weekdaysLong?: string[];
+  weekdaysShort?: string[];
 }
 
 export interface DayPickerInputProps {


### PR DESCRIPTION
I think the typings for `months`, `weekdaysLong` and `weekdaysShort` are too strict. For instance, I get a type error from the following

```
const months = ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'];

<DayPicker
  months={months}
  ...
/>
```

because the inferred type of the months variable is `string[]`. Whilst the current typings for `months`, `weekdaysLong` and `weekdaysShort` are strictly true in requiring 12, 7 and 7 entries, typescript has difficulty in inferring those types and this makes them unwieldy to use in practice. I suggest loosening them slightly to be `sting[]`.
