### PR TITLE
Add aria-polite to announce month change during navigation

### DIFF
--- a/src/Caption.js
+++ b/src/Caption.js
@@ -51,7 +51,7 @@ export default class Caption extends Component {
       onClick,
     } = this.props;
     return (
-      <div className={classNames.caption} role="heading">
+      <div className={classNames.caption} role="heading" aria-live="polite">
         <div onClick={onClick} onKeyUp={this.handleKeyUp}>
           {months
             ? `${months[date.getMonth()]} ${date.getFullYear()}`


### PR DESCRIPTION
Hiya! Friend from Shedd here again - it turns out the other issue was actually fixed in a later version of v7 (and we just needed to update), so here's a PR just for the `aria-live="polite"` bit!  This allows the NVDA screenreader to announce the changing text in the month header. Thank you for your work! 💖