### PR TITLE
Fix range selection selected modifiers

### DIFF
--- a/packages/react-day-picker/package.json
+++ b/packages/react-day-picker/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
+    "@testing-library/react-hooks": "^7.0.2",
     "@types/jest": "^26.0.23",
     "@types/node": "^14.17.3",
     "@types/react": "^17.0.11",

--- a/packages/react-day-picker/src/hooks/useModifiers/useModifiers.test.tsx
+++ b/packages/react-day-picker/src/hooks/useModifiers/useModifiers.test.tsx
@@ -1,8 +1,7 @@
-import * as React from 'react';
-
 import tk from 'timekeeper';
+import { addDays } from 'date-fns';
 
-import { customRender } from 'test';
+import { customRenderHook } from 'test';
 
 import { useModifiers } from './useModifiers';
 
@@ -11,27 +10,30 @@ const today = new Date(2021, 8);
 beforeEach(() => tk.freeze(today));
 afterEach(() => tk.reset());
 
-const TestComponent = ({ day }: { day: Date }) => {
-  const modifiers = useModifiers(day);
-  const isSelected = modifiers.modifiers.selected || false;
-
-  return <button data-testid="test-div">{isSelected.toString()}</button>;
-};
-
-describe('uncontrolled date ranges', () => {
-  test('should return selected as true based on defaultSelected', () => {
-    const { getByTestId } = customRender(<TestComponent day={today} />, {
-      mode: 'range',
-      defaultSelected: { from: today, to: today }
-    });
-    expect(getByTestId('test-div')).toHaveTextContent('true');
+describe('when mode="range" and defaultSelected includes the current date', () => {
+  const { result } = customRenderHook(() => useModifiers(today), {
+    mode: 'range',
+    defaultSelected: { from: today, to: today }
   });
-
-  test('should not be selected when nothing is selected', () => {
-    const { getByTestId } = customRender(<TestComponent day={today} />, {
-      mode: 'range',
-      defaultSelected: undefined
-    });
-    expect(getByTestId('test-div')).toHaveTextContent('false');
+  test('useModifiers should return the selected modifier as true', () => {
+    expect(result.current.modifiers.selected).toBeTruthy();
+  });
+});
+describe('when mode="range" and defaultSelected is undefined', () => {
+  const { result } = customRenderHook(() => useModifiers(today), {
+    mode: 'range'
+  });
+  test('useModifiers should return the selected modifier as false', () => {
+    expect(result.current.modifiers.selected).toBeFalsy();
+  });
+});
+describe('when mode="range" and defaultSelected does not span the current date', () => {
+  const tomorrow = addDays(today, 1);
+  const { result } = customRenderHook(() => useModifiers(today), {
+    mode: 'range',
+    defaultSelected: { from: tomorrow, to: tomorrow }
+  });
+  test('useModifiers should return the selected modifier as false', () => {
+    expect(result.current.modifiers.selected).toBeFalsy();
   });
 });

--- a/packages/react-day-picker/src/hooks/useModifiers/useModifiers.test.tsx
+++ b/packages/react-day-picker/src/hooks/useModifiers/useModifiers.test.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+import tk from 'timekeeper';
+
+import { customRender } from 'test';
+
+import { useModifiers } from './useModifiers';
+
+const today = new Date(2021, 8);
+
+beforeEach(() => tk.freeze(today));
+afterEach(() => tk.reset());
+
+const TestComponent = ({ day }: { day: Date }) => {
+  const modifiers = useModifiers(day);
+  const isSelected = modifiers.modifiers.selected || false;
+
+  return <button data-testid="test-div">{isSelected.toString()}</button>;
+};
+
+describe('uncontrolled date ranges', () => {
+  test('should return selected as true based on defaultSelected', () => {
+    const { getByTestId } = customRender(<TestComponent day={today} />, {
+      mode: 'range',
+      defaultSelected: { from: today, to: today }
+    });
+    expect(getByTestId('test-div')).toHaveTextContent('true');
+  });
+
+  test('should not be selected when nothing is selected', () => {
+    const { getByTestId } = customRender(<TestComponent day={today} />, {
+      mode: 'range',
+      defaultSelected: undefined
+    });
+    expect(getByTestId('test-div')).toHaveTextContent('false');
+  });
+});

--- a/packages/react-day-picker/src/hooks/useModifiers/useModifiers.ts
+++ b/packages/react-day-picker/src/hooks/useModifiers/useModifiers.ts
@@ -49,9 +49,6 @@ export function useModifiers(date: Date): UseModifiers {
     modifiers.range_start = rangeSelect.modifiers.range_start ?? [];
     modifiers.range_middle = rangeSelect.modifiers.range_middle ?? [];
     modifiers.range_end = rangeSelect.modifiers.range_end ?? [];
-    modifiers.disabled = modifiers.disabled.concat(
-      rangeSelect.modifiers.disabled ?? []
-    );
   }
 
   const status = getModifierStatus(date, modifiers);

--- a/packages/react-day-picker/src/hooks/useModifiers/useModifiers.ts
+++ b/packages/react-day-picker/src/hooks/useModifiers/useModifiers.ts
@@ -41,10 +41,10 @@ export function useModifiers(date: Date): UseModifiers {
     );
   } else if (isDayPickerRange(context)) {
     modifiers.selected = modifiers.selected.concat(
-      multipleSelect.modifiers.selected ?? []
+      rangeSelect.modifiers.selected ?? []
     );
     modifiers.disabled = modifiers.disabled.concat(
-      multipleSelect.modifiers.disabled ?? []
+      rangeSelect.modifiers.disabled ?? []
     );
     modifiers.range_start = rangeSelect.modifiers.range_start ?? [];
     modifiers.range_middle = rangeSelect.modifiers.range_middle ?? [];

--- a/packages/react-day-picker/src/test/customRender.tsx
+++ b/packages/react-day-picker/src/test/customRender.tsx
@@ -1,10 +1,5 @@
 import * as React from 'react';
 import { render, RenderResult } from '@testing-library/react';
-import {
-  renderHook,
-  Renderer,
-  RenderHookResult
-} from '@testing-library/react-hooks';
 
 import { DayPickerProps } from 'types';
 
@@ -15,14 +10,4 @@ export const customRender = (
   contextValue: DayPickerProps = {}
 ): RenderResult => {
   return render(<ContextProvider {...contextValue}>{element}</ContextProvider>);
-};
-
-export const customRenderHook = <TProps, TResult>(
-  callback: (props: TProps) => TResult,
-  contextValue: DayPickerProps = {}
-): RenderHookResult<TProps, TResult, Renderer<TProps>> => {
-  const wrapper = ({ children }: { children?: React.ReactNode }) => (
-    <ContextProvider {...contextValue}>{children}</ContextProvider>
-  );
-  return renderHook<TProps, TResult>(callback, { wrapper });
 };

--- a/packages/react-day-picker/src/test/customRender.tsx
+++ b/packages/react-day-picker/src/test/customRender.tsx
@@ -1,5 +1,10 @@
-import { render, RenderResult } from '@testing-library/react';
 import * as React from 'react';
+import { render, RenderResult } from '@testing-library/react';
+import {
+  renderHook,
+  Renderer,
+  RenderHookResult
+} from '@testing-library/react-hooks';
 
 import { DayPickerProps } from 'types';
 
@@ -10,4 +15,14 @@ export const customRender = (
   contextValue: DayPickerProps = {}
 ): RenderResult => {
   return render(<ContextProvider {...contextValue}>{element}</ContextProvider>);
+};
+
+export const customRenderHook = <TProps, TResult>(
+  callback: (props: TProps) => TResult,
+  contextValue: DayPickerProps = {}
+): RenderHookResult<TProps, TResult, Renderer<TProps>> => {
+  const wrapper = ({ children }: { children?: React.ReactNode }) => (
+    <ContextProvider {...contextValue}>{children}</ContextProvider>
+  );
+  return renderHook<TProps, TResult>(callback, { wrapper });
 };

--- a/packages/react-day-picker/src/test/customRenderHook.tsx
+++ b/packages/react-day-picker/src/test/customRenderHook.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import {
+  renderHook,
+  Renderer,
+  RenderHookResult
+} from '@testing-library/react-hooks';
+import { DayPickerProps } from 'types';
+import { ContextProvider } from '../contexts/ContextProvider';
+
+export function customRenderHook<TProps, TResult>(
+  callback: (props: TProps) => TResult,
+  contextValue: DayPickerProps = {}
+): RenderHookResult<TProps, TResult, Renderer<TProps>> {
+  const wrapper = ({ children }: { children?: React.ReactNode }) => (
+    <ContextProvider {...contextValue}>{children}</ContextProvider>
+  );
+  return renderHook<TProps, TResult>(callback, { wrapper });
+}

--- a/packages/react-day-picker/src/test/index.ts
+++ b/packages/react-day-picker/src/test/index.ts
@@ -1,2 +1,3 @@
 export * from './customRender';
+export * from './customRenderHook';
 export * from './PageObjects';

--- a/packages/react-day-picker/style.css
+++ b/packages/react-day-picker/style.css
@@ -7,7 +7,8 @@
   --rdp-background-color-dark: #180270;
   /* Outline border for focused elements */
   --rdp-outline: 2px solid var(--rdp-accent-color);
-  --rdp-outline-selected: 2px solid rgba(0,0,0,0.75);
+  /* Outline border for focused and selected elements */
+  --rdp-outline-selected: 2px solid rgba(0, 0, 0, 0.75);
 }
 
 .rdp {

--- a/packages/react-day-picker/style.css
+++ b/packages/react-day-picker/style.css
@@ -7,6 +7,7 @@
   --rdp-background-color-dark: #180270;
   /* Outline border for focused elements */
   --rdp-outline: 2px solid var(--rdp-accent-color);
+  --rdp-outline-selected: 2px solid rgba(0,0,0,0.75);
 }
 
 .rdp {
@@ -266,6 +267,10 @@
 .rdp-day_selected:hover:not([disabled]) {
   color: white;
   background-color: var(--rdp-accent-color);
+}
+
+.rdp-day_selected:focus:not([disabled]) {
+  border: var(--rdp-outline-selected);
 }
 
 .rdp-day_range_start {

--- a/website/docs/basics/selecting-days-range-min-max.tsx
+++ b/website/docs/basics/selecting-days-range-min-max.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { format } from 'date-fns';
+import { format, isSameDay } from 'date-fns';
 
 import { DateRange, DayPicker } from 'react-day-picker';
 import 'react-day-picker/style.css';
@@ -9,9 +9,11 @@ export default function Example() {
   const [range, setRange] = React.useState<DateRange | undefined>();
 
   let footer = 'Please pick the first day.';
-  if (range && range.from && !range.to) footer = 'Please pick the last day.';
-  if (range && range.from && range.to)
+  if (range && range.from && (!range.to || isSameDay(range.from, range.to))) {
+    footer = format(range.from, 'PPP');
+  } else if (range && range.from && range.to) {
     footer = `${format(range.from, 'PPP')}–${format(range.to, 'PPP')}`;
+  }
 
   return (
     <DayPicker

--- a/website/docs/basics/selecting-days-range.tsx
+++ b/website/docs/basics/selecting-days-range.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { addDays, format } from 'date-fns';
+import { addDays, format, isSameDay } from 'date-fns';
 
 import { DateRange, DayPicker } from 'react-day-picker';
 import 'react-day-picker/style.css';
@@ -10,13 +10,17 @@ export default function Example() {
     from: new Date(),
     to: addDays(new Date(), 4)
   };
-  const [range, setRange] = React.useState(defaultSelected);
+  const [range, setRange] = React.useState<DateRange>(defaultSelected);
+
+  console.log(range);
 
   let footer = 'Please pick the first day.';
-  if (range.from && !range.to) footer = 'Please pick the last day.';
-  if (range.from && range.to)
+  if (range && range.from && (!range.to || isSameDay(range.from, range.to))) {
+    footer = format(range.from, 'PPP');
+  } else if (range && range.from && range.to) {
     footer = `${format(range.from, 'PPP')}–${format(range.to, 'PPP')}`;
-
+  }
+  
   return (
     <DayPicker
       mode="range"

--- a/website/docs/basics/styling.mdx
+++ b/website/docs/basics/styling.mdx
@@ -25,6 +25,8 @@ The CSS uses few variables to quickly override the colors and the cell size:
   --rdp-background-color-dark: #180270;
   /* Outline border for focused elements */
   --rdp-outline: 2px solid var(--rdp-accent-color);
+  /* Outline border for focused and selected elements */
+  --rdp-outline-selected: 2px solid rgba(0, 0, 0, 0.75);
 }
 ```
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3075,6 +3075,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/react-hooks@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "@testing-library/react-hooks@npm:7.0.2"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+    "@types/react": ">=16.9.0"
+    "@types/react-dom": ">=16.9.0"
+    "@types/react-test-renderer": ">=16.9.0"
+    react-error-boundary: ^3.1.0
+  peerDependencies:
+    react: ">=16.9.0"
+    react-dom: ">=16.9.0"
+    react-test-renderer: ">=16.9.0"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+    react-test-renderer:
+      optional: true
+  checksum: 26354a98923c0780494271419c46db01007f2406a4d0615c6d851b1793f591ea4767a05e48be7db8b4ab7591f699e60b8143020669e6d9c949c032f55282f084
+  languageName: node
+  linkType: hard
+
 "@testing-library/react@npm:^11.2.7":
   version: 11.2.7
   resolution: "@testing-library/react@npm:11.2.7"
@@ -3436,12 +3458,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-dom@npm:>=16.9.0":
+  version: 17.0.11
+  resolution: "@types/react-dom@npm:17.0.11"
+  dependencies:
+    "@types/react": "*"
+  checksum: 4ebd8c0f858ab3c2db2a527307d05042310259b0a2642d3e34dcdc6c8cdee2618712bfb88d8ba3a0479f93658058f21da83653ff1f4ddf215e855d8512c546bc
+  languageName: node
+  linkType: hard
+
 "@types/react-dom@npm:^17.0.8":
   version: 17.0.8
   resolution: "@types/react-dom@npm:17.0.8"
   dependencies:
     "@types/react": "*"
   checksum: 3859a6e06ec4545319c159ea71814beb3822801f0d4c41219855258557722cbcec8b5fba84551489169ec228b8817b4c05a8ef0dc87eb2bafb4d1431d1af9608
+  languageName: node
+  linkType: hard
+
+"@types/react-test-renderer@npm:>=16.9.0":
+  version: 17.0.1
+  resolution: "@types/react-test-renderer@npm:17.0.1"
+  dependencies:
+    "@types/react": "*"
+  checksum: bd3f8c6c2ae23f270b465106ae81c7e72dc97b64f83b980239bd45a69dcc9f41aada4183f16634320e8d02cede942e46258366a596dbefaae558abad236f4ab6
   languageName: node
   linkType: hard
 
@@ -3453,6 +3493,17 @@ __metadata:
     "@types/scheduler": "*"
     csstype: ^3.0.2
   checksum: 5bcaabadc90a23ad9008540eae98a5819b638c4cf1b968adc67be47d6a8dc8cb100061d877dae97618fb275e405dc484b37154080c7ac0ea7df5efcdd8f98c24
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:>=16.9.0":
+  version: 17.0.34
+  resolution: "@types/react@npm:17.0.34"
+  dependencies:
+    "@types/prop-types": "*"
+    "@types/scheduler": "*"
+    csstype: ^3.0.2
+  checksum: 197fe4fa6c1a697dbaf5bdc35af373afbc90a76073e4262f8ab4295dbc1cb1893888119dd55529206c3d2167a248927eaa2b2e01078c49eaf13cd14c89146167
   languageName: node
   linkType: hard
 
@@ -16551,6 +16602,7 @@ fsevents@^1.2.7:
   dependencies:
     "@testing-library/jest-dom": ^5.14.1
     "@testing-library/react": ^11.2.7
+    "@testing-library/react-hooks": ^7.0.2
     "@types/jest": ^26.0.23
     "@types/node": ^14.17.3
     "@types/react": ^17.0.11
@@ -16628,6 +16680,17 @@ fsevents@^1.2.7:
   peerDependencies:
     react: 17.0.2
   checksum: 960a74ff6670766846a73097a599115963df1574833c59ca0c2fd909758ebe7a6214cd14f5e6aa63ce846d8f39fde7f3b80474ccfcfadc45dd7f3246364718c6
+  languageName: node
+  linkType: hard
+
+"react-error-boundary@npm:^3.1.0":
+  version: 3.1.4
+  resolution: "react-error-boundary@npm:3.1.4"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+  peerDependencies:
+    react: ">=16.13.1"
+  checksum: 46284fe6294810fe95a2157e20bf8b241d8761f4e5ae5be7f3b3b1085133cdb7af99d1fa8e3f16ffffc1230e7e858fb04e479c8dafbdb41abbf389d74b8538f0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Additionally, add a missing focused state for selected days to the default stylesheet and fix the two navigable selecting-days-range doc files to allow for de-selecting a range without creating errors