### PR TITLE
Reference the commonjs and ESM outputs in the package.json

### DIFF
--- a/packages/react-day-picker/package.json
+++ b/packages/react-day-picker/package.json
@@ -12,7 +12,8 @@
   "bugs": {
     "url": "https://github.com/gpbl/react-day-picker/issues"
   },
-  "main": "lib/index.js",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
   "types": "lib/index.d.ts",
   "scripts": {
     "develop": "concurrently --names='tsc-alias,tsc' 'yarn tsc-alias -w' 'yarn tsc -w'",


### PR DESCRIPTION
This module ships with a dist folder, but the package.json does not reference any of the build outputs.

On a related note, I wonder if you've considered using a tool like [`microbundle`](https://github.com/developit/microbundle) to simplify the build process? It makes the build process a little less painful, but I can also imagine it being too opinionated for some projects.