### PR TITLE
(package) Add eslint-plugin-react-hooks

### DIFF
--- a/packages/react-day-picker/.eslintrc
+++ b/packages/react-day-picker/.eslintrc
@@ -8,6 +8,7 @@
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
     "prettier",
     "plugin:prettier/recommended"
   ],

--- a/packages/react-day-picker/package.json
+++ b/packages/react-day-picker/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-jest": "^24.3.6",
     "eslint-plugin-prettier": "^3.4.0",
+    "eslint-plugin-react-hooks": "^4.3.0",
     "jest": "^26.6.3",
     "jest-date": "^1.1.4",
     "prettier": "^2.3.1",

--- a/packages/react-day-picker/src/components/Day/hooks/useDayFocus.ts
+++ b/packages/react-day-picker/src/components/Day/hooks/useDayFocus.ts
@@ -32,7 +32,7 @@ export function useDayFocus(
     if (isSameDay(focusedDay, date)) {
       buttonRef.current?.focus();
     }
-  }, [focusedDay]);
+  }, [focusedDay, date, buttonRef]);
 
   const focusOnKeyDown: React.KeyboardEventHandler = (e) => {
     switch (e.key) {

--- a/packages/react-day-picker/src/contexts/Navigation/useNavigationState.ts
+++ b/packages/react-day-picker/src/contexts/Navigation/useNavigationState.ts
@@ -28,7 +28,7 @@ export function useNavigationState(): [
     if (!context.month) return;
     if (isSameMonth(context.month, month)) return;
     setMonth(context.month);
-  }, [context.month]);
+  }, [context.month, month]);
 
   return [month, goToMonth];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6963,6 +6963,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-react-hooks@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "eslint-plugin-react-hooks@npm:4.3.0"
+  peerDependencies:
+    eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+  checksum: 0ba1566ba0780bbc75a5921f49188edf232db2085ab32c8d3889592f0db9d6fadc97fcf639775e0101dec6b5409ca3c803ec44213b90c8bacaf0bdf921871c2e
+  languageName: node
+  linkType: hard
+
 "eslint-scope@npm:5.1.1, eslint-scope@npm:^5.1.1":
   version: 5.1.1
   resolution: "eslint-scope@npm:5.1.1"
@@ -13212,6 +13221,7 @@ __metadata:
     eslint-plugin-import: ^2.23.4
     eslint-plugin-jest: ^24.3.6
     eslint-plugin-prettier: ^3.4.0
+    eslint-plugin-react-hooks: ^4.3.0
     jest: ^26.6.3
     jest-date: ^1.1.4
     prettier: ^2.3.1


### PR DESCRIPTION
I found a couple issues with the new docusaurus updates:

1. There is a hook in website/src/pages/render.tsx (useLocation) that React wants us to hoist to the top of the `Render` function. It spits out an error in the javascript console
2. The svg path for the previous and next icons has no height and width and does not render inside an iframe in the latest version of chrome (see screenshot)
<img width="339" alt="Screen Shot 2021-11-16 at 3 36 40 PM" src="https://user-images.githubusercontent.com/2838338/142061807-d0b2ee0a-e9c6-467f-8d3d-e8db598a6176.png">

I think we might be able to use the following plugin to catch the first issue. It certainly caught a few issues in the react-day-picker package, which I've fixed below.

I have no idea how to fix the second issue. It works fine in firefox

