### PR TITLE
Mark package as tree shakable

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -6,6 +6,7 @@
   "homepage": "http://react-day-picker.js.org",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",
+  "sideEffects": false,
   "typings": "typings/react-day-picker.d.ts",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
When installing the package and building the application, it is not tree shaken properly. All modules are included in the main bundle.

Mark the package as tree shakable so that it will be tree shaken properly.