### PR TITLE
Mark handled keydown events as handled

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -382,15 +382,19 @@ export class DayPicker extends Component {
     switch (e.keyCode) {
       case LEFT:
         this.showPreviousMonth();
+        Helpers.cancelEvent(e);
         break;
       case RIGHT:
         this.showNextMonth();
+        Helpers.cancelEvent(e);
         break;
       case UP:
         this.showPreviousYear();
+        Helpers.cancelEvent(e);
         break;
       case DOWN:
         this.showNextYear();
+        Helpers.cancelEvent(e);
         break;
       default:
         break;


### PR DESCRIPTION
The Arrow keys are used by the browser to scroll, and `DayPicker` uses them to navigate months and years on the body of the `DayPicker`. Currently these events are not marked as handled so the browser does it's default action - which is scrolling when in a container that scrolls, and they bubble to anyone else listening higher up the tree. I've used the cancel event helper to stop that happening.

Here is a sandbox that highlights the issue https://codesandbox.io/s/1q60jqr9ml
