### PR TITLE
Wrapper - add the ability to remove the tabIndex

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -591,7 +591,7 @@ export class DayPicker extends Component {
       className = `${className} ${this.props.className}`;
     }
     
-    let tabIndex = undefined;ֿ
+    let tabIndex = undefined;
 
     if (!this.props.removeWrapperTabIndex) {
       tabIndex = (this.props.canChangeMonth && typeof this.props.tabIndex !== 'undefined') ? this.props.tabIndex : -1;

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -591,9 +591,11 @@ export class DayPicker extends Component {
       className = `${className} ${this.props.className}`;
     }
     
-    const tabIndex = !this.props.removeWrapperTabIndex ? (
-        this.props.canChangeMonth && typeof this.props.tabIndex !== 'undefined' ? this.props.tabIndex : -1
-      ) : undefined;
+    let tabIndex = undefined;ֿ
+
+    if (!this.props.removeWrapperTabIndex) {
+      tabIndex = (this.props.canChangeMonth && typeof this.props.tabIndex !== 'undefined') ? this.props.tabIndex : -1;
+    }
 
     return (
       <div

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -90,6 +90,7 @@ export class DayPicker extends Component {
     className: PropTypes.string,
     containerProps: PropTypes.object,
     tabIndex: PropTypes.number,
+    removeWrapperTabIndex: PropTypes.bool,
 
     // Custom elements
     renderDay: PropTypes.func,
@@ -132,6 +133,7 @@ export class DayPicker extends Component {
   static defaultProps = {
     classNames,
     tabIndex: 0,
+    removeWrapperTabIndex: false,
     numberOfMonths: 1,
     labels: {
       previousMonth: 'Previous Month',
@@ -588,6 +590,11 @@ export class DayPicker extends Component {
     if (this.props.className) {
       className = `${className} ${this.props.className}`;
     }
+    
+    const tabIndex = !this.props.removeWrapperTabIndex ? (
+        this.props.canChangeMonth && typeof this.props.tabIndex !== 'undefined' ? this.props.tabIndex : -1
+      ) : undefined;
+
     return (
       <div
         {...this.props.containerProps}
@@ -598,12 +605,7 @@ export class DayPicker extends Component {
         <div
           className={this.props.classNames.wrapper}
           ref={el => (this.wrapper = el)}
-          tabIndex={
-            this.props.canChangeMonth &&
-            typeof this.props.tabIndex !== 'undefined'
-              ? this.props.tabIndex
-              : -1
-          }
+          tabIndex={tabIndex}
           onKeyDown={this.handleKeyDown}
           onFocus={this.props.onFocus}
           onBlur={this.props.onBlur}


### PR DESCRIPTION
When we are talking about a calendar without an input there is no need to add a focus on the wrapper element at all. So we need the ability to remove the tabindex property from this element at all.
Thanks!

👋🏽 Thanks for opening a pull request!

* Please explain clearly your changes. If they involve a lot of code, let discuss them first in on our chat: https://spectrum.chat/react-day-picker?tab=chat
* 🙏🏽 Please **DO NOT** build files or update the docs in your pull request – as this may cause git conflicts. Thanks!
