### PR TITLE
Export MomentLocaleUtils as value

### DIFF
--- a/types/moment.d.ts
+++ b/types/moment.d.ts
@@ -1,2 +1,2 @@
 import { LocaleUtils } from './utils';
-export type MomentLocaleUtils = LocaleUtils;
+export const MomentLocaleUtils: LocaleUtils;


### PR DESCRIPTION
We need to import `MomentLocaleUtils` from `react-day-picker/moment` as a value, not just as a type:

```typescript
import * as React from 'react';

import DayPicker, { DayPickerProps } from 'react-day-picker';
import MomentLocaleUtils from 'react-day-picker/moment';

/* ... */

    <DayPicker
      // ...
      localeUtils={MomentLocaleUtils}
      // ...
    />
```

The proposed change fixes this type error.
