### PR TITLE
Corrected typing for RangerModifier

### DIFF
--- a/types/Modifiers.d.ts
+++ b/types/Modifiers.d.ts
@@ -1,11 +1,6 @@
 export interface RangeModifier {
-  from: Date;
-  to: Date;
-}
-
-export interface RangeModifier {
-  from: Date;
-  to: Date;
+  from: Date | undefined;
+  to: Date | undefined;
 }
 
 export interface BeforeModifier {


### PR DESCRIPTION
Came across a typing issue when using react-day-picker in our Typescript project.

Specifically, making use of the util function `addDayToRange`. The typing for `addDayToRange` is defined as:
`addDayToRange(day: Date, range: RangeModifier): RangeModifier;`. 
where `export interface RangeModifier {
  from: Date;
  to: Date;
}`

However the function `addDayToRange`, implemented in `DateUtils.js`expects (and handles) null date objects (from and to) objects, which contradicts the current typing for `RangeModifier`

I simply changed the typing to allow for the dates to be `undefined` within the `RangeModifier` object, and this solved the typing issues we were experiencing.

I also noticed `RangeModifier` was defined twice, so I removed the duplicate.

Cheers!
