### PR TITLE
Hide overlay on overlayblur

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -394,6 +394,7 @@ export default class DayPickerInput extends React.Component {
     // focusing it
     this.overlayBlurTimeout = setTimeout(() => {
       this.overlayHasFocus = false;
+      this.setState({ showOverlay: false });
     }, 3);
   }
 


### PR DESCRIPTION
This PR addresses the bug described in issue #819.  

Old behavior: When using a custom overlay, after clicking on anything in the overlay, then clicking away, the overlay does not close. Once the overlay has been focused, the only way to make the overlay close is to click on the input and then click away.

New behavior: After clicking on anything in the overlay, then clicking away, the overlay will close.

Note: With this PR - If the user clicks on the input field, after clicking on something inside of the overlay, the overlay will momentarily close and then reopen. This is not ideal, but it is better than the current behavior. If there is a preferred way to avoid calling `setState` when clicking on the input field, let's do that instead 👍.

🚀 Amazing library 🚀  I hope this PR helps