### PR TITLE
allow clear date button to work when an invalid date is typed in

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -422,16 +422,10 @@ export default class DayPickerInput extends React.Component {
       inputProps.onChange(e);
     }
     const { value } = e.target;
-    if (value.trim() === '') {
-      this.setState({ value, typedValue: '' });
-      if (onDayChange) onDayChange(undefined, {}, this);
-      return;
-    }
     const day = parseDate(value, format, dayPickerProps.locale);
-    if (!day) {
-      // Day is invalid: we save the value in the typedValue state
+    if (value.trim() === '' || !day) {
       this.setState({ value, typedValue: value });
-      if (onDayChange) onDayChange(undefined, {}, this);
+      if (onDayChange) onDayChange(value, {}, this);
       return;
     }
     this.updateState(day, value);
@@ -586,8 +580,8 @@ export default class DayPickerInput extends React.Component {
         <Input
           ref={el => (this.input = el)}
           placeholder={this.props.placeholder}
+          value={this.state.value}
           {...inputProps}
-          value={this.state.value || this.state.typedValue}
           onChange={this.handleInputChange}
           onFocus={this.handleInputFocus}
           onBlur={this.handleInputBlur}

--- a/test/daypickerinput/events.js
+++ b/test/daypickerinput/events.js
@@ -128,33 +128,11 @@ describe('DayPickerInput', () => {
         wrapper.update();
         expect(wrapper.find('input')).toHaveProp('value', ' ');
       });
-      it("should call `onDayChange` if the input's value is empty", () => {
-        const onDayChange = jest.fn();
-        const wrapper = mount(<DayPickerInput onDayChange={onDayChange} />);
-        const input = wrapper.find('input');
-        input.simulate('change', { target: { value: '' } });
-        expect(onDayChange).toHaveBeenCalledWith(
-          undefined,
-          {},
-          expect.anything()
-        );
-      });
       it("should update the input's value if the value is not a valid date", () => {
         const wrapper = mount(<DayPickerInput />);
         const input = wrapper.find('input');
         input.simulate('change', { target: { value: 'foo' } });
         expect(wrapper.find('input')).toHaveProp('value', 'foo');
-      });
-      it('should call `onDayChange` with `undefined` if the value is not a valid date', () => {
-        const onDayChange = jest.fn();
-        const wrapper = mount(<DayPickerInput onDayChange={onDayChange} />);
-        const input = wrapper.find('input');
-        input.simulate('change', { target: { value: 'foo' } });
-        expect(onDayChange).toHaveBeenCalledWith(
-          undefined,
-          {},
-          expect.anything()
-        );
       });
       it("should update the input's value and the displayed month", () => {
         const wrapper = mount(<DayPickerInput />);
@@ -417,25 +395,6 @@ describe('DayPickerInput', () => {
           },
           expect.anything()
         );
-      });
-      it('should call `onDayChange` when typing an invalid day', () => {
-        const onDayChange = jest.fn();
-        const wrapper = mount(
-          <DayPickerInput onDayChange={onDayChange} clickUnselectsDay />
-        );
-        wrapper.update();
-        wrapper
-          .find('input')
-          .simulate('change', { target: { value: '02/07/x' } });
-        wrapper.update();
-        expect(onDayChange).toHaveBeenCalledWith(
-          undefined,
-          {},
-          expect.anything()
-        );
-        wrapper.setState({ typedValue: '02/07/x', value: '' });
-        expect(wrapper.state('typedValue')).toBe('02/07/x');
-        expect(wrapper.find('input')).toHaveProp('value', '02/07/x');
       });
       it('should not call `onDayChange` if the day is disabled', () => {
         const onDayChange = jest.fn();


### PR DESCRIPTION
👋🏽 Thanks for opening a pull request!
#1255 
* Please explain clearly your changes. If they involve a lot of code, let discuss them first in on our chat: https://spectrum.chat/react-day-picker?tab=chat
* 🙏🏽 Please **DO NOT** build files or update the docs in your pull request – as this may cause git conflicts. Thanks!
I can't explain too clearly about this, but if you do a `console.log(this.props.value)` on componentDidUpdate, you will see that the value never changes if the date is invalid, it will always be an empty string. This pull request force it to recognize the change by calling the onDayChange function with whatever typed. The 3 test cases removed are no longer necessary, because they are no longer called with `undefined`. The only thing I'm wondering is whether we need the typedValue anymore.