### PR TITLE
Fix different time when date is typed in the input field

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -83,7 +83,7 @@ export function defaultParse(str) {
     return undefined;
   }
 
-  return new Date(year, month, day);
+  return new Date(year, month, day, 12, 0, 0, 0); // always set noon to avoid time zone issues
 }
 
 export default class DayPickerInput extends React.Component {
@@ -410,12 +410,14 @@ export default class DayPickerInput extends React.Component {
       inputProps.onChange(e);
     }
     const { value } = e.target;
+
     if (value.trim() === '') {
       this.setState({ value, typedValue: undefined });
       if (onDayChange) onDayChange(undefined, {}, this);
       return;
     }
     const day = parseDate(value, format, dayPickerProps.locale);
+
     if (!day) {
       // Day is invalid: we save the value in the typedValue state
       this.setState({ value, typedValue: value });

--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -410,14 +410,12 @@ export default class DayPickerInput extends React.Component {
       inputProps.onChange(e);
     }
     const { value } = e.target;
-
     if (value.trim() === '') {
       this.setState({ value, typedValue: undefined });
       if (onDayChange) onDayChange(undefined, {}, this);
       return;
     }
     const day = parseDate(value, format, dayPickerProps.locale);
-
     if (!day) {
       // Day is invalid: we save the value in the typedValue state
       this.setState({ value, typedValue: value });

--- a/test/daypickerinput/events.js
+++ b/test/daypickerinput/events.js
@@ -188,7 +188,9 @@ describe('DayPickerInput', () => {
         wrapper.update();
         input.simulate('change', { target: { value: '2015-12-20' } });
         expect(onDayChange).toHaveBeenCalledTimes(1);
-        expect(onDayChange.mock.calls[0][0]).toEqual(new Date(2015, 11, 20));
+        expect(onDayChange.mock.calls[0][0]).toEqual(
+          new Date(2015, 11, 20, 12, 0, 0, 0)
+        );
         expect(onDayChange.mock.calls[0][1]).toEqual({
           foo: true,
           selected: true,

--- a/test/daypickerinput/methods.js
+++ b/test/daypickerinput/methods.js
@@ -48,7 +48,7 @@ describe('DayPickerInput', () => {
     });
     it('should return a parsed date', () => {
       const parsed = defaultParse('2018-7-12');
-      expect(parsed).toEqual(new Date(2018, 6, 12));
+      expect(parsed).toEqual(new Date(2018, 6, 12, 12, 0, 0, 0));
     });
   });
 });


### PR DESCRIPTION
This is a fix for #875

it sets the time to 12:00:00 after parsing manual input