### PR TITLE
Fix export issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Flexible date picker component for React",
   "browser": "lib/react-day-picker.min.js",
   "main": "build/index.js",
+  "module": "build/index.js",
   "types": "types/index.d.ts",
   "style": "lib/style.css",
   "files": [


### PR DESCRIPTION
I think this should fix:
Closes https://github.com/gpbl/react-day-picker/issues/1205
Closes https://github.com/gpbl/react-day-picker/issues/1039

How webpack uses export keys:
https://github.com/webpack/webpack/issues/4674#issuecomment-639669772
