### PR TITLE
chore: rename style to multiple_months

### DIFF
--- a/packages/react-day-picker/src/components/Root/Root.tsx
+++ b/packages/react-day-picker/src/components/Root/Root.tsx
@@ -24,7 +24,7 @@ export function Root(): JSX.Element {
 
   const rootClassNames = [className ?? classNames.root];
   if (numberOfMonths > 1) {
-    rootClassNames.push(classNames.multiple_month);
+    rootClassNames.push(classNames.multiple_months);
   }
   if (showWeekNumber) {
     rootClassNames.push(classNames.with_weeknumber);

--- a/packages/react-day-picker/src/contexts/DayPicker/defaultClassNames.ts
+++ b/packages/react-day-picker/src/contexts/DayPicker/defaultClassNames.ts
@@ -5,7 +5,7 @@ import { ClassNames } from '../../types';
  */
 export const defaultClassNames: Required<ClassNames> = {
   root: 'rdp',
-  multiple_month: 'rdp-multiple_months',
+  multiple_months: 'rdp-multiple_months',
   with_weeknumber: 'rdp-with_weeknumber',
   vhidden: 'rdp-vhidden',
   button_reset: 'rdp-button_reset',

--- a/packages/react-day-picker/src/types/Styles.ts
+++ b/packages/react-day-picker/src/types/Styles.ts
@@ -5,7 +5,7 @@ export type StyledElement<T = string | React.CSSProperties> = {
   /** The style of the root element. */
   readonly root: T;
   /** The style of the root element when `numberOfMonths > 1`. */
-  readonly multiple_month: T;
+  readonly multiple_months: T;
   /** The style of the root element when `showWeekNumber={true}`. */
   readonly with_weeknumber: T;
   /** The style of an element visually hidden. */


### PR DESCRIPTION
Rename the style: `multiple_month` → `multiple_months`