### PR TITLE
fix: restore custom caption component

### DIFF
--- a/packages/react-day-picker/src/components/Month/Month.test.tsx
+++ b/packages/react-day-picker/src/components/Month/Month.test.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 
+import { screen } from '@testing-library/react';
+
 import { getMonthCaption, getMonthGrid } from 'test/po';
 import { customRender } from 'test/render';
 
-import { DayPickerProps } from 'types/DayPicker';
+import { CustomComponents, DayPickerProps } from 'types/DayPicker';
 
 import { Month, MonthProps } from './Month';
 
@@ -43,6 +45,18 @@ describe('when rendered', () => {
     const captionId = getMonthCaption().getAttribute('id');
     const gridLabelledBy = getMonthGrid().getAttribute('aria-labelledby');
     expect(captionId).toEqual(gridLabelledBy);
+  });
+});
+
+describe('when using a custom Caption component', () => {
+  const components: CustomComponents = {
+    Caption: () => <>custom caption foo</>
+  };
+  beforeEach(() => {
+    setup({ displayIndex: 0, displayMonth }, { components });
+  });
+  test('it should render the custom component instead', () => {
+    expect(screen.getByText('custom caption foo')).toBeInTheDocument();
   });
 });
 

--- a/packages/react-day-picker/src/components/Month/Month.tsx
+++ b/packages/react-day-picker/src/components/Month/Month.tsx
@@ -16,7 +16,7 @@ export interface MonthProps {
 /** Render a month. */
 export function Month(props: MonthProps) {
   const dayPicker = useDayPicker();
-  const { dir, classNames, styles } = dayPicker;
+  const { dir, classNames, styles, components } = dayPicker;
   const { displayMonths } = useNavigation();
   const captionId = useId();
   const className = [classNames.month];
@@ -42,9 +42,11 @@ export function Month(props: MonthProps) {
     style = { ...style, ...styles.caption_between };
   }
 
+  const CaptionComponent = components?.Caption ?? Caption;
+
   return (
     <div key={props.displayIndex} className={className.join(' ')} style={style}>
-      <Caption id={captionId} displayMonth={props.displayMonth} />
+      <CaptionComponent id={captionId} displayMonth={props.displayMonth} />
       <Table aria-labelledby={captionId} displayMonth={props.displayMonth} />
     </div>
   );


### PR DESCRIPTION
Solves #1393 

I think this got accidentally lost when extracting the `Month` component out of `Root`
(see https://github.com/gpbl/react-day-picker/commit/fc9d913678bbdf3a07c170c4a6e37a3ba1686c3b#diff-562116226713def1cf68ac5328a7d4582aa5d3d431dd7ee5d77bd2802dccaedaL21)
