### PR TITLE
Remove initialMonth from defaultProps (#2)

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -132,7 +132,6 @@ export class DayPicker extends Component {
   static defaultProps = {
     classNames,
     tabIndex: 0,
-    initialMonth: new Date(),
     numberOfMonths: 1,
     labels: {
       previousMonth: 'Previous Month',
@@ -186,7 +185,7 @@ export class DayPicker extends Component {
    */
   getCurrentMonthFromProps(props) {
     const initialMonth = Helpers.startOfMonth(
-      props.month || props.initialMonth
+      props.month || props.initialMonth || new Date()
     );
     let currentMonth = initialMonth;
 


### PR DESCRIPTION
Original Issue: https://github.com/gpbl/react-day-picker/issues/861
Original PR: https://github.com/gpbl/react-day-picker/pull/874

I originally submitted a PR to fix this bug last year, however I mistakenly edited the wrong source files (`/lib/src`) instead of (`/src`).  Consequently this bug fix never made it into v7.4.  This PR makes the same bug fix, but in the correct file.