### PR TITLE
Remove null option from RangeModifier type to fix mismatched type signatures

### DIFF
--- a/types/Modifiers.d.ts
+++ b/types/Modifiers.d.ts
@@ -1,6 +1,6 @@
 export interface RangeModifier {
-  from: Date | undefined | null;
-  to: Date | undefined | null;
+  from: Date | undefined;
+  to: Date | undefined;
 }
 
 export interface BeforeModifier {
@@ -30,7 +30,6 @@ export type Modifier =
   | BeforeAfterModifier
   | DaysOfWeekModifier
   | FunctionModifier
-  | null
   | undefined;
 
 export interface Modifiers {

--- a/types/Modifiers.d.ts
+++ b/types/Modifiers.d.ts
@@ -30,6 +30,7 @@ export type Modifier =
   | BeforeAfterModifier
   | DaysOfWeekModifier
   | FunctionModifier
+  | null
   | undefined;
 
 export interface Modifiers {


### PR DESCRIPTION
Fixes a typescript error where the RangeModifier attributes are not valid Modifiers, by allowing Modifiers to be null

Each part of the RangeModifier is supposed to be a valid Modifier. This is shown in the example here: https://react-day-picker.js.org/examples/selected-range/

Notice how the `from` attribute is used as a Modifier several times in the example.

However, because the `RangeModifier` type now supports `null` (as of v7.4.9), the `RangeModifier.from` and `RangeModifier.to` attributes are no longer valid Modifier types (Modifiers cannot be `null`).

```
RangeModifier {
  from: Date | undefined | null;
  to: Date | undefined | null;
}
```

Therefore, when you're storing a `RangeModifier` type in state, and using the `from` and `to` attributes as other Modifiers, typescript generates errors, specifically:
```
    Type 'Date | null | undefined' is not assignable to type 'Modifier'.
```


These errors should be generated in v7.4.9 and v7.4.10 with the following code:

```
import React, { useState } from 'react';
import DayPicker, { DateUtils, RangeModifier } from 'react-day-picker';
import 'react-day-picker/lib/style.css';


function Example() {

    const [range, setRange] = useState<RangeModifier>({ from: undefined, to: undefined })

    const handleDayClick = (day: Date) => {
        const newRange = DateUtils.addDayToRange(day, range);
        setRange(newRange)
    }

    const { from, to } = range;
    const modifiers = { start: from, end: to };
    return (
      <DayPicker
          className="Selectable"
          selectedDays={[from, { from, to }]}
          modifiers={modifiers}
          onDayClick={handleDayClick}
      />
    );
}
```