### PR TITLE
feat: add DayPickerSingleRequiredProps

### DIFF
--- a/packages/react-day-picker/src/DayPicker.tsx
+++ b/packages/react-day-picker/src/DayPicker.tsx
@@ -5,7 +5,8 @@ import {
   DayPickerMultipleProps,
   DayPickerProps,
   DayPickerRangeProps,
-  DayPickerSingleProps
+  DayPickerSingleProps,
+  DayPickerSingleRequiredProps
 } from './types';
 
 import { Root } from './components/Root';
@@ -100,7 +101,7 @@ import { RootProvider } from './contexts/RootProvider';
 export function DayPicker(
   props:
     | DayPickerProps
-    | DayPickerSingleProps
+    | (DayPickerSingleProps | DayPickerSingleRequiredProps)
     | DayPickerMultipleProps
     | DayPickerRangeProps
     | DayPickerCustomProps

--- a/packages/react-day-picker/src/types/DayPickerSingle.ts
+++ b/packages/react-day-picker/src/types/DayPickerSingle.ts
@@ -1,15 +1,28 @@
 import { DayPickerProps } from './DayPicker';
-import { SelectSingleEventHandler } from './EventHandlers';
+import {
+  SelectSingleEventHandler,
+  SelectSingleRequiredEventHandler
+} from './EventHandlers';
+
+export interface DayPickerSingleRequiredProps extends DayPickerProps {
+  mode: 'single';
+  /** The selected day. */
+  selected: Date;
+  /** Event fired when a day is selected. */
+  onSelect?: SelectSingleRequiredEventHandler;
+  /** Make the selection required. */
+  required: true;
+}
 
 /** The props for the [[DayPicker]] component when using `mode="single"`. */
 export interface DayPickerSingleProps extends DayPickerProps {
   mode: 'single';
   /** The selected day. */
-  selected?: Date | undefined;
+  selected?: Date;
   /** Event fired when a day is selected. */
   onSelect?: SelectSingleEventHandler;
   /** Make the selection required. */
-  required?: boolean;
+  required?: false;
 }
 
 /** Returns true when the props are of type [[DayPickerSingle]]. */

--- a/packages/react-day-picker/src/types/EventHandlers.ts
+++ b/packages/react-day-picker/src/types/EventHandlers.ts
@@ -68,6 +68,18 @@ export interface SelectSingleEventHandler {
   ): void;
 }
 
+export interface SelectSingleRequiredEventHandler {
+  (
+    /** The selected day, `undefined` when `required={false}` (default) and the day is clicked again. */
+    day: Date,
+    /** The day that was selected (or clicked) triggering the event. */
+    selectedDay: Date,
+    /** The modifiers of the selected day. */
+    modifiers: ModifierStatus,
+    e: React.MouseEvent
+  ): void;
+}
+
 /**The event handler when the week number is clicked. */
 export type WeekNumberClickEventHandler = (
   /** The week number that has been clicked. */

--- a/website/examples/single-required.tsx
+++ b/website/examples/single-required.tsx
@@ -5,9 +5,7 @@ import { format } from 'date-fns';
 
 export default function App() {
   const today = new Date();
-  const [selectedDay, setSelectedDay] = React.useState<
-    Date | undefined
-  >(today);
+  const [selectedDay, setSelectedDay] = React.useState(today);
 
   const footer = selectedDay
     ? `You selected ${format(selectedDay, 'PPP')}.`


### PR DESCRIPTION
This new type will make the type check to _not accept_ `undefined` as `selected` value while `mode="single"` and `required={true}`. Not sure if is the correct approach, and if we should add something similar for the Mul

The test case is included in the PR: it removes `undefined` from the example. cc @tjfred35 