### PR TITLE
Switch what left and right keys do in RTL

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -378,13 +378,14 @@ export class DayPicker extends Component {
 
   handleKeyDown = e => {
     e.persist();
+    const isRtl = this.props.dir === 'rtl';
 
     switch (e.keyCode) {
       case LEFT:
-        this.showPreviousMonth();
+        isRtl ? this.showNextMonth() : this.showPreviousMonth();
         break;
       case RIGHT:
-        this.showNextMonth();
+        isRtl ? this.showPreviousMonth() : this.showNextMonth();
         break;
       case UP:
         this.showPreviousYear();
@@ -403,14 +404,16 @@ export class DayPicker extends Component {
 
   handleDayKeyDown = (day, modifiers, e) => {
     e.persist();
+    const isRTL = this.props.dir === 'rtl';
+
     switch (e.keyCode) {
       case LEFT:
         Helpers.cancelEvent(e);
-        this.focusPreviousDay(e.target);
+        isRTL ? this.focusNextDay(e.target) : this.focusPreviousDay(e.target);
         break;
       case RIGHT:
         Helpers.cancelEvent(e);
-        this.focusNextDay(e.target);
+        isRTL ? this.focusPreviousDay(e.target) : this.focusNextDay(e.target);
         break;
       case UP:
         Helpers.cancelEvent(e);

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -378,14 +378,21 @@ export class DayPicker extends Component {
 
   handleKeyDown = e => {
     e.persist();
-    const isRtl = this.props.dir === 'rtl';
 
     switch (e.keyCode) {
       case LEFT:
-        isRtl ? this.showNextMonth() : this.showPreviousMonth();
+        if (this.props.dir === 'rtl') {
+          this.showNextMonth();
+        } else {
+          this.showPreviousMonth();
+        }
         break;
       case RIGHT:
-        isRtl ? this.showPreviousMonth() : this.showNextMonth();
+        if (this.props.dir === 'rtl') {
+          this.showPreviousMonth();
+        } else {
+          this.showNextMonth();
+        }
         break;
       case UP:
         this.showPreviousYear();
@@ -404,16 +411,23 @@ export class DayPicker extends Component {
 
   handleDayKeyDown = (day, modifiers, e) => {
     e.persist();
-    const isRTL = this.props.dir === 'rtl';
 
     switch (e.keyCode) {
       case LEFT:
         Helpers.cancelEvent(e);
-        isRTL ? this.focusNextDay(e.target) : this.focusPreviousDay(e.target);
+        if (this.props.dir === 'rtl') {
+          this.focusNextDay(e.target);
+        } else {
+          this.focusPreviousDay(e.target);
+        }
         break;
       case RIGHT:
         Helpers.cancelEvent(e);
-        isRTL ? this.focusPreviousDay(e.target) : this.focusNextDay(e.target);
+        if (this.props.dir === 'rtl') {
+          this.focusPreviousDay(e.target);
+        } else {
+          this.focusNextDay(e.target);
+        }
         break;
       case UP:
         Helpers.cancelEvent(e);

--- a/test/daypicker/navigation.js
+++ b/test/daypicker/navigation.js
@@ -157,6 +157,27 @@ describe('DayPicker’s navigation', () => {
     expect(showPreviousMonth).toHaveBeenCalledTimes(1);
     showPreviousMonth.mockReset();
   });
+  it('should call `showPreviousMonth()` when the RIGHT key is pressed and the direction is rtl', () => {
+    const wrapper = mount(<DayPicker dir="rtl" />);
+    const showPreviousMonth = jest.spyOn(
+      wrapper.instance(),
+      'showPreviousMonth'
+    );
+    wrapper
+      .find('.DayPicker-wrapper')
+      .simulate('keyDown', { keyCode: keys.RIGHT });
+    expect(showPreviousMonth).toHaveBeenCalledTimes(1);
+    showPreviousMonth.mockReset();
+  });
+  it('should call `showNextMonth()` when the LEFT key is pressed and the direction is rtl', () => {
+    const wrapper = mount(<DayPicker dir="rtl" />);
+    const showNextMonth = jest.spyOn(wrapper.instance(), 'showNextMonth');
+    wrapper
+      .find('.DayPicker-wrapper')
+      .simulate('keyDown', { keyCode: keys.LEFT });
+    expect(showNextMonth).toHaveBeenCalledTimes(1);
+    showNextMonth.mockReset();
+  });
   it('should call `showPreviousYear()` when the UP key is pressed', () => {
     const wrapper = mount(<DayPicker />);
     const showPreviousYear = jest.spyOn(wrapper.instance(), 'showPreviousYear');
@@ -196,6 +217,28 @@ describe('DayPicker’s navigation', () => {
       .simulate('keyDown', { keyCode: keys.LEFT });
     expect(focusPreviousDay).toHaveBeenCalledTimes(1);
     focusPreviousDay.mockReset();
+  });
+  it('should call `focusPreviousDay()` when the RIGHT key is pressed on a day and the direction is rtl', () => {
+    const wrapper = mount(<DayPicker dir="rtl" />);
+    const focusPreviousDay = jest.spyOn(wrapper.instance(), 'focusPreviousDay');
+    wrapper
+      .find('.DayPicker-Day')
+      .filterWhere(node => !node.hasClass('DayPicker-Day--outside'))
+      .first()
+      .simulate('keyDown', { keyCode: keys.RIGHT });
+    expect(focusPreviousDay).toHaveBeenCalledTimes(1);
+    focusPreviousDay.mockReset();
+  });
+  it('should call `focusNextDay()` when the LEFT key is pressed on a day and the direction is rtl', () => {
+    const wrapper = mount(<DayPicker dir="rtl" />);
+    const focusNextDay = jest.spyOn(wrapper.instance(), 'focusNextDay');
+    wrapper
+      .find('.DayPicker-Day')
+      .filterWhere(node => !node.hasClass('DayPicker-Day--outside'))
+      .first()
+      .simulate('keyDown', { keyCode: keys.LEFT });
+    expect(focusNextDay).toHaveBeenCalledTimes(1);
+    focusNextDay.mockReset();
   });
   it('should call `focusNextWeek()` when the DOWN key is pressed on a day', () => {
     const wrapper = mount(<DayPicker />);

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -49,6 +49,7 @@ export interface DayPickerProps {
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
   >;
+  dir?: string;
   disabledDays?: Modifier | Modifier[];
   showOutsideDays?: boolean;
   enableOutsideDaysClick?: boolean;


### PR DESCRIPTION
Fix for #837:

Basically, it used the dir prop to decide how to handle the left and right arrows being pressed, switching what they do in RTL.

I've also added the missing `dir` prop to the `DayPickerProps` interface.

The docs for dir usage are missing right now... it would be good to add them, I'd be happy to do that as part of this PR - although the PR template warns against making any changes to the docs
