### PR TITLE
fix: labelDay missing the modifiers argument

### DIFF
--- a/packages/react-day-picker/src/components/Day/Day.test.tsx
+++ b/packages/react-day-picker/src/components/Day/Day.test.tsx
@@ -1,3 +1,35 @@
+import React from 'react';
+import { es, enUS } from 'date-fns/locale';
+import { Day } from './Day';
+import { customRender } from '../../test';
+import { DayPickerProps } from '../../types';
+
+const renderNovember182021 = (contextValue: DayPickerProps) => {
+  return customRender(
+    <Day displayMonth={new Date(2021, 10)} date={new Date(2021, 10, 18)} />,
+    contextValue
+  );
+};
+
+describe('when the locale is enUS', () => {
+  const locale = enUS;
+  test('the day should have aria text content in english', () => {
+    const { container } = renderNovember182021({
+      locale
+    });
+    expect(container).toHaveTextContent('18th November (Thursday)');
+  });
+});
+describe('when the locale is es', () => {
+  const locale = es;
+  test('the day should have aria text content in spanish', () => {
+    const { container } = renderNovember182021({
+      locale
+    });
+    expect(container).toHaveTextContent('18º noviembre (jueves)');
+  });
+});
+
 describe('when matches the `hidden` modifier', () => {
   test.todo('should not render anything');
 });

--- a/packages/react-day-picker/src/contexts/DayPicker/labels/labelDay.ts
+++ b/packages/react-day-picker/src/contexts/DayPicker/labels/labelDay.ts
@@ -5,6 +5,6 @@ import { DayLabel } from '../../../types';
 /**
  * The default ARIA label for the day button.
  */
-export const labelDay: DayLabel = (day, options): string => {
+export const labelDay: DayLabel = (day, modifiers, options): string => {
   return format(day, 'do MMMM (EEEE)', options);
 };


### PR DESCRIPTION
This becomes a typescript error when we more strongly type ModifierStatus (the second parameter) -- see https://github.com/gpbl/react-day-picker/pull/1299. 

