### PR TITLE
v7: Added support for MouseEnter and MouseLeave events on WeekNumber

### DIFF
--- a/docs/src/code-samples/examples/customization-week-numbers.js
+++ b/docs/src/code-samples/examples/customization-week-numbers.js
@@ -7,6 +7,8 @@ export default function Example() {
     <DayPicker
       showWeekNumbers
       onWeekClick={(week, days) => console.log(week, days)}
+      onWeekMouseEnter={(week, days) => console.log(week, days)}
+      onWeekMouseLeave={(week, days) => console.log(week, days)}
     />
   );
 }

--- a/docs/src/code-samples/examples/selected-week.js
+++ b/docs/src/code-samples/examples/selected-week.js
@@ -57,6 +57,18 @@ export default class Example extends React.Component {
     });
   };
 
+  handleWeekMouseEnter = (weekNumber, days, e) => {
+    this.setState({
+      hoverRange: getWeekRange(days[0])
+    });
+  };
+
+  handleWeekMouseLeave = (weekNumber, days, e) => {
+    this.setState({
+      hoverRange: undefined,
+    });
+  };
+
   render() {
     const { hoverRange, selectedDays } = this.state;
 
@@ -85,6 +97,8 @@ export default class Example extends React.Component {
           onDayMouseEnter={this.handleDayEnter}
           onDayMouseLeave={this.handleDayLeave}
           onWeekClick={this.handleWeekClick}
+          onWeekMouseEnter={this.handleWeekMouseLeave}
+          onWeekMouseLeave={this.handleWeekMouseEnter}
         />
         {selectedDays.length === 7 && (
           <div>

--- a/docs/src/pages/api/DayPicker.js
+++ b/docs/src/pages/api/DayPicker.js
@@ -81,6 +81,8 @@ export default () => (
       <a href="#onMonthChange">onMonthChange</a>,{' '}
       <a href="#onTodayButtonClick">onTodayButtonClick</a>,{' '}
       <a href="#onWeekClick">onWeekClick</a>
+      <a href="#onWeekMouseEnter">onWeekMouseEnter</a>
+      <a href="#onWeekMouseLeave">onWeekMouseLeave</a>
     </p>
 
     <h4>Public Methods</h4>
@@ -631,6 +633,33 @@ export default () => (
         <a href="#showWeekNumbers">showWeekNumbers</a> is set to{' '}
         <code>true</code>).
       </p>
+
+      <h3>
+        <Anchor id="onWeekMouseEnter" />
+        onWeekMouseEnter{' '}
+        <code>
+          (weekNumber: number, days: date[], e: SyntheticEvent) ⇒ void
+        </code>
+      </h3>
+      <p>
+        Event handler when the mouse hovers a week number (when{' '}
+        <a href="#showWeekNumbers">showWeekNumbers</a> is set to{' '}
+        <code>true</code>).
+      </p>
+
+      <h3>
+        <Anchor id="onWeekMouseLeave" />
+        onWeekMouseLeave{' '}
+        <code>
+          (weekNumber: number, days: date[], e: SyntheticEvent) ⇒ void
+        </code>
+      </h3>
+      <p>
+        Event handler when the mouse stops hovering a week number (when{' '}
+        <a href="#showWeekNumbers">showWeekNumbers</a> is set to{' '}
+        <code>true</code>).
+      </p>
+
       <h3>
         <Anchor id="onTodayButtonClick" />
         onTodayButtonClick{' '}

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -126,6 +126,8 @@ export class DayPicker extends Component {
     onMonthChange: PropTypes.func,
     onCaptionClick: PropTypes.func,
     onWeekClick: PropTypes.func,
+    onWeekMouseEnter: PropTypes.func,
+    onWeekMouseLeave: PropTypes.func,
     onTodayButtonClick: PropTypes.func,
   };
 

--- a/src/Month.js
+++ b/src/Month.js
@@ -65,6 +65,8 @@ export default class Month extends Component {
     onDayTouchEnd: PropTypes.func,
     onDayTouchStart: PropTypes.func,
     onWeekClick: PropTypes.func,
+    onWeekMouseEnter: PropTypes.func,
+    onWeekMouseLeave: PropTypes.func,
   };
 
   renderDay = day => {
@@ -149,6 +151,8 @@ export default class Month extends Component {
       showWeekNumbers,
       showWeekDays,
       onWeekClick,
+      onWeekMouseEnter,
+      onWeekMouseLeave,
     } = this.props;
 
     const captionProps = {
@@ -199,6 +203,16 @@ export default class Month extends Component {
                     onClick={
                       onWeekClick
                         ? e => onWeekClick(weekNumber, week, e)
+                        : undefined
+                    }
+                    onMouseEnter={
+                      onWeekMouseEnter
+                        ? e => onWeekMouseEnter(weekNumber, week, e)
+                        : undefined
+                    }
+                    onMouseLeave={
+                      onWeekMouseLeave
+                        ? e => onWeekMouseLeave(weekNumber, week, e)
                         : undefined
                     }
                     onKeyUp={

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,3 @@
-export { localeUtils } from '../build/LocaleUtils';
-export { dateUtils } from '../build/DateUtils';
-export { modifiersUtils } from '../build/ModifiersUtils';
+export { localeUtils } from './LocaleUtils';
+export { dateUtils } from './DateUtils';
+export { modifiersUtils } from './ModifiersUtils';

--- a/test/daypicker/events.js
+++ b/test/daypicker/events.js
@@ -347,4 +347,34 @@ describe('DayPicker’s events handlers', () => {
       .simulate('keyUp', { keyCode: keys.SPACE });
     expect(handleWeekClick).toHaveBeenCalledTimes(0);
   });
+  it('should call `onWeekMouseEnter` when hovering a week number', () => {
+    const handleWeekMouseEnter = jest.fn();
+    const wrapper = mount(
+      <DayPicker
+        showWeekNumbers
+        onWeekMouseEnter={handleWeekMouseEnter}
+        initialMonth={new Date(2015, 1)}
+      />
+    );
+    wrapper
+      .find('.DayPicker-WeekNumber')
+      .at(1)
+      .simulate('mouseEnter');
+    expect(handleWeekMouseEnter).toHaveBeenCalledTimes(1);
+  });
+  it('should call `onWeekMouseLeave` when stopping hovering a week number', () => {
+    const handleWeekMouseLeave = jest.fn();
+    const wrapper = mount(
+      <DayPicker
+        showWeekNumbers
+        onWeekMouseLeave={handleWeekMouseLeave}
+        initialMonth={new Date(2015, 1)}
+      />
+    );
+    wrapper
+      .find('.DayPicker-WeekNumber')
+      .at(1)
+      .simulate('mouseLeave');
+    expect(handleWeekMouseLeave).toHaveBeenCalledTimes(1);
+  });
 });

--- a/types/Props.d.ts
+++ b/types/Props.d.ts
@@ -126,6 +126,16 @@ export interface DayPickerProps {
     days: Date[],
     e: React.MouseEvent<HTMLDivElement>
   ) => void;
+  onWeekMouseEnter?: (
+    weekNumber: number,
+    days: Date[],
+    e: React.MouseEvent<HTMLDivElement>
+  ) => void;
+  onWeekMouseLeave?: (
+    weekNumber: number,
+    days: Date[],
+    e: React.MouseEvent<HTMLDivElement>
+  ) => void;
   pagedNavigation?: boolean;
   renderDay?: (date: Date, modifiers: DayModifiers) => React.ReactNode;
   renderWeek?: (


### PR DESCRIPTION
I added support for the MouseEnter and MouseLeave events for week numbers. This can be useful to pre-select the week days on hovering the week number.

A little GIF is better than a thousand words: https://gyazo.com/9db1f69153293697f96465e3f5f9bf1f