### PR TITLE
DayPicker props renderDay and renderWeek are optional

### DIFF
--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -133,8 +133,8 @@ export interface DayPickerProps {
     e: React.MouseEvent<HTMLDivElement>
   ) => void;
   pagedNavigation?: boolean;
-  renderDay: (date: Date, modifiers: DayModifiers) => React.ReactNode;
-  renderWeek: (
+  renderDay?: (date: Date, modifiers: DayModifiers) => React.ReactNode;
+  renderWeek?: (
     weekNumber: number,
     week: Date[],
     month: Date


### PR DESCRIPTION
If the `renderDay` and `renderWeek` props are not specified for `<DayPicker>`, defaults [kick in via `defaultProps`](https://github.com/gpbl/react-day-picker/blob/v7/src/DayPicker.js#L150-L151).

This PR indicates to TypeScript that they aren't mandatory.
