### PR TITLE
Merge default class names with class names from props

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -10,7 +10,7 @@ import * as Helpers from './Helpers';
 import * as DateUtils from './DateUtils';
 import * as LocaleUtils from './LocaleUtils';
 import * as ModifiersUtils from './ModifiersUtils';
-import classNames from './classNames';
+import defaultClassNames from './classNames';
 
 import { ENTER, SPACE, LEFT, UP, DOWN, RIGHT } from './keys';
 
@@ -130,7 +130,7 @@ export class DayPicker extends Component {
   };
 
   static defaultProps = {
-    classNames,
+    classNames: defaultClassNames,
     tabIndex: 0,
     initialMonth: new Date(),
     numberOfMonths: 1,
@@ -151,8 +151,8 @@ export class DayPicker extends Component {
     renderDay: day => day.getDate(),
     renderWeek: weekNumber => weekNumber,
     weekdayElement: <Weekday />,
-    navbarElement: <Navbar classNames={classNames} />,
-    captionElement: <Caption classNames={classNames} />,
+    navbarElement: <Navbar classNames={defaultClassNames} />,
+    captionElement: <Caption classNames={defaultClassNames} />,
   };
 
   dayPicker = null;
@@ -174,6 +174,12 @@ export class DayPicker extends Component {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ currentMonth });
     }
+  }
+
+  get classNames() {
+    return this.props.classNames === defaultClassNames
+      ? defaultClassNames
+      : { ...defaultClassNames, ...this.props.classNames };
   }
 
   /**
@@ -306,16 +312,16 @@ export class DayPicker extends Component {
   }
 
   focusFirstDayOfMonth() {
-    Helpers.getDayNodes(this.dayPicker, this.props.classNames)[0].focus();
+    Helpers.getDayNodes(this.dayPicker, this.classNames)[0].focus();
   }
 
   focusLastDayOfMonth() {
-    const dayNodes = Helpers.getDayNodes(this.dayPicker, this.props.classNames);
+    const dayNodes = Helpers.getDayNodes(this.dayPicker, this.classNames);
     dayNodes[dayNodes.length - 1].focus();
   }
 
   focusPreviousDay(dayNode) {
-    const dayNodes = Helpers.getDayNodes(this.dayPicker, this.props.classNames);
+    const dayNodes = Helpers.getDayNodes(this.dayPicker, this.classNames);
     const dayNodeIndex = Helpers.nodeListToArray(dayNodes).indexOf(dayNode);
     if (dayNodeIndex === -1) return;
     if (dayNodeIndex === 0) {
@@ -326,7 +332,7 @@ export class DayPicker extends Component {
   }
 
   focusNextDay(dayNode) {
-    const dayNodes = Helpers.getDayNodes(this.dayPicker, this.props.classNames);
+    const dayNodes = Helpers.getDayNodes(this.dayPicker, this.classNames);
     const dayNodeIndex = Helpers.nodeListToArray(dayNodes).indexOf(dayNode);
     if (dayNodeIndex === -1) return;
     if (dayNodeIndex === dayNodes.length - 1) {
@@ -337,7 +343,7 @@ export class DayPicker extends Component {
   }
 
   focusNextWeek(dayNode) {
-    const dayNodes = Helpers.getDayNodes(this.dayPicker, this.props.classNames);
+    const dayNodes = Helpers.getDayNodes(this.dayPicker, this.classNames);
     const dayNodeIndex = Helpers.nodeListToArray(dayNodes).indexOf(dayNode);
     const isInLastWeekOfMonth = dayNodeIndex > dayNodes.length - 8;
 
@@ -345,7 +351,7 @@ export class DayPicker extends Component {
       this.showNextMonth(() => {
         const daysAfterIndex = dayNodes.length - dayNodeIndex;
         const nextMonthDayNodeIndex = 7 - daysAfterIndex;
-        Helpers.getDayNodes(this.dayPicker, this.props.classNames)[
+        Helpers.getDayNodes(this.dayPicker, this.classNames)[
           nextMonthDayNodeIndex
         ].focus();
       });
@@ -355,7 +361,7 @@ export class DayPicker extends Component {
   }
 
   focusPreviousWeek(dayNode) {
-    const dayNodes = Helpers.getDayNodes(this.dayPicker, this.props.classNames);
+    const dayNodes = Helpers.getDayNodes(this.dayPicker, this.classNames);
     const dayNodeIndex = Helpers.nodeListToArray(dayNodes).indexOf(dayNode);
     const isInFirstWeekOfMonth = dayNodeIndex <= 6;
 
@@ -363,7 +369,7 @@ export class DayPicker extends Component {
       this.showPreviousMonth(() => {
         const previousMonthDayNodes = Helpers.getDayNodes(
           this.dayPicker,
-          this.props.classNames
+          this.classNames
         );
         const startOfLastWeekOfMonth = previousMonthDayNodes.length - 7;
         const previousMonthDayNodeIndex = startOfLastWeekOfMonth + dayNodeIndex;
@@ -460,7 +466,7 @@ export class DayPicker extends Component {
     e.persist();
 
     if (
-      modifiers[this.props.classNames.outside] &&
+      modifiers[this.classNames.outside] &&
       this.props.enableOutsideDaysClick
     ) {
       this.handleOutsideDayClick(day);
@@ -510,8 +516,8 @@ export class DayPicker extends Component {
 
     const props = {
       month: this.state.currentMonth,
-      classNames: this.props.classNames,
-      className: this.props.classNames.navBar,
+      classNames: this.classNames,
+      className: this.classNames.navBar,
       nextMonth: this.getNextNavigableMonth(),
       previousMonth: this.getPreviousNavigableMonth(),
       showPreviousButton: this.allowPreviousMonth(),
@@ -554,9 +560,7 @@ export class DayPicker extends Component {
   renderFooter() {
     if (this.props.todayButton) {
       return (
-        <div className={this.props.classNames.footer}>
-          {this.renderTodayButton()}
-        </div>
+        <div className={this.classNames.footer}>{this.renderTodayButton()}</div>
       );
     }
     return null;
@@ -567,7 +571,7 @@ export class DayPicker extends Component {
       <button
         type="button"
         tabIndex={0}
-        className={this.props.classNames.todayButton}
+        className={this.classNames.todayButton}
         aria-label={this.props.todayButton}
         onClick={this.handleTodayButtonClick}
       >
@@ -577,10 +581,10 @@ export class DayPicker extends Component {
   }
 
   render() {
-    let className = this.props.classNames.container;
+    let className = this.classNames.container;
 
     if (!this.props.onDayClick) {
-      className = `${className} ${this.props.classNames.interactionDisabled}`;
+      className = `${className} ${this.classNames.interactionDisabled}`;
     }
     if (this.props.className) {
       className = `${className} ${this.props.className}`;
@@ -593,7 +597,7 @@ export class DayPicker extends Component {
         lang={this.props.locale}
       >
         <div
-          className={this.props.classNames.wrapper}
+          className={this.classNames.wrapper}
           tabIndex={
             this.props.canChangeMonth &&
             typeof this.props.tabIndex !== 'undefined'
@@ -605,9 +609,7 @@ export class DayPicker extends Component {
           onBlur={this.props.onBlur}
         >
           {this.renderNavbar()}
-          <div className={this.props.classNames.months}>
-            {this.renderMonths()}
-          </div>
+          <div className={this.classNames.months}>{this.renderMonths()}</div>
           {this.renderFooter()}
         </div>
       </div>

--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -86,6 +86,12 @@ export function defaultParse(str) {
   return new Date(year, month, day);
 }
 
+const defaultClassNames = {
+  container: 'DayPickerInput',
+  overlayWrapper: 'DayPickerInput-OverlayWrapper',
+  overlay: 'DayPickerInput-Overlay',
+};
+
 export default class DayPickerInput extends React.Component {
   static propTypes = {
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
@@ -139,11 +145,7 @@ export default class DayPickerInput extends React.Component {
     component: 'input',
     inputProps: {},
     overlayComponent: OverlayComponent,
-    classNames: {
-      container: 'DayPickerInput',
-      overlayWrapper: 'DayPickerInput-OverlayWrapper',
-      overlay: 'DayPickerInput-Overlay',
-    },
+    classNames: defaultClassNames,
   };
 
   input = null;
@@ -219,6 +221,12 @@ export default class DayPickerInput extends React.Component {
     clearTimeout(this.inputFocusTimeout);
     clearTimeout(this.inputBlurTimeout);
     clearTimeout(this.overlayBlurTimeout);
+  }
+
+  get classNames() {
+    return this.props.classNames === defaultClassNames
+      ? defaultClassNames
+      : { ...defaultClassNames, ...this.props.classNames };
   }
 
   getInitialMonthFromProps(props) {
@@ -513,13 +521,7 @@ export default class DayPickerInput extends React.Component {
   }
 
   renderOverlay() {
-    const {
-      classNames,
-      dayPickerProps,
-      parseDate,
-      formatDate,
-      format,
-    } = this.props;
+    const { dayPickerProps, parseDate, formatDate, format } = this.props;
     const { selectedDays, value } = this.state;
     let selectedDay;
     if (!selectedDays && value) {
@@ -543,7 +545,7 @@ export default class DayPickerInput extends React.Component {
     const Overlay = this.props.overlayComponent;
     return (
       <Overlay
-        classNames={classNames}
+        classNames={this.classNames}
         month={this.state.month}
         selectedDay={selectedDay}
         input={this.input}
@@ -568,7 +570,7 @@ export default class DayPickerInput extends React.Component {
     const Input = this.props.component;
     const { inputProps } = this.props;
     return (
-      <div className={this.props.classNames.container} style={this.props.style}>
+      <div className={this.classNames.container} style={this.props.style}>
         <Input
           ref={el => (this.input = el)}
           placeholder={this.props.placeholder}


### PR DESCRIPTION
Default class names are overwritten when passing not all classes to `classNames` prop.

If you want to change one of the classes you should do something like that:
```jsx
<DayPicker
  classNames={{
    // only want to change styles for container
    container: styles.container, 
    
    // must add this for saving default styles
    wrapper: 'DayPicker-wrapper',
    interactionDisabled: 'DayPicker--interactionDisabled',
    months: 'DayPicker-Months',
    month: 'DayPicker-Month',

    navBar: 'DayPicker-NavBar',
    navButtonPrev: 'DayPicker-NavButton DayPicker-NavButton--prev',
    navButtonNext: 'DayPicker-NavButton DayPicker-NavButton--next',
    navButtonInteractionDisabled: 'DayPicker-NavButton--interactionDisabled',

    caption: 'DayPicker-Caption',
    weekdays: 'DayPicker-Weekdays',
    weekdaysRow: 'DayPicker-WeekdaysRow',
    weekday: 'DayPicker-Weekday',
    body: 'DayPicker-Body',
    week: 'DayPicker-Week',
    weekNumber: 'DayPicker-WeekNumber',
    day: 'DayPicker-Day',
    footer: 'DayPicker-Footer',
    todayButton: 'DayPicker-TodayButton',

    today: 'today',
    selected: 'selected',
    disabled: 'disabled',
    outside: 'outside',
  }}
/>
``` 

With my changes, you can simply do this:
```jsx
<DayPicker
  classNames={{
    container: styles.container, 
  }}
/>
```