### PR TITLE
docs: fix v7 github link in styling doc

### DIFF
--- a/docs/src/pages/docs/styling.js
+++ b/docs/src/pages/docs/styling.js
@@ -12,7 +12,7 @@ export default () => (
   <DocPage title="Styling">
     <p>
       To style the component, use{' '}
-      <a href="https://github.com/gpbl/react-day-picker/blob/master/src/style.css">
+      <a href="https://github.com/gpbl/react-day-picker/blob/v7/src/style.css">
         src/style.css
       </a>{' '}
       as template and update it to fit the desired style. Then, just include it


### PR DESCRIPTION
👋🏽 Thanks for opening a pull request!

* Please explain clearly your changes. If they involve a lot of code, let discuss them first in on our chat: https://spectrum.chat/react-day-picker?tab=chat
* 🙏🏽 Please **DO NOT** build files or update the docs in your pull request – as this may cause git conflicts. Thanks!

Reading the docs for v7, this link results in a 404 because it doesn't exist on the master branch.