### PR TITLE
Remove `typeof` for LocaleUtils

### DIFF
--- a/types/DayPicker.d.ts
+++ b/types/DayPicker.d.ts
@@ -12,7 +12,7 @@ import {
 
 export default class DayPicker extends React.Component<DayPickerProps, any> {
   static VERSION: string;
-  static LocaleUtils: typeof LocaleUtils;
+  static LocaleUtils: LocaleUtils;
   static DateUtils: typeof DateUtils;
   static ModifiersUtils: typeof ModifiersUtils;
   static DayModifiers: DayModifiers;

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -14,7 +14,7 @@ import { DayPickerInput } from './DayPickerInput';
 export interface CaptionElementProps {
   date: Date;
   classNames: ClassNames;
-  localeUtils: typeof LocaleUtils;
+  localeUtils: LocaleUtils;
   locale: string;
   months?: string[];
   onClick?: React.MouseEventHandler<HTMLElement>;
@@ -32,14 +32,14 @@ export interface NavbarElementProps {
   onNextClick(callback?: () => void): void;
   dir?: string;
   labels: { previousMonth: string; nextMonth: string };
-  localeUtils: typeof LocaleUtils;
+  localeUtils: LocaleUtils;
   locale: string;
 }
 
 export interface WeekdayElementProps {
   weekday: number;
   className: string;
-  localeUtils: typeof LocaleUtils;
+  localeUtils: LocaleUtils;
   locale: string;
   weekdaysLong?: string[];
   weekdaysShort?: string[];
@@ -67,7 +67,7 @@ export interface DayPickerProps {
   initialMonth?: Date;
   labels?: { previousMonth: string; nextMonth: string };
   locale?: string;
-  localeUtils?: typeof LocaleUtils;
+  localeUtils?: LocaleUtils;
   modifiers?: Partial<Modifiers>;
   modifiersStyles?: object;
   month?: Date;

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -26,7 +26,7 @@ export interface LocaleUtils {
     string
   ];
   parseDate(str: string, format?: string, locale?: string): Date;
-};
+}
 
 export const DateUtils: {
   addDayToRange(day: Date, range: RangeModifier): RangeModifier;


### PR DESCRIPTION
In the #873 , `LocaleUtils` is not a `const` variable and it is and `Interface` there no need to use `typeof` for it's type usage. (This is breaking a build pipeline when tsconfig is set `strict:true`)

That's why I remove them.