### PR TITLE
Fix DateUtils.addDayToRange second argument typing

### DIFF
--- a/types/DateUtils.d.ts
+++ b/types/DateUtils.d.ts
@@ -1,7 +1,7 @@
 import { RangeModifier } from './Modifiers';
 
 export const DateUtils: {
-  addDayToRange(day: Date, range: RangeModifier): RangeModifier;
+  addDayToRange(day: Date, range?: RangeModifier): RangeModifier;
   addMonths(d: Date, n: number): Date;
   clone(d: Date): Date;
   isDate(d: Date): boolean;


### PR DESCRIPTION
It's to fix the typing on DateUtils.addDayToRange which doesn't accept undefined as second argument whereas it is perfectly able to handle it.