### PR TITLE
fix: small type fix on setSelected

### DIFF
--- a/packages/react-day-picker/src/hooks/useInput/useInput.ts
+++ b/packages/react-day-picker/src/hooks/useInput/useInput.ts
@@ -62,7 +62,7 @@ export interface UseInput {
   /** A function to reset to the initial state. */
   reset: () => void;
   /** A function to set the selected day. */
-  setSelected: (day: Date) => void;
+  setSelected: (day: Date | undefined) => void;
 }
 
 /** Return props and setters for binding an input field to DayPicker. */


### PR DESCRIPTION
When using `useInput` hook, the returned function `setSelected` has incorrect type (doesn't allow 'undefined' as a value)

