### PR TITLE
Added TodayButtonElement Prop for daypicker

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -591,7 +591,7 @@ export class DayPicker extends Component {
     const { todayButtonElement } = this.props;
 
     const props = {
-      onClick: this.handleTodayButtonClick,
+      onTodayButtonElementClick: this.handleTodayButtonClick,
     };
     return React.isValidElement(todayButtonElement)
       ? React.cloneElement(todayButtonElement, props)

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -109,6 +109,11 @@ export class DayPicker extends Component {
       PropTypes.func,
       PropTypes.instanceOf(Component),
     ]),
+    todayButtonElement: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.func,
+      PropTypes.instanceOf(Component),
+    ]),
 
     // Events
     onBlur: PropTypes.func,
@@ -556,10 +561,12 @@ export class DayPicker extends Component {
   }
 
   renderFooter() {
-    if (this.props.todayButton) {
+    if (this.props.todayButton || this.props.todayButtonElement) {
       return (
         <div className={this.props.classNames.footer}>
-          {this.renderTodayButton()}
+          {this.props.todayButtonElement
+            ? this.renderTodayButtonElement()
+            : this.renderTodayButton()}
         </div>
       );
     }
@@ -578,6 +585,17 @@ export class DayPicker extends Component {
         {this.props.todayButton}
       </button>
     );
+  }
+
+  renderTodayButtonElement() {
+    const { todayButtonElement } = this.props;
+
+    const props = {
+      onClick: this.handleTodayButtonClick,
+    };
+    return React.isValidElement(todayButtonElement)
+      ? React.cloneElement(todayButtonElement, props)
+      : React.createElement(todayButtonElement, props);
   }
 
   render() {

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -45,6 +45,10 @@ export interface WeekdayElementProps {
   weekdaysShort?: string[];
 }
 
+export interface TodayButtonElementProps {
+  onTodayButtonElementClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
 export interface DayPickerProps {
   canChangeMonth?: boolean;
   captionElement?:
@@ -152,6 +156,10 @@ export interface DayPickerProps {
   weekdaysLong?: string[];
   weekdaysShort?: string[];
   tabIndex?: number;
+  todayButtonElement?:
+    | React.ReactElement<Partial<TodayButtonElementProps>>
+    | React.ComponentClass<TodayButtonElementProps>
+    | React.SFC<TodayButtonElementProps>;
 }
 
 export interface DayPickerInputProps {


### PR DESCRIPTION
Added a property for the daypicker to render a custom todayButtonElement inside the footer. If the property ```todayButtonElement``` exists, we will render the custom component instead of the default ```<button>```.