### PR TITLE
Set overlayHasFocus to false in hideAfterDayClick

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -334,7 +334,10 @@ export default class DayPickerInput extends React.Component {
     if (!this.props.hideOnDayClick) {
       return;
     }
-    this.hideTimeout = setTimeout(() => this.hideDayPicker(), HIDE_TIMEOUT);
+    this.hideTimeout = setTimeout(() => {
+      this.overlayHasFocus = false;
+      this.hideDayPicker();
+    }, HIDE_TIMEOUT);
   }
 
   handleInputClick(e) {


### PR DESCRIPTION
`overlayHasFocus` wasn't being set to false when the overlay was hidden after clicking on a day. 
This was causing the issue seen in: 
Fixes https://github.com/gpbl/react-day-picker/issues/723