### PR TITLE
Added formatDate&parseDate definitions for MomentLocaleUtils

### DIFF
--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -24,6 +24,8 @@ export interface LocaleUtils {
     string,
     string
   ];
+  formatDate(date: Date, format?: string, locale?: string ): string;
+  parseDate(dateString: string, format?: string, locale?: string): Date;
 }
 
 export interface DateUtils {

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -24,7 +24,7 @@ export interface LocaleUtils {
     string,
     string
   ];
-  formatDate(date: Date, format?: string, locale?: string ): string;
+  formatDate(date: Date, format?: string, locale?: string): string;
   parseDate(dateString: string, format?: string, locale?: string): Date;
 }
 


### PR DESCRIPTION
type definitions for `formatDate` and `parseDate` were missing, so I added them.

As described I added missing type definitions to the MomentLocaleUtils.

Since I'm fairly new to writing typescript definitions it would be great if someone who's good with TS reviews my change.
