### PR TITLE
add missing utils typescript definitions

### DIFF
--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -145,7 +145,7 @@ export interface DayPickerProps {
 
 export interface DayPickerInputProps {
   value?: string | Date;
-  format: string | string[];
+  format?: string | string[];
   placeholder?: string;
 
   dayPickerProps?: DayPickerProps;

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -24,6 +24,8 @@ export interface LocaleUtils {
     string,
     string
   ];
+  formatDate(day: Date, format?: string, locale?: string): string;
+  parseDate(input: string, format?: string, locale?: string): Date | undefined;
 }
 
 export interface DateUtils {


### PR DESCRIPTION
Not very much to explain actually. It seemed to me that some type definition were missing, because all the other functions in MomentLocaleUtils.js were declared correctly in the utils.d.ts definition file, except the ones that i added. So I added them.