### PR TITLE
chore: don't run workflows twice on pushes to pull request branches

### DIFF
--- a/.github/workflows/react-day-picker.yml
+++ b/.github/workflows/react-day-picker.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
   push:
+    branches:
+      - master
     paths:
       - "packages/react-day-picker/**"
       - ".github/workflows/**"

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
   push:
+    branches:
+      - master
     paths:
       - "website/**"
       - ".github/workflows/**"


### PR DESCRIPTION
I think all pushes to a pull request branch will trigger via the pull_request event. Let's test and find out.