### PR TITLE
Fix exports and ts errors

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,11 +2,6 @@
 
 export { default } from './DayPicker';
 
-import * as UtilTypes from './utils';
 export * from './common';
 export * from './props';
 export * from './utils';
-
-export const DateUtils: UtilTypes.DateUtils;
-export const LocaleUtils: UtilTypes.LocaleUtils;
-export const ModifiersUtils: UtilTypes.ModifiersUtils;


### PR DESCRIPTION
👋🏽 Thanks for opening a pull request!

* Please explain clearly your changes. If they involve a lot of code, let discuss them first in on our gitter room: 
https://gitter.im/gpbl/react-day-picker
* 🙏🏽 Please **DO NOT** build files or update the docs in your pull request – as this may cause git conflicts. Thanks!

`DateUtils`, `LocaleUtils`, `ModifiersUtils` are already exported by `export * from './utils';`.
Moreover `export const DateUtils: UtilTypes.DateUtils;` causes error because `UtilTypes.DateUtils` is variable but used as type. It might be like `export const DateUtils: typeof UtilTypes.DateUtils;` but unnecessary.
