### PR TITLE
TypeScript: import formatDate and parseDate from react-day-picker/moment

### DIFF
--- a/types/moment.d.ts
+++ b/types/moment.d.ts
@@ -2,4 +2,9 @@
 
 import { LocaleUtils } from './utils';
 
-export const MomentLocaleUtils: LocaleUtils;
+interface MomentLocaleUtils extends LocaleUtils {
+  formatDate(date: Date, format?: string, locale?: string): string;
+  parseDate(str: string, format?: string, locale?: string): Date | undefined;
+}
+
+export = MomentLocaleUtils;


### PR DESCRIPTION
This allows TypeScript to understand the following import:

```js
import MomentLocaleUtils, {
  formatDate,
  parseDate,
} from 'react-day-picker/moment';
```

as [specified in the documentation](http://react-day-picker.js.org/examples/input-moment).