### PR TITLE
Update Navigation.tsx

### DIFF
--- a/packages/react-day-picker/src/components/Navigation/Navigation.tsx
+++ b/packages/react-day-picker/src/components/Navigation/Navigation.tsx
@@ -31,7 +31,7 @@ export function Navigation(props: NavigationProps): JSX.Element {
   const nextLabel = labelNext(nextMonth, { locale });
   const nextClassName = [
     classNames.nav_button,
-    classNames.nav_button_previous
+    classNames.nav_button_next
   ].join(' ');
 
   const previousButton = (


### PR DESCRIPTION
This change fixes the issue that the 'nav_button_previous' className is added to both nav buttons instead of only the previous button.