### PR TITLE
Fix utils TypeScript types

### DIFF
--- a/types/DayPicker.d.ts
+++ b/types/DayPicker.d.ts
@@ -12,9 +12,9 @@ import {
 
 export default class DayPicker extends React.Component<DayPickerProps, any> {
   static VERSION: string;
-  static LocaleUtils: LocaleUtils;
-  static DateUtils: DateUtils;
-  static ModifiersUtils: ModifiersUtils;
+  static LocaleUtils: typeof LocaleUtils;
+  static DateUtils: typeof DateUtils;
+  static ModifiersUtils: typeof ModifiersUtils;
   static DayModifiers: DayModifiers;
   static Modifiers: Modifiers;
   readonly dayPicker: HTMLDivElement;

--- a/types/moment.d.ts
+++ b/types/moment.d.ts
@@ -2,4 +2,4 @@
 
 import { LocaleUtils } from './utils';
 
-export const MomentLocaleUtils: LocaleUtils;
+export const MomentLocaleUtils: typeof LocaleUtils;

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -1,14 +1,20 @@
 // TypeScript Version: 2.2
 
 import * as React from 'react';
-import { ClassNames, Modifier, Modifiers, DayModifiers, InputClassNames } from './common';
+import {
+  ClassNames,
+  Modifier,
+  Modifiers,
+  DayModifiers,
+  InputClassNames,
+} from './common';
 import { LocaleUtils } from './utils';
 import { DayPickerInput } from './DayPickerInput';
 
 export interface CaptionElementProps {
   date: Date;
   classNames: ClassNames;
-  localeUtils: LocaleUtils;
+  localeUtils: typeof LocaleUtils;
   locale: string;
   months?: string[];
   onClick?: React.MouseEventHandler<HTMLElement>;
@@ -26,14 +32,14 @@ export interface NavbarElementProps {
   onNextClick(callback?: () => void): void;
   dir?: string;
   labels: { previousMonth: string; nextMonth: string };
-  localeUtils: LocaleUtils;
+  localeUtils: typeof LocaleUtils;
   locale: string;
 }
 
 export interface WeekdayElementProps {
   weekday: number;
   className: string;
-  localeUtils: LocaleUtils;
+  localeUtils: typeof LocaleUtils;
   locale: string;
   weekdaysLong?: string[];
   weekdaysShort?: string[];
@@ -61,7 +67,7 @@ export interface DayPickerProps {
   initialMonth?: Date;
   labels?: { previousMonth: string; nextMonth: string };
   locale?: string;
-  localeUtils?: LocaleUtils;
+  localeUtils?: typeof LocaleUtils;
   modifiers?: Partial<Modifiers>;
   modifiersStyles?: object;
   month?: Date;

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -1,8 +1,8 @@
 // TypeScript Version: 2.2
 
-import { RangeModifier, Modifier } from "./common";
+import { RangeModifier, Modifier } from './common';
 
-export interface LocaleUtils {
+export const LocaleUtils: {
   formatDay(day: Date, locale?: string): string;
   formatMonthTitle(month: Date, locale?: string): string;
   formatWeekdayLong(weekday: number, locale?: string): string;
@@ -24,9 +24,9 @@ export interface LocaleUtils {
     string,
     string
   ];
-}
+};
 
-export interface DateUtils {
+export const DateUtils: {
   addDayToRange(day: Date, range: RangeModifier): RangeModifier;
   addMonths(d: Date, n: number): Date;
   clone(d: Date): Date;
@@ -39,12 +39,12 @@ export interface DateUtils {
   isPastDay(day: Date): boolean;
   isSameDay(day1: Date, day2: Date): boolean;
   isSameMonth(day1: Date, day2: Date): boolean;
-}
+};
 
-export interface ModifiersUtils {
+export const ModifiersUtils: {
   dayMatchesModifier(day: Date, modifier?: Modifier | Modifier[]): boolean;
   getModifiersForDay(
     day: Date,
     modifiers: Record<string, Modifier | Modifier[]>
   ): string[];
-}
+};


### PR DESCRIPTION
- Fixes the error:
  > DateUtils only refers to a type but is being used as a value here TS2693
- I believe this would be a better fix than using namespaces as in #896 due to reasons listed on [this issue](https://github.com/babel/babel/issues/8244#issuecomment-401616905).

resolves #887 & resolves #865