### PR TITLE
aria-disabled and aria-selected break when using custom classNames prop

### DIFF
--- a/src/Month.js
+++ b/src/Month.js
@@ -106,8 +106,8 @@ export default class Month extends Component {
         }
         tabIndex={tabIndex}
         ariaLabel={this.props.localeUtils.formatDay(day, this.props.locale)}
-        ariaDisabled={isOutside || dayModifiers.indexOf('disabled') > -1}
-        ariaSelected={dayModifiers.indexOf('selected') > -1}
+        ariaDisabled={isOutside || dayModifiers.indexOf(this.props.classNames.disabled) > -1}
+        ariaSelected={dayModifiers.indexOf(this.props.classNames.selected) > -1}
         onClick={this.props.onDayClick}
         onFocus={this.props.onDayFocus}
         onKeyDown={this.props.onDayKeyDown}


### PR DESCRIPTION
When checking if an item is selected or disabled, we need to use the classNames given to the component rather than hardcoded strings. When using hardcoded strings, it will break when custom classNames are provided