### PR TITLE
feat: remove the day_today default class name and provide some type h…

### DIFF
--- a/packages/react-day-picker/src/contexts/DayPicker/defaultClassNames.ts
+++ b/packages/react-day-picker/src/contexts/DayPicker/defaultClassNames.ts
@@ -43,11 +43,9 @@ export const defaultClassNames: Required<ClassNames> = {
   nav_icon: 'rdp-nav_icon',
 
   row: 'rdp-row',
-  row_head: 'rdp-row_head',
   weeknumber: 'rdp-weeknumber',
   cell: 'rdp-cell',
 
   day: 'rdp-day',
-  day_outside: 'rdp-day_outside',
-  day_today: 'rdp-day_today'
+  day_outside: 'rdp-day_outside'
 };

--- a/packages/react-day-picker/src/contexts/DayPicker/labels/labelDay.ts
+++ b/packages/react-day-picker/src/contexts/DayPicker/labels/labelDay.ts
@@ -5,6 +5,6 @@ import { DayLabel } from '../../../types';
 /**
  * The default ARIA label for the day button.
  */
-export const labelDay: DayLabel = (day, options): string => {
+export const labelDay: DayLabel = (day, modifers, options): string => {
   return format(day, 'do MMMM (EEEE)', options);
 };

--- a/packages/react-day-picker/src/contexts/DayPicker/utils/parseModifierProps.ts
+++ b/packages/react-day-picker/src/contexts/DayPicker/utils/parseModifierProps.ts
@@ -21,6 +21,7 @@ export function parseModifierProps(initialProps: DayPickerProps): Modifiers {
     selected: [],
     disabled: [],
     hidden: [],
+    today: [],
     range_end: [],
     range_middle: [],
     range_start: []

--- a/packages/react-day-picker/src/types/Modifiers.ts
+++ b/packages/react-day-picker/src/types/Modifiers.ts
@@ -9,6 +9,7 @@ export type InternalModifier =
   | 'selected'
   | 'disabled'
   | 'hidden'
+  | 'today'
   | 'range_start'
   | 'range_end'
   | 'range_middle';
@@ -17,13 +18,16 @@ export type InternalModifier =
 export type Modifier = string;
 
 /** The status of a modifiers when matched a day. */
-export type ModifierStatus = Record<Modifier, true>;
+export type ModifierStatus = Record<Modifier, true> &
+  Partial<Record<InternalModifier, true>>;
 
 /** The inline-style to apply to the day matching `modifier`. */
-export type ModifierStyles = Record<Modifier, React.CSSProperties>;
+export type ModifierStyles = Record<Modifier, React.CSSProperties> &
+  Partial<Record<InternalModifier, React.CSSProperties>>;
 
 /** The classnames to assign to each modifier. */
-export type ModifierClassNames = Record<Modifier, string>;
+export type ModifierClassNames = Record<Modifier, string> &
+  Partial<Record<InternalModifier, string>>;
 
 /** A map of matchers to use as custom modifiers.*/
 export type CustomModifiers = Record<Modifier, Matcher | Matcher[]>;

--- a/packages/react-day-picker/src/types/Styles.ts
+++ b/packages/react-day-picker/src/types/Styles.ts
@@ -69,8 +69,6 @@ export type StyledElement<T = string | React.CSSProperties> = {
 
   /** A style of the table’s row. */
   readonly row: T;
-  /** The style of the row’s head (displaying the week numbers). */
-  readonly row_head: T;
   /** The style of the weeknumber. */
   readonly weeknumber: T;
   /** The style of the table cell containing the day element. */
@@ -79,8 +77,6 @@ export type StyledElement<T = string | React.CSSProperties> = {
   readonly day: T;
   /** The style of a day when outside the month. */
   readonly day_outside: T;
-  /** The style of today button. */
-  readonly day_today: T;
 };
 
 /** The class names of each element. */


### PR DESCRIPTION
…ints for the internal modifiers

This allows for a bit of type hinting, as shown in the screenshot below:

<img width="428" alt="Screen Shot 2021-11-29 at 9 31 04 AM" src="https://user-images.githubusercontent.com/2838338/143886344-e54e3f2f-4b11-41d2-b787-c7a6f97c5656.png">

It also removes the `day_today` type hint as shown in the screenshot below, which was incorrectly shown, and moves 'today' to an internal modifier, which is how "today" is actually invoked.

<img width="296" alt="Screen Shot 2021-11-29 at 9 33 40 AM" src="https://user-images.githubusercontent.com/2838338/143886665-fda029cb-8c9a-460c-9fc8-04db9286c709.png">

Lastly, this provides type hints to anyone using ModifierStatus. For example, in my custom Day class:

<img width="713" alt="Screen Shot 2021-11-29 at 9 35 33 AM" src="https://user-images.githubusercontent.com/2838338/143886944-3b01d2c8-5e75-4611-a0ab-baf1223ef6ae.png">



