### PR TITLE
Fix DayPickerInput value does not recompute on locale change

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -183,8 +183,13 @@ export default class DayPickerInput extends React.Component {
     // Current props
     const { value, formatDate, format, dayPickerProps } = this.props;
 
-    // Update the input value if the `value` prop has changed
-    if (value !== prevProps.value) {
+    // Update the input value if `value`, `dayPickerProps.locale` or `format`
+    // props have changed
+    if (
+      value !== prevProps.value ||
+      dayPickerProps.locale !== prevProps.dayPickerProps.locale ||
+      format !== prevProps.format
+    ) {
       if (isDate(value)) {
         newState.value = formatDate(value, format, dayPickerProps.locale);
       } else {

--- a/test/daypickerinput/rendering.js
+++ b/test/daypickerinput/rendering.js
@@ -149,6 +149,40 @@ describe('DayPickerInput', () => {
       wrapper.setProps({ value: '01/10/2018' });
       expect(wrapper.instance().state.value).toBe('01/10/2018');
     });
+    it('should update the current value when `dayPickerProps.locale` changes', () => {
+      const date = new Date(2019, 8, 30);
+      const formatDate = (d, _format, _locale) => {
+        const year = d.getFullYear();
+        const month = `${d.getMonth() + 1}`;
+        const day = `${d.getDate()}`;
+        return `${year}-${month}-${day} ${_locale}`;
+      };
+      const wrapper = mount(
+        <DayPickerInput value={date} formatDate={formatDate} />
+      );
+      wrapper.setProps({ dayPickerProps: { locale: 'en' }, formatDate });
+      expect(wrapper.instance().state.value).toBe('2019-9-30 en');
+
+      wrapper.setProps({ dayPickerProps: { locale: 'es' }, formatDate });
+      expect(wrapper.instance().state.value).toBe('2019-9-30 es');
+    });
+    it('should update the current value when `format` changes', () => {
+      const date = new Date(2019, 8, 30);
+      const formatDate = (d, _format) => {
+        const year = d.getFullYear();
+        const month = `${d.getMonth() + 1}`;
+        const day = `${d.getDate()}`;
+        return `${year}-${month}-${day} ${_format}`;
+      };
+      const wrapper = mount(
+        <DayPickerInput value={date} formatDate={formatDate} />
+      );
+      wrapper.setProps({ format: 'YYYY-M-D', formatDate });
+      expect(wrapper.instance().state.value).toBe('2019-9-30 YYYY-M-D');
+
+      wrapper.setProps({ format: 'YYYY-MM-DD', formatDate });
+      expect(wrapper.instance().state.value).toBe('2019-9-30 YYYY-MM-DD');
+    });
     it('should not update the current value when other props are updated', () => {
       const wrapper = mount(<DayPickerInput value="2017-12-15" />);
       wrapper.setProps({ dayPickerProps: {} });


### PR DESCRIPTION
on DayPickerInput:

when the "dayPickerProps.locale" or "format" props change
the value of the input should be recomputed

Fixes #938