### PR TITLE
chore: re-include main field

### DIFF
--- a/packages/react-day-picker/package.json
+++ b/packages/react-day-picker/package.json
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/gpbl/react-day-picker/issues"
   },
+  "main": "dist/main.js",
   "module": "build/main.js",
   "types": "build/main.d.ts",
   "scripts": {


### PR DESCRIPTION
Re-include `main` field in package.json for CJS bundlers