### PR TITLE
Add missing locale utils type definitions

### DIFF
--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -24,6 +24,8 @@ export const LocaleUtils: {
     string,
     string
   ];
+  formatDate(date: Date, format?: string, locale?: string): string;
+  parseDate(str: string, format?: string, locale?: string): string;
 };
 
 export const DateUtils: {


### PR DESCRIPTION
So, today I wanted to add date formatting in a project using typescript and while [following the documentation](https://react-day-picker.js.org/examples/input-moment) I've noticed that there are some definitions missing for `MomentLocaleUtils`. So here's a small fix :wink: 