### PR TITLE
fix: codesandbox style import

### DIFF
--- a/website/src/theme/CodeBlock/sandbox/index.tsx
+++ b/website/src/theme/CodeBlock/sandbox/index.tsx
@@ -1,5 +1,5 @@
 import React, { StrictMode } from 'react';
-import 'react-day-picker/style.css';
+import 'react-day-picker/dist/style.css';
 import { render } from 'react-dom';
 
 import App from './App';


### PR DESCRIPTION
The docs currently say the v8 styles should be imported from /dist/style.css but the Code Sandbox examples in the website point to just /style.css and are subsequently all boken.