### PR TITLE
Custom week number element

### DIFF
--- a/docs/src/pages/api/DayPicker.js
+++ b/docs/src/pages/api/DayPicker.js
@@ -61,6 +61,7 @@ export default () => (
     <p>
       <a href="#renderDay">renderDay</a>, <a href="#renderWeek">renderWeek</a>,{' '}
       <a href="#weekdayElement">weekdayElement</a>,{' '}
+      <a href="#weekNumberElement">weekNumberElement</a>,{' '}
       <a href="#navbarElement">navbarElement</a>,{' '}
       <a href="#captionElement">captionElement</a>
     </p>
@@ -499,6 +500,37 @@ export default () => (
         An array containing the short weekdays names to use in the month’s
         header. Defaults to the English weekdays names. Must start from Sunday.
       </p>
+
+      <h3>
+        <Anchor id="weekNumberElement" />
+        weekNumberElement{' '}
+        <code>React.Element | React.Component | (props) ⇒ React.Element</code>
+      </h3>
+      <p>
+        A React Element or React Component to render the week number cells when{' '}
+        <a href="#showWeekNumbers">
+          <code>showWeekNumbers</code>
+        </a>{' '}
+        is set. It will receive the following props:
+      </p>
+
+      <ul>
+        <li>
+          classNames <code>string</code>
+        </li>
+        <li>
+          weekNumber <code>number</code>
+        </li>
+        <li>
+          renderWeek <code>(week) ⇒ week</code>
+        </li>
+        <li>
+          week <code>Date[]</code>
+        </li>
+        <li>
+          month <code>Date</code>
+        </li>
+      </ul>
 
       <hr />
       <h2 id="event-handlers">Event handlers</h2>

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -5,6 +5,7 @@ import Caption from './Caption';
 import Navbar from './Navbar';
 import Month from './Month';
 import Weekday from './Weekday';
+import WeekNumber from './WeekNumber';
 
 import * as Helpers from './Helpers';
 import * as DateUtils from './DateUtils';
@@ -99,6 +100,11 @@ export class DayPicker extends Component {
       PropTypes.func,
       PropTypes.instanceOf(Component),
     ]),
+    weekNumberElement: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.func,
+      PropTypes.instanceOf(Component),
+    ]),
     navbarElement: PropTypes.oneOfType([
       PropTypes.element,
       PropTypes.func,
@@ -151,6 +157,7 @@ export class DayPicker extends Component {
     renderDay: day => day.getDate(),
     renderWeek: weekNumber => weekNumber,
     weekdayElement: <Weekday />,
+    weekNumberElement: <WeekNumber classNames={classNames} />,
     navbarElement: <Navbar classNames={classNames} />,
     captionElement: <Caption classNames={classNames} />,
   };

--- a/src/Month.js
+++ b/src/Month.js
@@ -191,6 +191,7 @@ export default class Month extends Component {
               weekNumber = DateUtils.getWeekNumber(week[6]);
 
               weekNumberElementProps = {
+                className: classNames.weekNumber,
                 month,
                 onWeekClick,
                 renderWeek,

--- a/src/Month.js
+++ b/src/Month.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 import Weekdays from './Weekdays';
 import Day from './Day';
-import { ENTER } from './keys';
 
 import * as ModifiersUtils from './ModifiersUtils';
 import * as Helpers from './Helpers';
@@ -151,7 +150,7 @@ export default class Month extends Component {
       showWeekDays,
       onWeekClick,
 
-      renderWeek
+      renderWeek,
     } = this.props;
 
     const captionProps = {
@@ -192,16 +191,21 @@ export default class Month extends Component {
               weekNumber = DateUtils.getWeekNumber(week[6]);
 
               weekNumberElementProps = {
-                month: month,
-                onWeekClick: onWeekClick,
-                renderWeek: renderWeek,
-                week: week,
-                weekNumber: weekNumber,
-              }
-  
-              weekNumberElementComponent = React.isValidElement(weekNumberElement)
+                month,
+                onWeekClick,
+                renderWeek,
+                week,
+                weekNumber,
+              };
+
+              weekNumberElementComponent = React.isValidElement(
+                weekNumberElement
+              )
                 ? React.cloneElement(weekNumberElement, weekNumberElementProps)
-                : React.createElement(weekNumberElement, weekNumberElementProps);
+                : React.createElement(
+                    weekNumberElement,
+                    weekNumberElementProps
+                  );
             }
 
             return (

--- a/src/Month.js
+++ b/src/Month.js
@@ -41,6 +41,11 @@ export default class Month extends Component {
       PropTypes.func,
       PropTypes.instanceOf(React.Component),
     ]),
+    weekNumberElement: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.func,
+      PropTypes.instanceOf(React.Component),
+    ]),
 
     fixedWeeks: PropTypes.bool,
     showWeekNumbers: PropTypes.bool,
@@ -132,6 +137,7 @@ export default class Month extends Component {
       fixedWeeks,
       captionElement,
       weekdayElement,
+      weekNumberElement,
 
       locale,
       localeUtils,
@@ -144,6 +150,8 @@ export default class Month extends Component {
       showWeekNumbers,
       showWeekDays,
       onWeekClick,
+
+      renderWeek
     } = this.props;
 
     const captionProps = {
@@ -177,36 +185,32 @@ export default class Month extends Component {
         <div className={classNames.body} role="rowgroup">
           {weeks.map(week => {
             let weekNumber;
+            let weekNumberElementComponent;
+            let weekNumberElementProps;
+
             if (showWeekNumbers) {
               weekNumber = DateUtils.getWeekNumber(week[6]);
+
+              weekNumberElementProps = {
+                month: month,
+                onWeekClick: onWeekClick,
+                renderWeek: renderWeek,
+                week: week,
+                weekNumber: weekNumber,
+              }
+  
+              weekNumberElementComponent = React.isValidElement(weekNumberElement)
+                ? React.cloneElement(weekNumberElement, weekNumberElementProps)
+                : React.createElement(weekNumberElement, weekNumberElementProps);
             }
+
             return (
               <div
                 key={week[0].getTime()}
                 className={classNames.week}
                 role="row"
               >
-                {showWeekNumbers && (
-                  <div
-                    className={classNames.weekNumber}
-                    tabIndex={onWeekClick ? 0 : -1}
-                    role="gridcell"
-                    onClick={
-                      onWeekClick
-                        ? e => onWeekClick(weekNumber, week, e)
-                        : undefined
-                    }
-                    onKeyUp={
-                      onWeekClick
-                        ? e =>
-                            e.keyCode === ENTER &&
-                            onWeekClick(weekNumber, week, e)
-                        : undefined
-                    }
-                  >
-                    {this.props.renderWeek(weekNumber, week, month)}
-                  </div>
-                )}
+                {showWeekNumbers && weekNumberElementComponent}
                 {week.map(this.renderDay)}
               </div>
             );

--- a/src/WeekNumber.js
+++ b/src/WeekNumber.js
@@ -1,0 +1,57 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import defaultClassNames from './classNames';
+
+export default class WeekNumber extends Component {
+  static propTypes = {
+    classNames: PropTypes.shape({
+      weekNumber: PropTypes.string.isRequired
+    }),
+    month: PropTypes.instanceOf(Date),
+    onWeekClick: PropTypes.func,
+    renderWeek: PropTypes.func,
+    week: PropTypes.array,
+    weekNumber: PropTypes.number
+  };
+
+  static defaultProps = {
+    classNames: defaultClassNames,
+  };
+
+  shouldComponentUpdate(nextProps) {
+    return this.props !== nextProps;
+  }
+
+  render() {
+    const {
+      classNames,
+      month,
+      onWeekClick,
+      renderWeek,
+      week,
+      weekNumber
+    } = this.props;
+
+    return (
+      <div
+        className={classNames.weekNumber}
+        tabIndex={onWeekClick ? 0 : -1}
+        role="gridcell"
+        onClick={
+          onWeekClick
+            ? e => onWeekClick(weekNumber, week, e)
+            : undefined
+        }
+        onKeyUp={
+          onWeekClick
+            ? e =>
+                e.keyCode === ENTER &&
+                onWeekClick(weekNumber, week, e)
+            : undefined
+        }
+      >
+        {renderWeek(weekNumber, week, month)}
+      </div>
+    );
+  }
+}

--- a/src/WeekNumber.js
+++ b/src/WeekNumber.js
@@ -5,6 +5,7 @@ import { ENTER } from './keys';
 
 export default class WeekNumber extends Component {
   static propTypes = {
+    className: PropTypes.string,
     classNames: PropTypes.shape({
       weekNumber: PropTypes.string.isRequired,
     }),
@@ -25,6 +26,7 @@ export default class WeekNumber extends Component {
 
   render() {
     const {
+      className,
       classNames,
       month,
       onWeekClick,
@@ -35,7 +37,7 @@ export default class WeekNumber extends Component {
 
     return (
       <div
-        className={classNames.weekNumber}
+        className={className || classNames.weekNumber}
         tabIndex={onWeekClick ? 0 : -1}
         role="gridcell"
         onClick={

--- a/src/WeekNumber.js
+++ b/src/WeekNumber.js
@@ -1,17 +1,18 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import defaultClassNames from './classNames';
+import { ENTER } from './keys';
 
 export default class WeekNumber extends Component {
   static propTypes = {
     classNames: PropTypes.shape({
-      weekNumber: PropTypes.string.isRequired
+      weekNumber: PropTypes.string.isRequired,
     }),
     month: PropTypes.instanceOf(Date),
     onWeekClick: PropTypes.func,
     renderWeek: PropTypes.func,
     week: PropTypes.array,
-    weekNumber: PropTypes.number
+    weekNumber: PropTypes.number,
   };
 
   static defaultProps = {
@@ -29,7 +30,7 @@ export default class WeekNumber extends Component {
       onWeekClick,
       renderWeek,
       week,
-      weekNumber
+      weekNumber,
     } = this.props;
 
     return (
@@ -38,15 +39,11 @@ export default class WeekNumber extends Component {
         tabIndex={onWeekClick ? 0 : -1}
         role="gridcell"
         onClick={
-          onWeekClick
-            ? e => onWeekClick(weekNumber, week, e)
-            : undefined
+          onWeekClick ? e => onWeekClick(weekNumber, week, e) : undefined
         }
         onKeyUp={
           onWeekClick
-            ? e =>
-                e.keyCode === ENTER &&
-                onWeekClick(weekNumber, week, e)
+            ? e => e.keyCode === ENTER && onWeekClick(weekNumber, week, e)
             : undefined
         }
       >

--- a/test/daypicker/events.js
+++ b/test/daypicker/events.js
@@ -311,7 +311,7 @@ describe('DayPicker’s events handlers', () => {
       />
     );
     wrapper
-      .find('.DayPicker-WeekNumber')
+      .find('div.DayPicker-WeekNumber')
       .at(1)
       .simulate('click');
     expect(handleWeekClick.mock.calls[0][0]).toBe(7);

--- a/test/daypicker/rendering.js
+++ b/test/daypicker/rendering.js
@@ -23,6 +23,7 @@ describe('DayPicker’s rendering', () => {
     expect(dayPicker.props.pagedNavigation).toBe(false);
     expect(typeof dayPicker.props.renderDay).toBe('function');
     expect(typeof dayPicker.props.weekdayElement).toBe('object');
+    expect(typeof dayPicker.props.weekNumberElement).toBe('object');
     expect(typeof dayPicker.props.navbarElement).toBe('object');
     expect(dayPicker.props.tabIndex).toBe(0);
   });

--- a/test/daypicker/rendering.js
+++ b/test/daypicker/rendering.js
@@ -299,6 +299,76 @@ describe('DayPicker’s rendering', () => {
     /* eslint-enable react/prefer-stateless-function */
     /* eslint-enable react/no-multi-comp */
   });
+  it('should render a custom week number element', () => {
+    const CustomWeekNumber = ({ className, weekNumber }) => (
+      <div className={className}>{weekNumber}</div>
+    );
+    CustomWeekNumber.propTypes = {
+      className: PropTypes.string,
+      weekNumber: PropTypes.number,
+    };
+    const weekNumber = <CustomWeekNumber />;
+    const dayPicker = (
+      <DayPicker
+        showWeekNumbers
+        weekNumberElement={weekNumber}
+        onWeekClick={() => {}}
+      />
+    );
+    const wrapper = mount(dayPicker);
+    expect(isElement(dayPicker.props.weekNumberElement)).toBe(true);
+    expect(wrapper.containsMatchingElement(<CustomWeekNumber />)).toBe(true);
+    expect(wrapper.find('div.DayPicker-WeekNumber')).toHaveLength(5);
+  });
+  it('should render a custom week number element as a function', () => {
+    const CustomWeekNumber = ({ className, weekNumber }) => (
+      <div className={className}>{weekNumber}</div>
+    );
+    CustomWeekNumber.propTypes = {
+      className: PropTypes.string,
+      weekNumber: PropTypes.number,
+    };
+    const dayPicker = (
+      <DayPicker
+        showWeekNumbers
+        weekNumberElement={CustomWeekNumber}
+        onWeekClick={() => {}}
+      />
+    );
+    const wrapper = mount(dayPicker);
+
+    expect(wrapper.containsMatchingElement(<CustomWeekNumber />)).toBe(true);
+    expect(wrapper.find('div.DayPicker-WeekNumber')).toHaveLength(5);
+  });
+  it('should render a custom week number element as a class', () => {
+    /* eslint-disable react/prefer-stateless-function */
+    /* eslint-disable react/no-multi-comp */
+    class CustomWeekNumber extends React.Component {
+      static propTypes = {
+        className: PropTypes.string,
+        weekNumber: PropTypes.number,
+      };
+
+      render() {
+        return (
+          <div className={this.props.className}>{this.props.weekNumber}</div>
+        );
+      }
+    }
+    const dayPicker = (
+      <DayPicker
+        showWeekNumbers
+        weekNumberElement={CustomWeekNumber}
+        onWeekClick={() => {}}
+      />
+    );
+    const wrapper = mount(dayPicker);
+
+    expect(wrapper.containsMatchingElement(<CustomWeekNumber />)).toBe(true);
+    expect(wrapper.find('div.DayPicker-WeekNumber')).toHaveLength(5);
+    /* eslint-enable react/prefer-stateless-function */
+    /* eslint-enable react/no-multi-comp */
+  });
   it('should not render the outside days', () => {
     const wrapper = mount(<DayPicker initialMonth={new Date(2015, 6)} />);
     expect(wrapper.find('.DayPicker-Day').at(0)).toHaveText('');
@@ -353,8 +423,8 @@ describe('DayPicker’s rendering', () => {
     const wrapper = mount(
       <DayPicker showWeekNumbers initialMonth={new Date(2015, 1)} />
     );
-    expect(wrapper.find('.DayPicker-WeekNumber')).toHaveLength(4);
-    expect(wrapper.find('.DayPicker-WeekNumber').at(1)).toHaveText('7');
+    expect(wrapper.find('div.DayPicker-WeekNumber')).toHaveLength(4);
+    expect(wrapper.find('div.DayPicker-WeekNumber').at(1)).toHaveText('7');
   });
   it('should use the specified class names', () => {
     const wrapper = mount(

--- a/types/DayPicker.d.ts
+++ b/types/DayPicker.d.ts
@@ -7,6 +7,7 @@ import {
   CaptionElementProps,
   NavbarElementProps,
   WeekdayElementProps,
+  WeekNumberElementProps,
   DayPickerProps,
 } from './props';
 

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -39,6 +39,19 @@ export interface WeekdayElementProps {
   weekdaysShort?: string[];
 }
 
+export interface WeekNumberElementProps {
+	week: Date[];
+	weekNumber: number[];
+	month?: Date;
+	classNames: string;
+	onWeekClick(
+		weekNumber: number,
+		days: Date[],
+		e: React.MouseEvent<HTMLDivElement>
+	  ): void;
+	renderWeek(weekNumber: number, week: Date[], month: Date): React.ReactNode;
+}
+
 export interface DayPickerProps {
   canChangeMonth?: boolean;
   captionElement?:

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -42,8 +42,9 @@ export interface WeekdayElementProps {
 export interface WeekNumberElementProps {
 	week: Date[];
 	weekNumber: number[];
-	month?: Date;
+	month: Date;
 	classNames: string;
+	className: string;
 	onWeekClick(
 		weekNumber: number,
 		days: Date[],


### PR DESCRIPTION
Fixes https://github.com/gpbl/react-day-picker/issues/727

- Provides ability to add custom week number element via `weekNumberElement` prop

**Note:** `WeekNumber.js` file has just under 100% coverage due to `shouldComponentUpdate` not being covered. Wanted to keep a consistent theme of class components (Navbar.js, Weekday.js, etc). But, if this isn't necessary, the component can be written as a pure function to achieve 100%.