### PR TITLE
a11y fixes for v7

### DIFF
--- a/src/Caption.js
+++ b/src/Caption.js
@@ -51,7 +51,7 @@ export default class Caption extends Component {
       onClick,
     } = this.props;
     return (
-      <div className={classNames.caption} role="heading">
+      <div className={classNames.caption} role="heading" aria-live="polite">
         <div onClick={onClick} onKeyUp={this.handleKeyUp}>
           {months
             ? `${months[date.getMonth()]} ${date.getFullYear()}`

--- a/src/Day.js
+++ b/src/Day.js
@@ -137,7 +137,6 @@ export default class Day extends Component {
         tabIndex={tabIndex}
         style={style}
         role="gridcell"
-        aria-label={ariaLabel}
         aria-disabled={ariaDisabled}
         aria-selected={ariaSelected}
         onClick={handleEvent(onClick, day, modifiers)}
@@ -150,7 +149,8 @@ export default class Day extends Component {
         onTouchStart={handleEvent(onTouchStart, day, modifiers)}
         onFocus={handleEvent(onFocus, day, modifiers)}
       >
-        {children}
+        <span className="DayPicker-ScreenReaderOnly">{ariaLabel}</span>
+        <span aria-hidden="true">{children}</span>
       </div>
     );
   }

--- a/src/style.css
+++ b/src/style.css
@@ -210,3 +210,16 @@
   background: white;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
 }
+
+/* DayPicker a11y helpers */
+
+.DayPicker-ScreenReaderOnly {
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+}

--- a/test/daypicker/localization.js
+++ b/test/daypicker/localization.js
@@ -32,7 +32,7 @@ describe('DayPicker’s localization', () => {
       <DayPicker initialMonth={new Date(2015, 0)} firstDayOfWeek={1} />
     );
     expect(wrapper.find('.DayPicker-Weekday').first()).toHaveText('Mo');
-    expect(wrapper.find('.DayPicker-Day').at(3)).toHaveText('1');
+    expect(wrapper.find('.DayPicker-Day').at(3)).toHaveText('Thu Jan 01 20151');
   });
   it('should use the weekdaysShort prop to localize the weekday names', () => {
     const wrapper = mount(

--- a/test/daypicker/methods.js
+++ b/test/daypicker/methods.js
@@ -247,9 +247,9 @@ describe('DayPicker’s methods', () => {
         const previousNode = getDayNode(body, 0, 1);
         instance.focusPreviousDay(focusedNode);
 
-        expect(focusedNode.innerHTML).toBe('2');
-        expect(previousNode.innerHTML).toBe('1');
-        expect(document.activeElement.innerHTML).toBe('1');
+        expect(focusedNode.children[1].innerHTML).toBe('2');
+        expect(previousNode.children[1].innerHTML).toBe('1');
+        expect(document.activeElement.children[1].innerHTML).toBe('1');
         expect(instance.state.currentMonth.getMonth()).toBe(5);
       });
       it('should focus on the last day of the previous week', () => {
@@ -257,17 +257,17 @@ describe('DayPicker’s methods', () => {
         const previousNode = getDayNode(body, 0, 6);
         instance.focusPreviousDay(focusedNode);
 
-        expect(focusedNode.innerHTML).toBe('7');
-        expect(previousNode.innerHTML).toBe('6');
-        expect(document.activeElement.innerHTML).toBe('6');
+        expect(focusedNode.children[1].innerHTML).toBe('7');
+        expect(previousNode.children[1].innerHTML).toBe('6');
+        expect(document.activeElement.children[1].innerHTML).toBe('6');
         expect(instance.state.currentMonth.getMonth()).toBe(5);
       });
       it('should focus on the last day of the previous month', () => {
         const focusedNode = getDayNode(body, 0, 1);
         instance.focusPreviousDay(focusedNode);
 
-        expect(focusedNode.innerHTML).toBe('1');
-        expect(document.activeElement.innerHTML).toBe('31');
+        expect(focusedNode.children[1].innerHTML).toBe('1');
+        expect(document.activeElement.children[1].innerHTML).toBe('31');
         expect(instance.state.currentMonth.getMonth()).toBe(4);
       });
       it('should not throw an error when the node is not found', () => {
@@ -283,9 +283,9 @@ describe('DayPicker’s methods', () => {
         const nextNode = getDayNode(body, 0, 3);
         instance.focusNextDay(focusedNode);
 
-        expect(focusedNode.innerHTML).toBe('2');
-        expect(nextNode.innerHTML).toBe('3');
-        expect(document.activeElement.innerHTML).toBe('3');
+        expect(focusedNode.children[1].innerHTML).toBe('2');
+        expect(nextNode.children[1].innerHTML).toBe('3');
+        expect(document.activeElement.children[1].innerHTML).toBe('3');
         expect(instance.state.currentMonth.getMonth()).toBe(5);
       });
       it('should focus on the first day of the next week', () => {
@@ -293,17 +293,17 @@ describe('DayPicker’s methods', () => {
         const nextNode = getDayNode(body, 1, 0);
         instance.focusNextDay(focusedNode);
 
-        expect(focusedNode.innerHTML).toBe('6');
-        expect(nextNode.innerHTML).toBe('7');
-        expect(document.activeElement.innerHTML).toBe('7');
+        expect(focusedNode.children[1].innerHTML).toBe('6');
+        expect(nextNode.children[1].innerHTML).toBe('7');
+        expect(document.activeElement.children[1].innerHTML).toBe('7');
         expect(instance.state.currentMonth.getMonth()).toBe(5);
       });
       it('should focus on the first day of the next month', () => {
         const focusedNode = getDayNode(body, 4, 2);
         instance.focusNextDay(focusedNode);
 
-        expect(focusedNode.innerHTML).toBe('30');
-        expect(document.activeElement.innerHTML).toBe('1');
+        expect(focusedNode.children[1].innerHTML).toBe('30');
+        expect(document.activeElement.children[1].innerHTML).toBe('1');
         expect(instance.state.currentMonth.getMonth()).toBe(6);
       });
       it('should focus the first day of the next month after leapday', () => {
@@ -314,8 +314,8 @@ describe('DayPicker’s methods', () => {
         const focusedNode = getDayNode(body, 4, 1);
         instance.focusNextDay(focusedNode);
 
-        expect(focusedNode.innerHTML).toBe('29');
-        expect(document.activeElement.innerHTML).toBe('1');
+        expect(focusedNode.children[1].innerHTML).toBe('29');
+        expect(document.activeElement.children[1].innerHTML).toBe('1');
         expect(instance.state.currentMonth.getMonth()).toBe(2);
       });
       it('should not throw an error when the node is not found', () => {
@@ -330,23 +330,23 @@ describe('DayPicker’s methods', () => {
         const focusedNode = getDayNode(body, 2, 1);
         instance.focusNextWeek(focusedNode);
 
-        expect(focusedNode.innerHTML).toBe('15');
-        expect(document.activeElement.innerHTML).toBe('22');
+        expect(focusedNode.children[1].innerHTML).toBe('15');
+        expect(document.activeElement.children[1].innerHTML).toBe('22');
         expect(instance.state.currentMonth.getMonth()).toBe(5);
       });
       it('should focus on the same day of the next week in the next month', () => {
         const juneThirtieth = getDayNode(body, 4, 2);
-        expect(juneThirtieth.innerHTML).toBe('30');
+        expect(juneThirtieth.children[1].innerHTML).toBe('30');
 
         instance.focusNextWeek(juneThirtieth);
-        expect(document.activeElement.innerHTML).toBe('7');
+        expect(document.activeElement.children[1].innerHTML).toBe('7');
         expect(instance.state.currentMonth.getMonth()).toBe(6);
 
         const julyThirtyFirst = getDayNode(body, 4, 5);
-        expect(julyThirtyFirst.innerHTML).toBe('31');
+        expect(julyThirtyFirst.children[1].innerHTML).toBe('31');
 
         instance.focusNextWeek(julyThirtyFirst);
-        expect(document.activeElement.innerHTML).toBe('7');
+        expect(document.activeElement.children[1].innerHTML).toBe('7');
         expect(instance.state.currentMonth.getMonth()).toBe(7);
       });
     });
@@ -354,25 +354,25 @@ describe('DayPicker’s methods', () => {
     describe('focusPreviousWeek()', () => {
       it('should focus on the same day of the previous week', () => {
         const focusedNode = getDayNode(body, 2, 1);
-        expect(focusedNode.innerHTML).toBe('15');
+        expect(focusedNode.children[1].innerHTML).toBe('15');
 
         instance.focusPreviousWeek(focusedNode);
-        expect(document.activeElement.innerHTML).toBe('8');
+        expect(document.activeElement.children[1].innerHTML).toBe('8');
         expect(instance.state.currentMonth.getMonth()).toBe(5);
       });
       it('should focus on the same day of the previous week in the previous month', () => {
         const juneFirst = getDayNode(body, 0, 1);
-        expect(juneFirst.innerHTML).toBe('1');
+        expect(juneFirst.children[1].innerHTML).toBe('1');
 
         instance.focusPreviousWeek(juneFirst);
-        expect(document.activeElement.innerHTML).toBe('25');
+        expect(document.activeElement.children[1].innerHTML).toBe('25');
         expect(instance.state.currentMonth.getMonth()).toBe(4);
 
         const maySecond = getDayNode(body, 1, 0);
-        expect(maySecond.innerHTML).toBe('3');
+        expect(maySecond.children[1].innerHTML).toBe('3');
 
         instance.focusPreviousWeek(maySecond);
-        expect(document.activeElement.innerHTML).toBe('26');
+        expect(document.activeElement.children[1].innerHTML).toBe('26');
         expect(instance.state.currentMonth.getMonth()).toBe(3);
       });
     });

--- a/test/daypicker/modifiers.js
+++ b/test/daypicker/modifiers.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import DayPicker from '../../src/DayPicker';
+import * as LocaleUtils from '../../src/LocaleUtils';
 
 describe('DayPicker’s day modifiers', () => {
   it('should use `selectedDays` prop as `selected` modifier', () => {
@@ -66,9 +67,11 @@ describe('DayPicker’s day modifiers', () => {
     );
   });
   it('should include "today"', () => {
+    const today = new Date();
+    const formattedDate = LocaleUtils.formatDay(today);
     const wrapper = mount(<DayPicker />);
     expect(wrapper.find('.DayPicker-Day--today')).toHaveText(
-      `Mon Nov 25 2019${new Date().getDate().toString()}`
+      `${formattedDate}${today.getDate().toString()}`
     );
   });
   it('should add custom modifiers', () => {

--- a/test/daypicker/modifiers.js
+++ b/test/daypicker/modifiers.js
@@ -68,7 +68,7 @@ describe('DayPicker’s day modifiers', () => {
   it('should include "today"', () => {
     const wrapper = mount(<DayPicker />);
     expect(wrapper.find('.DayPicker-Day--today')).toHaveText(
-      new Date().getDate().toString()
+      `Mon Nov 25 2019${new Date().getDate().toString()}`
     );
   });
   it('should add custom modifiers', () => {
@@ -94,7 +94,7 @@ describe('DayPicker’s day modifiers', () => {
       <DayPicker initialMonth={new Date(2018, 2, 10)} modifiers={modifiers} />
     );
     expect(wrapper.find('.DayPicker-Day--today')).toHaveText(
-      newToday.getDate().toString()
+      `Sun Mar 11 2018${newToday.getDate().toString()}`
     );
   });
 });

--- a/test/daypicker/rendering.js
+++ b/test/daypicker/rendering.js
@@ -164,7 +164,9 @@ describe('DayPicker’s rendering', () => {
         renderDay={renderDay}
       />
     );
-    expect(wrapper.find('.DayPicker-Day').first()).toHaveText('bar');
+    expect(wrapper.find('.DayPicker-Day').first()).toHaveText(
+      'Sun Oct 27 2019bar'
+    );
   });
   it('should render a custom number of months', () => {
     const wrapper = render(<DayPicker numberOfMonths={3} />);
@@ -309,9 +311,15 @@ describe('DayPicker’s rendering', () => {
     const wrapper = mount(
       <DayPicker showOutsideDays initialMonth={new Date(2015, 6)} />
     );
-    expect(wrapper.find('.DayPicker-Day').at(0)).toHaveText('28');
-    expect(wrapper.find('.DayPicker-Day').at(1)).toHaveText('29');
-    expect(wrapper.find('.DayPicker-Day').at(2)).toHaveText('30');
+    expect(wrapper.find('.DayPicker-Day').at(0)).toHaveText(
+      'Sun Jun 28 201528'
+    );
+    expect(wrapper.find('.DayPicker-Day').at(1)).toHaveText(
+      'Mon Jun 29 201529'
+    );
+    expect(wrapper.find('.DayPicker-Day').at(2)).toHaveText(
+      'Tue Jun 30 201530'
+    );
   });
   it('should not allow tabbing to outside days', () => {
     const wrapper = mount(

--- a/test/daypickerinput/events.js
+++ b/test/daypickerinput/events.js
@@ -299,7 +299,9 @@ describe('DayPickerInput', () => {
           .simulate('click');
         expect(wrapper.find('input')).toHaveProp('value', '2017-2-8');
         expect(wrapper.find('.DayPicker-Caption')).toHaveText('February 2017');
-        expect(wrapper.find('.DayPicker-Day--selected')).toHaveText('8');
+        expect(wrapper.find('.DayPicker-Day--selected')).toHaveText(
+          'Wed Feb 08 20178'
+        );
       });
       it('should call `onDayChange` when clicking on a day', () => {
         const onDayChange = jest.fn();
@@ -474,8 +476,8 @@ describe('DayPickerInput', () => {
           .simulate('click');
         const selectedDays = wrapper.find('.DayPicker-Day--selected');
         expect(selectedDays).toHaveLength(2);
-        expect(selectedDays.at(0)).toHaveText('8');
-        expect(selectedDays.at(1)).toHaveText('9');
+        expect(selectedDays.at(0)).toHaveText('Wed Feb 08 20178');
+        expect(selectedDays.at(1)).toHaveText('Thu Feb 09 20179');
       });
       it('should use `dayPickerProps.selectedDays` after typing a valid day', () => {
         const wrapper = mount(
@@ -493,8 +495,8 @@ describe('DayPickerInput', () => {
           .simulate('change', { target: { value: '02/07/2017' } });
         const selectedDays = wrapper.find('.DayPicker-Day--selected');
         expect(selectedDays).toHaveLength(2);
-        expect(selectedDays.at(0)).toHaveText('8');
-        expect(selectedDays.at(1)).toHaveText('9');
+        expect(selectedDays.at(0)).toHaveText('Wed Feb 08 20178');
+        expect(selectedDays.at(1)).toHaveText('Thu Feb 09 20179');
       });
     });
 

--- a/test/daypickerinput/rendering.js
+++ b/test/daypickerinput/rendering.js
@@ -119,7 +119,9 @@ describe('DayPickerInput', () => {
       wrapper.instance().showDayPicker();
       wrapper.update();
       expect(wrapper.find('.DayPicker-Day--selected')).toHaveLength(1);
-      expect(wrapper.find('.DayPicker-Day--selected')).toHaveText('15');
+      expect(wrapper.find('.DayPicker-Day--selected')).toHaveText(
+        'Fri Dec 15 201715'
+      );
     });
     it('should clear timeouts when component unmounts', () => {
       const container = document.createElement('div');


### PR DESCRIPTION
Problem:
1.	The full date of a day cell in the calendar day picker grid is not announced with NVDA, just the number of the day (e.g. 11 instead of Wednesday November 11th, 2019)
2.	The month name is not announced when changing between months

Solution:
1.	Some screen readers (NVDA) do not read ariaLabels directly on `<div>`s. 
a.	Place the visible text in a span hidden from screen readers
b.	have the screen readers read from a separate span that contains the ariaLabels.
c.	Add css class to hide only the screen reader span from display.
2.	Add aria-live=”polite” to caption so that it reads the month when changing between months.
