### PR TITLE
Make `format` optional in DayPickerInput

### DIFF
--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -152,7 +152,7 @@ export interface DayPickerProps {
 
 export interface DayPickerInputProps {
   value?: string | Date;
-  format: string | string[];
+  format?: string | string[];
   placeholder?: string;
 
   dayPickerProps?: DayPickerProps;


### PR DESCRIPTION
* Please explain clearly your changes.

the `format` prop in the `DayPickerInput` component is not required as far as i can tell in my project. this just updates the types to match