### PR TITLE
When value is not valid call onDayChange after setState is finished

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -430,8 +430,9 @@ export default class DayPickerInput extends React.Component {
     const day = parseDate(value, format, dayPickerProps.locale);
     if (!day) {
       // Day is invalid: we save the value in the typedValue state
-      this.setState({ value, typedValue: value });
-      if (onDayChange) onDayChange(undefined, {}, this);
+      this.setState({ value, typedValue: value }, () => {
+        if (onDayChange) onDayChange(undefined, {}, this);
+      });
       return;
     }
     this.updateState(day, value);


### PR DESCRIPTION
The problem:
react-day-picker doesn't expose dates that are invalid (i.e. 02/29/2019), instead it sends 'undefined' in onDayChange. An example use case where this would be required is a validation solution that would mark invalid fields in red (for example).

The solution:
By calling onDayChange after setState is finished, we can get to this.state.typedValue and perform any kind of validation on it.

I understand this could be solved any number of ways, but I felt that this change would be less intrusive to existing users.