### PR TITLE
Force first letter in caption to be uppercase

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -74,6 +74,10 @@
   text-align: left;
 }
 
+.DayPicker-Caption::first-letter {
+  text-transform: uppercase;
+}
+
 .DayPicker-Caption > div {
   font-weight: 500;
   font-size: 1.15em;

--- a/yarn.lock
+++ b/yarn.lock
@@ -783,11 +783,6 @@ babel-plugin-jest-hoist@^23.2.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
   integrity sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=
 
-babel-plugin-react-remove-prop-types@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-react-remove-prop-types/-/babel-plugin-react-remove-prop-types-3.0.0.tgz#adab984affb73b788931f26dc157e62e37f11ed5"
-  integrity sha1-rauYSv+3O3iJMfJtwVfmLjfxHtU=
-
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"


### PR DESCRIPTION
In many languages like french, monthes are written in lowercase. It causes the caption to begin with lowercases which is not very pretty.
This pull request add one line of style to transform the first letter of the caption into uppercase.
If the monthes with an uppercase letter causes issues with some languages, let me know so I could manage to add an props to enable uppercases.

This is my first pull request so thanks in advance for your advices.