### PR TITLE
feat: support for putting initial focus on the day grid

### DIFF
--- a/packages/react-day-picker/src/components/Day/hooks/useDayFocus.ts
+++ b/packages/react-day-picker/src/components/Day/hooks/useDayFocus.ts
@@ -15,24 +15,22 @@ export function useDayFocus(
   focusOnKeyDown: React.KeyboardEventHandler;
   isFocusTarget: boolean;
 } {
-  const [
+  const {
     focusedDay,
     focusTarget,
-    {
-      focusDayAfter,
-      focusDayBefore,
-      focusWeekAfterDay,
-      focusWeekBeforeDay,
-      blur,
-      focus,
-      focusMonthBefore,
-      focusMonthAfter,
-      focusYearBefore,
-      focusYearAfter,
-      focusStartOfWeek,
-      focusEndOfWeek
-    }
-  ] = useFocus();
+    focusDayAfter,
+    focusDayBefore,
+    focusWeekAfterDay,
+    focusWeekBeforeDay,
+    blur,
+    focus,
+    focusMonthBefore,
+    focusMonthAfter,
+    focusYearBefore,
+    focusYearAfter,
+    focusStartOfWeek,
+    focusEndOfWeek
+  } = useFocus();
   const { dir } = useDayPicker();
 
   // Focus the HTML element if this is the focused day.

--- a/packages/react-day-picker/src/components/Root/Root.tsx
+++ b/packages/react-day-picker/src/components/Root/Root.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Month } from 'components/Month';
 import { useDayPicker } from 'contexts/DayPicker';
+import { useFocus } from 'contexts/Focus';
 import { useNavigation } from 'contexts/Navigation';
 
 /**
@@ -16,9 +17,12 @@ export function Root(): JSX.Element {
     style,
     styles,
     numberOfMonths,
-    showWeekNumber
+    showWeekNumber,
+    initialFocusOnDay
   } = useDayPicker();
 
+  const [, focusTarget, { focus }] = useFocus();
+  const [initialFocus, setInitialFocus] = React.useState(false);
   const { displayMonths } = useNavigation();
 
   const rootClassNames = [className ?? classNames.root];
@@ -28,6 +32,13 @@ export function Root(): JSX.Element {
   if (showWeekNumber) {
     rootClassNames.push(classNames.with_weeknumber);
   }
+
+  React.useEffect(() => {
+    if (initialFocusOnDay && !initialFocus && focusTarget) {
+      focus(focusTarget);
+      setInitialFocus(true);
+    }
+  }, [initialFocusOnDay, initialFocus, focus, focusTarget]);
 
   return (
     <div

--- a/packages/react-day-picker/src/components/Root/Root.tsx
+++ b/packages/react-day-picker/src/components/Root/Root.tsx
@@ -18,11 +18,11 @@ export function Root(): JSX.Element {
     styles,
     numberOfMonths,
     showWeekNumber,
-    initialFocusOnDay
+    initialFocus
   } = useDayPicker();
 
-  const [, focusTarget, { focus }] = useFocus();
-  const [initialFocus, setInitialFocus] = React.useState(false);
+  const { focusTarget, focus } = useFocus();
+  const [hasInitialFocus, setHasInitialFocus] = React.useState(false);
   const { displayMonths } = useNavigation();
 
   const rootClassNames = [className ?? classNames.root];
@@ -34,11 +34,11 @@ export function Root(): JSX.Element {
   }
 
   React.useEffect(() => {
-    if (initialFocusOnDay && !initialFocus && focusTarget) {
+    if (initialFocus && !hasInitialFocus && focusTarget) {
       focus(focusTarget);
-      setInitialFocus(true);
+      setHasInitialFocus(true);
     }
-  }, [initialFocusOnDay, initialFocus, focus, focusTarget]);
+  }, [initialFocus, hasInitialFocus, focus, focusTarget]);
 
   return (
     <div

--- a/packages/react-day-picker/src/contexts/Focus/FocusContext.tsx
+++ b/packages/react-day-picker/src/contexts/Focus/FocusContext.tsx
@@ -16,38 +16,36 @@ import { useNavigation } from '../Navigation/useNavigation';
 import { getInitialFocusTarget } from './getInitialFocusTarget';
 
 /** Represents the value of the [[NavigationContext]]. */
-export type FocusContextValue = [
+export type FocusContextValue = {
   /** The day currently focused */
-  focusedDay: Date | undefined,
+  focusedDay: Date | undefined;
   /** The day that is the target of focus in the day grid (tabIndex = 0) */
-  focusTarget: Date | undefined,
-  setters: {
-    /** Focus the specified day. */
-    focus: (day: Date) => void;
-    /** Blur the focused day */
-    blur: () => void;
-    /** Focus the day after the focused day. */
-    focusDayAfter: () => void;
-    /** Focus the day before the focused day. */
-    focusDayBefore: () => void;
-    /** Focus the day in the week before the focused day. */
-    focusWeekBeforeDay: () => void;
-    /** Focus the day in the week after the focused day. */
-    focusWeekAfterDay: () => void;
-    /* Focus the day in the previous month. */
-    focusMonthBefore: () => void;
-    /* Focus the day in the next month. */
-    focusMonthAfter: () => void;
-    /* Focus the day in the previous year. */
-    focusYearBefore: () => void;
-    /* Focus the day in the next year. */
-    focusYearAfter: () => void;
-    /* Focus the day at the start of the week. */
-    focusStartOfWeek: () => void;
-    /* Focus the day at the end of the week. */
-    focusEndOfWeek: () => void;
-  }
-];
+  focusTarget: Date | undefined;
+  /** Focus the specified day. */
+  focus: (day: Date) => void;
+  /** Blur the focused day */
+  blur: () => void;
+  /** Focus the day after the focused day. */
+  focusDayAfter: () => void;
+  /** Focus the day before the focused day. */
+  focusDayBefore: () => void;
+  /** Focus the day in the week before the focused day. */
+  focusWeekBeforeDay: () => void;
+  /** Focus the day in the week after the focused day. */
+  focusWeekAfterDay: () => void;
+  /* Focus the day in the previous month. */
+  focusMonthBefore: () => void;
+  /* Focus the day in the next month. */
+  focusMonthAfter: () => void;
+  /* Focus the day in the previous year. */
+  focusYearBefore: () => void;
+  /* Focus the day in the next year. */
+  focusYearAfter: () => void;
+  /* Focus the day at the start of the week. */
+  focusStartOfWeek: () => void;
+  /* Focus the day at the end of the week. */
+  focusEndOfWeek: () => void;
+};
 
 /**
  * The Focus context shares details about the focused day for the keyboard navigation.
@@ -172,7 +170,9 @@ export function FocusProvider({
     focus(yearAfter);
   };
 
-  const setters = {
+  const value = {
+    focusedDay,
+    focusTarget,
     blur,
     focus,
     focusDayAfter,
@@ -188,8 +188,6 @@ export function FocusProvider({
   };
 
   return (
-    <FocusContext.Provider value={[focusedDay, focusTarget, setters]}>
-      {children}
-    </FocusContext.Provider>
+    <FocusContext.Provider value={value}>{children}</FocusContext.Provider>
   );
 }

--- a/packages/react-day-picker/src/types/DayPicker.ts
+++ b/packages/react-day-picker/src/types/DayPicker.ts
@@ -229,6 +229,8 @@ export interface DayPickerProps {
   formatters?: Partial<Formatters>;
   // #endregion
 
+  initialFocusOnDay?: boolean;
+
   // #region event handlers
   onDayClick?: DayClickEventHandler;
   onDayFocus?: DayFocusEventHandler;

--- a/packages/react-day-picker/src/types/DayPicker.ts
+++ b/packages/react-day-picker/src/types/DayPicker.ts
@@ -229,7 +229,14 @@ export interface DayPickerProps {
   formatters?: Partial<Formatters>;
   // #endregion
 
-  initialFocusOnDay?: boolean;
+  /**
+   * When set, DayPicker will focus on today,
+   * or the first selected day if set.
+   * This can be used for implementing a dialog
+   * pattern, for focusing on the day grid when
+   * the dialog opens.
+   **/
+  initialFocus?: boolean;
 
   // #region event handlers
   onDayClick?: DayClickEventHandler;

--- a/website/test-integration/examples/keyboard-focus.test.tsx
+++ b/website/test-integration/examples/keyboard-focus.test.tsx
@@ -60,9 +60,7 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
           });
           test('the last focused day should be remembered and receive the focus', () => {
             const lastFocusedDay = getFocusedElement();
-            getNextButton().focus();
-            (lastFocusedDay as HTMLButtonElement).onblur;
-            expect(lastFocusedDay).toHaveBeenCalled;
+            pressShiftTab(); // Back to next month button
             expect(lastFocusedDay).not.toHaveFocus();
             pressTab();
             expect(lastFocusedDay).toHaveFocus();
@@ -83,11 +81,11 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
     });
   });
 
-  describe('when configured to put initial focus on the day grid', () => {
+  describe('when "initialFocus" is true', () => {
     beforeEach(() => {
-      renderDayPicker({ dir, defaultMonth: today, initialFocusOnDay: true });
+      renderDayPicker({ dir, defaultMonth: today, initialFocus: true });
     });
-    test('the target focus day should have focus', () => {
+    test('the today button should have focus', () => {
       expect(getDayButton(today)).toHaveFocus();
     });
     describe('when attempting to move focus out of the day grid', () => {
@@ -100,7 +98,7 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
     });
   });
 
-  describe('when there is a selected day', () => {
+  describe('when a day is selected', () => {
     beforeEach(() => {
       renderDayPicker({ dir, defaultMonth: today, selected: tomorrow });
       tabToDayGrid();

--- a/website/test-integration/examples/keyboard-focus.test.tsx
+++ b/website/test-integration/examples/keyboard-focus.test.tsx
@@ -83,6 +83,23 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
     });
   });
 
+  describe('when configured to put initial focus on the day grid', () => {
+    beforeEach(() => {
+      renderDayPicker({ dir, defaultMonth: today, initialFocusOnDay: true });
+    });
+    test('the target focus day should have focus', () => {
+      expect(getDayButton(today)).toHaveFocus();
+    });
+    describe('when attempting to move focus out of the day grid', () => {
+      beforeEach(() => {
+        pressShiftTab();
+      });
+      test('the focus should not be trapped in the day grid', () => {
+        expect(getNextButton()).toHaveFocus();
+      });
+    });
+  });
+
   describe('when there is a selected day', () => {
     beforeEach(() => {
       renderDayPicker({ dir, defaultMonth: today, selected: tomorrow });


### PR DESCRIPTION
To support the use case where users will create a 
new DayPicker in a dialog, this property
allows us to put the focus on the target focus day of the day
grid, as defined by the business logic in the FocusProvider.

See https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/datepicker-dialog.html