### PR TITLE
Allow Head to be replaced

### DIFF
--- a/packages/react-day-picker/src/components/Table/Table.tsx
+++ b/packages/react-day-picker/src/components/Table/Table.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import { Head } from 'components/Head';
 import { useDayPicker } from 'contexts/DayPicker';
 
 import { getWeeks } from './utils/getWeeks';
@@ -23,7 +22,7 @@ export function Table(props: TableProps): JSX.Element {
     styles,
     hideHead,
     fixedWeeks,
-    components: { Row, Footer }
+    components: { Head, Row, Footer }
   } = useDayPicker();
   const weeks = getWeeks(props.displayMonth, { locale, fixedWeeks });
   return (


### PR DESCRIPTION
Currently `Head` cannot be replaced with a custom component as per [documentation](https://react-day-picker-next.netlify.app/api/interfaces/components#head). This PR allows a custom `Head` component to be used.