### PR TITLE
ESModules compliant export of DayPickerInput

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,3 +2,4 @@ export { default } from './DayPicker';
 export { default as DateUtils } from './DateUtils';
 export { default as LocaleUtils } from './LocaleUtils';
 export { default as ModifiersUtils } from './ModifiersUtils';
+export { default as DayPickerInput } from './DayPickerInput';


### PR DESCRIPTION
ESModules compliant export of DayPickerInput
This lib @ 7.4.10 currently blocks me and my team from moving forward with Vite/Rollup because DayPickerInput does not export in an ES Modules compliant way. This should now export DayPickerInput from the index of DayPicker.

this should resolve this open issue:
#1194

So we can import like this:

import { DayPickerInput } from 'react-day-picker';