### PR TITLE
fix(Caption): improve accessibility roles for Caption-Month relationship

### DIFF
--- a/src/Caption.js
+++ b/src/Caption.js
@@ -52,7 +52,7 @@ export default class Caption extends Component {
       onClick,
     } = this.props;
     return (
-      <caption
+      <div
         className={classNames.caption}
         id={captionId(date)}
         aria-live="polite"
@@ -62,7 +62,7 @@ export default class Caption extends Component {
             ? `${months[date.getMonth()]} ${date.getFullYear()}`
             : localeUtils.formatMonthTitle(date, locale)}
         </div>
-      </caption>
+      </div>
     );
   }
 }

--- a/src/Caption.js
+++ b/src/Caption.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import LocaleUtils from './LocaleUtils';
+import { captionId } from './CaptionUtils';
 
 import { ENTER } from './keys';
 
@@ -51,13 +52,17 @@ export default class Caption extends Component {
       onClick,
     } = this.props;
     return (
-      <div className={classNames.caption} role="heading" aria-live="polite">
+      <caption
+        className={classNames.caption}
+        id={captionId(date)}
+        aria-live="polite"
+      >
         <div onClick={onClick} onKeyUp={this.handleKeyUp}>
           {months
             ? `${months[date.getMonth()]} ${date.getFullYear()}`
             : localeUtils.formatMonthTitle(date, locale)}
         </div>
-      </div>
+      </caption>
     );
   }
 }

--- a/src/CaptionUtils.js
+++ b/src/CaptionUtils.js
@@ -1,0 +1,2 @@
+export const captionId = (date) =>
+  `react-day-picker-caption-${date.getMonth()}`;

--- a/src/Month.js
+++ b/src/Month.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Weekdays from './Weekdays';
 import Day from './Day';
 import { ENTER } from './keys';
+import { captionId } from './CaptionUtils';
 
 import * as ModifiersUtils from './ModifiersUtils';
 import * as Helpers from './Helpers';
@@ -165,7 +166,7 @@ export default class Month extends Component {
 
     const weeks = Helpers.getWeekArray(month, firstDayOfWeek, fixedWeeks);
     return (
-      <div className={classNames.month} role="grid">
+      <div className={classNames.month} role="grid" aria-describedby={captionId(date)}>
         {caption}
         {showWeekDays && (
           <Weekdays

--- a/src/Month.js
+++ b/src/Month.js
@@ -166,7 +166,11 @@ export default class Month extends Component {
 
     const weeks = Helpers.getWeekArray(month, firstDayOfWeek, fixedWeeks);
     return (
-      <div className={classNames.month} role="grid" aria-describedby={captionId(date)}>
+      <div
+        className={classNames.month}
+        role="grid"
+        aria-describedby={captionId(month)}
+      >
         {caption}
         {showWeekDays && (
           <Weekdays

--- a/test/daypicker/rendering.js
+++ b/test/daypicker/rendering.js
@@ -459,4 +459,17 @@ describe('Day.shouldComponentUpdate', () => {
     const newProps = Object.assign({}, day.props, { onKeyDown: () => {} });
     expect(day.shouldComponentUpdate(newProps)).toBeTruthy();
   });
+
+  it('should have an accessible caption', () => {
+    const dayPicker = mount(<DayPicker initialMonth={new Date(2020, 10)} />);
+    const captionId = 'react-day-picker-caption-10';
+
+    const monthCaption = dayPicker.find(`#${captionId}`);
+    const calendarContainer = dayPicker.find(
+      `div[aria-describedby="${captionId}"]`
+    );
+
+    expect(monthCaption).toHaveLength(1);
+    expect(calendarContainer).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
- Fixes an accessibility issue with having `role="heading"` on the caption column. Usually heading roles described semantically is the same as h1, h2, etc, so in this case we don't want to break page flow and should use a relationship with aria-describedby instead.

Storybook accessibility audit report:
Before:
![Screen Shot 2020-06-23 at 11 54 49 AM](https://user-images.githubusercontent.com/17029928/85426365-5ebdef00-b548-11ea-8229-9d6ed4dde298.png)

After:
![Screen Shot 2020-06-23 at 11 35 49 AM](https://user-images.githubusercontent.com/17029928/85426302-4a79f200-b548-11ea-97b4-71975723b4db.png)
