### PR TITLE
Fix month prop for DatePickerInput

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -311,9 +311,11 @@ export default class DayPickerInput extends React.Component {
       return;
     }
     // Reset the current displayed month when showing the overlay
-    const month = value
-      ? parseDate(value, format, dayPickerProps.locale) // Use the month in the input field
-      : this.getInitialMonthFromProps(this.props); // Restore the month from the props
+    const month =
+      dayPickerProps.month || value // Always open to month, if month prop set
+        ? parseDate(value, format, dayPickerProps.locale) // Use the month in the input field
+        : this.getInitialMonthFromProps(this.props); // Restore the month from the props
+
     this.setState(
       state => ({
         showOverlay: true,


### PR DESCRIPTION
The `month` prop is being ignored if used in `DatePickerInput`. According to docs: http://react-day-picker.js.org/api/DayPicker#month if `month` is set the calendar should open with the specified month displayed.

To see the bug in action https://codesandbox.io/s/y70dr