### PR TITLE
Minor a11y updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-day-picker",
-  "version": "7.5.8",
+  "version": "7.5.0",
   "description": "Flexible date picker component for React",
   "main": "lib/react-day-picker.min.js",
   "module": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-day-picker",
-  "version": "7.4.8",
+  "version": "7.5.8",
   "description": "Flexible date picker component for React",
   "main": "lib/react-day-picker.min.js",
   "module": "build/index.js",

--- a/src/Day.js
+++ b/src/Day.js
@@ -136,9 +136,7 @@ export default class Day extends Component {
         className={className}
         tabIndex={tabIndex}
         style={style}
-        aria-label={ariaLabel}
-        aria-disabled={ariaDisabled}
-        aria-selected={ariaSelected}
+        role="gridcell"
         onClick={handleEvent(onClick, day, modifiers)}
         onKeyDown={handleEvent(onKeyDown, day, modifiers)}
         onMouseEnter={handleEvent(onMouseEnter, day, modifiers)}
@@ -149,7 +147,9 @@ export default class Day extends Component {
         onTouchStart={handleEvent(onTouchStart, day, modifiers)}
         onFocus={handleEvent(onFocus, day, modifiers)}
       >
-        {children}
+        <div aria-label={ariaLabel} aria-disabled={ariaDisabled} role="button">
+          {children}
+        </div>
       </div>
     );
   }

--- a/src/Day.js
+++ b/src/Day.js
@@ -136,7 +136,7 @@ export default class Day extends Component {
         className={className}
         tabIndex={tabIndex}
         style={style}
-        role="gridcell"
+        role="button"
         aria-label={ariaLabel}
         aria-disabled={ariaDisabled}
         aria-selected={ariaSelected}

--- a/src/Day.js
+++ b/src/Day.js
@@ -136,7 +136,6 @@ export default class Day extends Component {
         className={className}
         tabIndex={tabIndex}
         style={style}
-        role="button"
         aria-label={ariaLabel}
         aria-disabled={ariaDisabled}
         aria-selected={ariaSelected}

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -591,6 +591,10 @@ export class DayPicker extends Component {
     return (
       <div
         {...this.props.containerProps}
+        aria-modal="true"
+        aria-labelledby="IDREF"
+        aria-live="polite"
+        role="dialog"
         className={className}
         ref={el => (this.dayPicker = el)}
         lang={this.props.locale}


### PR DESCRIPTION
- `<Day />` - Removing the role of gridcell because screen readers do not recognize it as a button
- `<DayPicker />` - Adding a few needed `aria` attributes

Resources - https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/datepicker-dialog.html