### PR TITLE
Fix locale util types

### DIFF
--- a/types/DayPicker.d.ts
+++ b/types/DayPicker.d.ts
@@ -1,21 +1,27 @@
+// TypeScript Version: 3.1
+
 import * as React from 'react';
 import { LocaleUtils, ModifiersUtils, DateUtils } from './utils';
-import { DayModifiers, Modifiers } from './common';
-
-import { DayPickerProps } from './props';
+import { ClassNames, DayModifiers, Modifier, Modifiers } from './common';
+import {
+  CaptionElementProps,
+  NavbarElementProps,
+  WeekdayElementProps,
+  DayPickerProps,
+} from './props';
 
 export default class DayPicker extends React.Component<DayPickerProps, any> {
   static VERSION: string;
-  static LocaleUtils: LocaleUtils;
-  static DateUtils: DateUtils;
-  static ModifiersUtils: ModifiersUtils;
+  static LocaleUtils: typeof LocaleUtils;
+  static DateUtils: typeof DateUtils;
+  static ModifiersUtils: typeof ModifiersUtils;
   static DayModifiers: DayModifiers;
   static Modifiers: Modifiers;
-  dayPicker: HTMLDivElement;
-  focus: () => void;
-  showMonth: (month: Date) => void;
-  showPreviousMonth: () => void;
-  showNextMonth: () => void;
-  showPreviousYear: () => void;
-  showNextYear: () => void;
+  readonly dayPicker: HTMLDivElement;
+  focus(): void;
+  showMonth(month: Date): void;
+  showPreviousMonth(): void;
+  showNextMonth(): void;
+  showPreviousYear(): void;
+  showNextYear(): void;
 }

--- a/types/DayPickerInput.d.ts
+++ b/types/DayPickerInput.d.ts
@@ -1,10 +1,12 @@
+// TypeScript Version: 3.1
+
 import * as React from 'react';
 import { DayPickerInputProps } from './props';
 import DayPicker from './DayPicker';
 
 export class DayPickerInput extends React.Component<DayPickerInputProps, any> {
-  showDayPicker: () => void;
-  hideDayPicker: () => void;
-  getDayPicker: () => DayPicker;
-  getInput: () => any;
+  showDayPicker(): void;
+  hideDayPicker(): void;
+  getDayPicker(): DayPicker;
+  getInput(): any;
 }

--- a/types/README.md
+++ b/types/README.md
@@ -1,0 +1,5 @@
+# TypeScript Definitions
+
+react-day-picker includes type definitions which the TypeScript compiler and language services can use to check your usage of the library.
+
+Note that _only exports from the root of the package_ (`import { ... } from "react-day-picker"`) are considered part of the public API.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,5 @@
+// TypeScript Version: 3.1
+
 export { default } from './DayPicker';
 export * from './common';
 export * from './props';

--- a/types/moment.d.ts
+++ b/types/moment.d.ts
@@ -1,2 +1,5 @@
+// TypeScript Version: 3.1
+
 import { LocaleUtils } from './utils';
-export type MomentLocaleUtils = LocaleUtils;
+
+export const MomentLocaleUtils: typeof LocaleUtils;

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -14,7 +14,7 @@ import { DayPickerInput } from './DayPickerInput';
 export interface CaptionElementProps {
   date: Date;
   classNames: ClassNames;
-  localeUtils: LocaleUtils;
+  localeUtils: typeof LocaleUtils;
   locale: string;
   months?: string[];
   onClick?: React.MouseEventHandler<HTMLElement>;
@@ -32,14 +32,14 @@ export interface NavbarElementProps {
   onNextClick(callback?: () => void): void;
   dir?: string;
   labels: { previousMonth: string; nextMonth: string };
-  localeUtils: LocaleUtils;
+  localeUtils: typeof LocaleUtils;
   locale: string;
 }
 
 export interface WeekdayElementProps {
   weekday: number;
   className: string;
-  localeUtils: LocaleUtils;
+  localeUtils: typeof LocaleUtils;
   locale: string;
   weekdaysLong?: string[];
   weekdaysShort?: string[];
@@ -67,7 +67,7 @@ export interface DayPickerProps {
   initialMonth?: Date;
   labels?: { previousMonth: string; nextMonth: string };
   locale?: string;
-  localeUtils?: LocaleUtils;
+  localeUtils?: typeof LocaleUtils;
   modifiers?: Partial<Modifiers>;
   modifiersStyles?: object;
   month?: Date;
@@ -77,68 +77,64 @@ export interface DayPickerProps {
     | React.ComponentClass<NavbarElementProps>
     | React.SFC<NavbarElementProps>;
   numberOfMonths?: number;
-  onBlur?: (e: React.FocusEvent<HTMLDivElement>) => void;
-  onCaptionClick?: (month: Date, e: React.MouseEvent<HTMLDivElement>) => void;
-  onDayClick?: (
+  onBlur?(e: React.FocusEvent<HTMLDivElement>): void;
+  onCaptionClick?(month: Date, e: React.MouseEvent<HTMLDivElement>): void;
+  onDayClick?(
     day: Date,
     modifiers: DayModifiers,
     e: React.MouseEvent<HTMLDivElement>
-  ) => void;
-  onDayKeyDown?: (
+  ): void;
+  onDayKeyDown?(
     day: Date,
     modifiers: DayModifiers,
     e: React.KeyboardEvent<HTMLDivElement>
-  ) => void;
-  onDayMouseEnter?: (
+  ): void;
+  onDayMouseEnter?(
     day: Date,
     modifiers: DayModifiers,
     e: React.MouseEvent<HTMLDivElement>
-  ) => void;
-  onDayMouseLeave?: (
+  ): void;
+  onDayMouseLeave?(
     day: Date,
     modifiers: DayModifiers,
     e: React.MouseEvent<HTMLDivElement>
-  ) => void;
-  onDayMouseDown?: (
+  ): void;
+  onDayMouseDown?(
     day: Date,
     modifiers: DayModifiers,
     e: React.MouseEvent<HTMLDivElement>
-  ) => void;
-  onDayMouseUp?: (
+  ): void;
+  onDayMouseUp?(
     day: Date,
     modifiers: DayModifiers,
     e: React.MouseEvent<HTMLDivElement>
-  ) => void;
-  onDayTouchEnd?: (
+  ): void;
+  onDayTouchEnd?(
     day: Date,
     modifiers: DayModifiers,
     e: React.TouchEvent<HTMLDivElement>
-  ) => void;
-  onDayTouchStart?: (
+  ): void;
+  onDayTouchStart?(
     day: Date,
     modifiers: DayModifiers,
     e: React.TouchEvent<HTMLDivElement>
-  ) => void;
-  onFocus?: (e: React.FocusEvent<HTMLDivElement>) => void;
-  onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
-  onMonthChange?: (month: Date) => void;
-  onTodayButtonClick?: (
+  ): void;
+  onFocus?(e: React.FocusEvent<HTMLDivElement>): void;
+  onKeyDown?(e: React.KeyboardEvent<HTMLDivElement>): void;
+  onMonthChange?(month: Date): void;
+  onTodayButtonClick?(
     day: Date,
     modifiers: DayModifiers,
     e: React.MouseEvent<HTMLButtonElement>
-  ) => void;
-  onWeekClick?: (
+  ): void;
+  onWeekClick?(
     weekNumber: number,
     days: Date[],
     e: React.MouseEvent<HTMLDivElement>
-  ) => void;
+  ): void;
   pagedNavigation?: boolean;
-  renderDay: (date: Date, modifiers: DayModifiers) => React.ReactNode;
-  renderWeek: (
-    weekNumber: number,
-    week: Date[],
-    month: Date
-  ) => React.ReactNode;
+  renderDay?(date: Date, modifiers: DayModifiers): React.ReactNode;
+  renderWeek?(weekNumber: number, week: Date[], month: Date): React.ReactNode;
   reverseMonths?: boolean;
   selectedDays?: Modifier | Modifier[];
   showWeekNumbers?: boolean;
@@ -162,29 +158,30 @@ export interface DayPickerInputProps {
   dayPickerProps?: DayPickerProps;
   inputProps?: object;
 
-  formatDate: (date: Date, format: string, locale: string) => string;
-  parseDate: (str: string, format: string, locale: string) => Date | void;
+  formatDate?(date: Date, format: string, locale: string): string;
+  parseDate?(str: string, format: string, locale: string): Date | void;
 
   hideOnDayClick?: boolean;
   clickUnselectsDay?: boolean;
   showOverlay?: boolean;
   keepFocus?: boolean;
 
+  // Not sure React.ComponentClass<any> is the right type for _propTypes2.default.any
   component?: any;
   overlayComponent?: any;
 
   classNames?: InputClassNames;
 
-  onDayChange: (
+  onDayChange?(
     day: Date,
     DayModifiers: DayModifiers,
     dayPickerInput: DayPickerInput
-  ) => void;
-  onDayPickerHide: () => void;
-  onDayPickerShow: () => void;
-  onChange?: (e: React.FocusEvent<HTMLDivElement>) => void;
-  onClick?: (e: React.FocusEvent<HTMLDivElement>) => void;
-  onFocus?: (e: React.FocusEvent<HTMLDivElement>) => void;
-  onBlur?: (e: React.FocusEvent<HTMLDivElement>) => void;
-  onKeyUp?: (e: React.FocusEvent<HTMLDivElement>) => void;
+  ): void;
+  onDayPickerHide?(): void;
+  onDayPickerShow?(): void;
+  onChange?(e: React.FocusEvent<HTMLDivElement>): void;
+  onClick?(e: React.FocusEvent<HTMLDivElement>): void;
+  onFocus?(e: React.FocusEvent<HTMLDivElement>): void;
+  onBlur?(e: React.FocusEvent<HTMLDivElement>): void;
+  onKeyUp?(e: React.FocusEvent<HTMLDivElement>): void;
 }

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "lib": ["es6", "dom"],
+    "lib": [
+      "es6",
+      "dom"
+    ],
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,
@@ -9,5 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "strictFunctionTypes": false
   },
-  "include": ["./*.d.ts"]
+  "include": [
+    "./*.d.ts"
+  ]
 }

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -26,9 +26,9 @@ export interface LocaleUtils {
     string
   ];
   parseDate(str: string, format?: string, locale?: string): Date;
-}
+};
 
-export type DateUtils = {
+export const DateUtils: {
   addDayToRange(day: Date, range: RangeModifier): RangeModifier;
   addMonths(d: Date, n: number): Date;
   clone(d: Date): Date;
@@ -43,7 +43,7 @@ export type DateUtils = {
   isSameMonth(day1: Date, day2: Date): boolean;
 };
 
-export type ModifiersUtils = {
+export const ModifiersUtils: {
   dayMatchesModifier(day: Date, modifier?: Modifier | Modifier[]): boolean;
   getModifiersForDay(
     day: Date,

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -2,7 +2,7 @@
 
 import { RangeModifier, Modifier } from './common';
 
-export interface LocaleUtils {
+export const LocaleUtils: {
   formatDate(date: Date, format?: string | string[], locale?: string): string;
   formatDay(day: Date, locale?: string): string;
   formatMonthTitle(month: Date, locale?: string): string;


### PR DESCRIPTION
adresses https://github.com/gpbl/react-day-picker/issues/948

This PR reverts the (unreleased) type refactorings and instead exports LocaleUtils as const again. This should fix the linked issue.

Imo, the refactoring is too big in scope and seems to be abandoned due to the new major release currently in development. This way, we have a working version again and aren't forced to pin to a lower version.