### PR TITLE
Addition of build step in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,13 @@ cd react-day-picker
 yarn install
 ```
 
-#### 2. Start the development environment
+#### 2. Build workspaces
+
+```bash
+yarn build
+```
+
+#### 3. Start the development environment
 
 Build the package and website in watch mode:
 
@@ -35,7 +41,7 @@ Build the package and website in watch mode:
 yarn develop
 ```
 
-#### 3. Apply changes and open a PR :)
+#### 4. Apply changes and open a PR :)
 
 * add tests and make sure they pass: `yarn test`
 * make sure your files are linted: `yarn lint`


### PR DESCRIPTION
### Problem
**1. yarn install** 
Downloads and installs all dependencies
**2. yarn develop** 
Fails with `Module not found: Can't resolve './react-day-picker/dist/style.css' in 'D:\Projects\open-source\react-day-picker\website\src\components\Frame'`

### Root cause
Error says that `style.css` is expected to be present in `dist` directory. However, `dist` directory is not present unless all workspaces are built successfully.

### Solution
`yarn build` needs to be run before `yarn develop`

This PR updates the corresponding piece of information in CONTRIBUTING.md