### PR TITLE
Add tabIndex to DayPickerProps

### DIFF
--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -141,6 +141,7 @@ export interface DayPickerProps {
     | React.SFC<WeekdayElementProps>;
   weekdaysLong?: string[];
   weekdaysShort?: string[];
+  tabIndex?: number;
 }
 
 export interface DayPickerInputProps {


### PR DESCRIPTION
It looks like this is [included in the propTypes](https://github.com/gpbl/react-day-picker/blob/421af9f56b1b07ed58f864678b3bbb8617cdaff7/src/DayPicker.js#L92) for the component, but didn't get added to the typescript typings.
