### PR TITLE
chore: stronger type-safety for useControlledValue

### DIFF
--- a/packages/react-day-picker/src/contexts/Navigation/useNavigationState.ts
+++ b/packages/react-day-picker/src/contexts/Navigation/useNavigationState.ts
@@ -16,10 +16,7 @@ export function useNavigationState(): [
 ] {
   const context = useDayPicker();
   const initialMonth = getInitialMonth(context);
-  const [month, setMonth] = useControlledValue<Date>(
-    initialMonth,
-    context.month
-  );
+  const [month, setMonth] = useControlledValue(initialMonth, context.month);
 
   const goToMonth = (date: Date) => {
     if (context.disableNavigation) return;

--- a/packages/react-day-picker/src/contexts/SelectMultiple/SelectMultipleProvider.tsx
+++ b/packages/react-day-picker/src/contexts/SelectMultiple/SelectMultipleProvider.tsx
@@ -114,10 +114,10 @@ function SelectMultipleProviderInternal({
 
   return (
     <SelectMultipleContext.Provider
-      value={{ 
-        selected: selectedDays, 
-        handleDayClick, 
-        modifiers 
+      value={{
+        selected: selectedDays,
+        handleDayClick,
+        modifiers
       }}
     >
       {children}

--- a/packages/react-day-picker/src/contexts/SelectRange/SelectRangeProvider.tsx
+++ b/packages/react-day-picker/src/contexts/SelectRange/SelectRangeProvider.tsx
@@ -6,7 +6,9 @@ import { useControlledValue } from '../../hooks/useControlledValue';
 import {
   DateRange,
   DayClickEventHandler,
+  DayPickerBase,
   DayPickerProps,
+  DayPickerRange,
   isDayPickerRange
 } from '../../types';
 
@@ -21,27 +23,43 @@ export function SelectRangeProvider({
   initialProps: DayPickerProps;
   children: React.ReactNode;
 }): JSX.Element {
-  const [selected, setSelected] = useControlledValue<DateRange | undefined>(
-    initialProps.defaultSelected,
-    initialProps.selected
+  if (!isDayPickerRange(initialProps)) {
+    return (
+      <SelectRangeContext.Provider value={EMPTY_SELECT_RANGE_CONTEXT}>
+        {children}
+      </SelectRangeContext.Provider>
+    );
+  }
+  return (
+    <SelectRangeProviderInternal
+      initialProps={initialProps}
+      children={children}
+    />
   );
+}
 
-  const modifiers: SelectRangeModifiers = {
+const EMPTY_SELECT_RANGE_CONTEXT = {
+  selected: undefined,
+  modifiers: {
     selected: [],
     range_start: [],
     range_end: [],
     range_middle: [],
     disabled: []
-  };
-
-  if (!isDayPickerRange(initialProps)) {
-    const contextValue = { selected: undefined, modifiers };
-    return (
-      <SelectRangeContext.Provider value={contextValue}>
-        {children}
-      </SelectRangeContext.Provider>
-    );
   }
+};
+
+export function SelectRangeProviderInternal({
+  initialProps,
+  children
+}: {
+  initialProps: DayPickerBase & DayPickerRange;
+  children: React.ReactNode;
+}): JSX.Element {
+  const [selected, setSelected] = useControlledValue(
+    initialProps.defaultSelected,
+    initialProps.selected
+  );
 
   const min = initialProps.min;
   const max = initialProps.max;
@@ -68,6 +86,14 @@ export function SelectRangeProvider({
     }
     setSelected(newValue);
     initialProps.onSelect?.(newValue, day, modifiers, e);
+  };
+
+  const modifiers: SelectRangeModifiers = {
+    selected: [],
+    range_start: [],
+    range_end: [],
+    range_middle: [],
+    disabled: []
   };
 
   if (selected) {
@@ -133,9 +159,10 @@ export function SelectRangeProvider({
       }
     }
   }
-  const contextValue = { selected, handleDayClick, modifiers };
   return (
-    <SelectRangeContext.Provider value={contextValue}>
+    <SelectRangeContext.Provider
+      value={{ selected, handleDayClick, modifiers }}
+    >
       {children}
     </SelectRangeContext.Provider>
   );

--- a/packages/react-day-picker/src/hooks/useControlledValue/useControlledValue.ts
+++ b/packages/react-day-picker/src/hooks/useControlledValue/useControlledValue.ts
@@ -9,8 +9,8 @@ export type DispatchStateAction<T> = React.Dispatch<React.SetStateAction<T>>;
  * returned setter to update it.
  */
 export function useControlledValue<T>(
-  defaultValue: unknown,
-  controlledValue: unknown | undefined
+  defaultValue: T,
+  controlledValue: T | undefined
 ): [T, DispatchStateAction<T>] {
   const [uncontrolledValue, setUncontrolledValue] =
     React.useState(defaultValue);


### PR DESCRIPTION
This PR adds internal provider components that can take advantage of the type predicates to safely narrow the typescript types so that they can pass in known types to the useControlledValue hook, instead of using unsafe casts.