### PR TITLE
chore: Make test:watch able to run against the source code

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build": "yarn workspace react-day-picker run build && yarn workspace website run build",
     "lint": "concurrently -n website,package \"yarn workspace website lint\" \"yarn workspace react-day-picker lint\"",
     "test": "yarn jest",
-    "test:watch": "yarn jest --watch",
+    "clean": "yarn workspace react-day-picker clean",
+    "test:watch": "yarn clean && yarn jest --watch",
     "typecheck-tests": "tsc --noEmit",
     "typecheck-tests:watch": "tsc --noEmit --watch"
   },

--- a/packages/react-day-picker/index.ts
+++ b/packages/react-day-picker/index.ts
@@ -1,0 +1,2 @@
+/** REQUIRED FOR DEVELOPMENT ONLY - DO NOT EDIT */
+export * from './src/main';

--- a/packages/react-day-picker/package.json
+++ b/packages/react-day-picker/package.json
@@ -21,6 +21,7 @@
     "build": "yarn prebuild && yarn rollup -c",
     "css-types": "yarn tcm -p style.css",
     "lint": "eslint --ext .ts,.tsx src",
+    "clean": "rm -rf ./dist && rm -rf ./build",
     "typecheck": "tsc --project ./tsconfig.json --noEmit",
     "typecheck:watch": "tsc --project ./tsconfig.json --noEmit --skipLibCheck --watch"
   },


### PR DESCRIPTION
Without this index.ts file, the module resolution code of jest
has to use the package.json file to resolve the modules, which
means jest is testing the code in the `dist` folder of react-day-picker
which is not rebuilt when running `test:watch`. This index.ts file
fixes that.

This allows for a testing technique called mutation testing, 
where we comment out parts of our production code and see
what tests fail (or don't fail).
