### PR TITLE
Improve typings, use TypeScript 3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "react-dom": "^16.4.2",
     "react-test-renderer": "^16.4.2",
     "rimraf": "^2.6.2",
-    "typescript": "^3.0.1",
+    "typescript": "^3.1.6",
     "webpack": "^3.10.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react": "~0.13.x || ~0.14.x || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
+    "@types/react": "^16.9.2",
     "autoprefixer": "^8.4.1",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
@@ -97,7 +98,6 @@
     "react-dom": "^16.4.2",
     "react-test-renderer": "^16.4.2",
     "rimraf": "^2.6.2",
-    "typescript": "^3.1.6",
     "webpack": "^3.10.0"
   },
   "dependencies": {

--- a/types/DayPicker.d.ts
+++ b/types/DayPicker.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 2.3
+// TypeScript Version: 3.1
 
 import * as React from 'react';
 import { LocaleUtils, ModifiersUtils, DateUtils } from './utils';

--- a/types/DayPickerInput.d.ts
+++ b/types/DayPickerInput.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 2.3
+// TypeScript Version: 3.1
 
 import * as React from 'react';
 import { DayPickerInputProps } from './props';

--- a/types/README.md
+++ b/types/README.md
@@ -1,0 +1,5 @@
+# TypeScript Definitions
+
+react-day-picker includes type definitions which the TypeScript compiler and language services can use to check your usage of the library.
+
+Note that _only exports from the root of the package_ (`import { ... } from "react-day-picker"`) are considered part of the public API.

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 2.3
+// TypeScript Version: 3.1
 
 export interface ClassNames {
   container: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,12 +1,6 @@
 // TypeScript Version: 3.1
 
 export { default } from './DayPicker';
-
-import * as UtilTypes from './utils';
 export * from './common';
 export * from './props';
 export * from './utils';
-
-export const DateUtils: typeof UtilTypes.DateUtils;
-export const LocaleUtils: typeof UtilTypes.LocaleUtils;
-export const ModifiersUtils: typeof UtilTypes.ModifiersUtils;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 2.3
+// TypeScript Version: 3.1
 
 export { default } from './DayPicker';
 

--- a/types/moment.d.ts
+++ b/types/moment.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 2.3
+// TypeScript Version: 3.1
 
 import { LocaleUtils } from './utils';
 

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 2.3
+// TypeScript Version: 3.1
 
 import * as React from 'react';
 import {

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -5,7 +5,7 @@
       "es6",
       "dom"
     ],
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,
     "noEmit": true,

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 2.3
+// TypeScript Version: 3.1
 
 import { RangeModifier, Modifier } from './common';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,6 +133,19 @@
   resolved "https://registry.yarnpkg.com/@types/parsimmon/-/parsimmon-1.10.0.tgz#ffb81cb023ff435a41d4710a29ab23c561dc9fdf"
   integrity sha512-bsTIJFVQv7jnvNiC42ld2pQW2KRI+pAG243L+iATvqzy3X6+NH1obz2itRKDZZ8VVhN3wjwYax/VBGCcXzgTqQ==
 
+"@types/prop-types@*":
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.2.tgz#0e58ae66773d7fd7c372a493aff740878ec9ceaa"
+  integrity sha512-f8JzJNWVhKtc9dg/dyDNfliTKNOJSLa7Oht/ElZdF/UbMUmAH3rLmAk3ODNjw0mZajDEgatA03tRjB4+Dp/tzA==
+
+"@types/react@^16.9.2":
+  version "16.9.2"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.2.tgz#6d1765431a1ad1877979013906731aae373de268"
+  integrity sha512-jYP2LWwlh+FTqGd9v7ynUKZzjj98T8x7Yclz479QdRhHfuW9yQ+0jjnD31eXSXutmBpppj5PYNLYLRfnZJvcfg==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
@@ -1979,6 +1992,11 @@ cssstyle@^1.0.0:
   integrity sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==
   dependencies:
     cssom "0.3.x"
+
+csstype@^2.2.0:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.6.tgz#c34f8226a94bbb10c32cc0d714afdf942291fc41"
+  integrity sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==
 
 d@1:
   version "1.0.1"
@@ -6949,11 +6967,6 @@ type@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/type/-/type-1.0.1.tgz#084c9a17fcc9151a2cdb1459905c2e45e4bb7d61"
   integrity sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==
-
-typescript@^3.0.1:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 typescript@next:
   version "3.6.0-dev.20190803"


### PR DESCRIPTION
- Upgrade TypeScript version to 3.1 (this version has been around for quite a while, it's safe to assume your users are on TS 3.1+ at this point, and 3.1 has a lot of bug fixes compared to 3.0)
  - also remove the explicit dependency on typescript, since dtslint pulls it in and you never invoke it directly
- Enable `noImplicitAny` in tsconfig.json so that you can check you are using types like `React.Component` correctly
  - install `@types/react` to get this to work
- Remove redundant re-exports in `types/index.d.ts`
  - Since `DateUtils`, `LocaleUtils`, and `ModifiersUtils` are all already `const` values in `utils.d.ts` which are reexported by `export * from './utils';`, there is no need to explicitly export them
- Add a README to the types folder to discourage TypeScript users from importing from `react-day-picker` submodules. This was the reason for the bug in https://github.com/palantir/blueprint/issues/3703: we were importing from `react-day-picker/types/utils`, which had a breaking change in https://github.com/gpbl/react-day-picker/pull/899. I was able to fix our usage by importing from the module root: https://github.com/palantir/blueprint/pull/3725