### PR TITLE
Fix/1255 clear input when invalid date is typed

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -196,6 +196,7 @@ export default class DayPickerInput extends React.Component {
         newState.value = formatDate(value, format, dayPickerProps.locale);
       } else {
         newState.value = value;
+        newState.typedValue = value;
       }
     }
 
@@ -423,7 +424,8 @@ export default class DayPickerInput extends React.Component {
     }
     const { value } = e.target;
     const day = parseDate(value, format, dayPickerProps.locale);
-    if (value.trim() === '' || !day) {
+    if (!day || value.trim() === '') {
+      // Day is invalid: we save the value in the typedValue state
       this.setState({ value, typedValue: value });
       if (onDayChange) onDayChange(value, {}, this);
       return;
@@ -580,8 +582,8 @@ export default class DayPickerInput extends React.Component {
         <Input
           ref={el => (this.input = el)}
           placeholder={this.props.placeholder}
-          value={this.state.value}
           {...inputProps}
+          value={this.state.value || this.state.typedValue}
           onChange={this.handleInputChange}
           onFocus={this.handleInputFocus}
           onBlur={this.handleInputBlur}

--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -422,16 +422,10 @@ export default class DayPickerInput extends React.Component {
       inputProps.onChange(e);
     }
     const { value } = e.target;
-    if (value.trim() === '') {
-      this.setState({ value, typedValue: '' });
-      if (onDayChange) onDayChange(undefined, {}, this);
-      return;
-    }
     const day = parseDate(value, format, dayPickerProps.locale);
-    if (!day) {
-      // Day is invalid: we save the value in the typedValue state
+    if (value.trim() === '' || !day) {
       this.setState({ value, typedValue: value });
-      if (onDayChange) onDayChange(undefined, {}, this);
+      if (onDayChange) onDayChange(value, {}, this);
       return;
     }
     this.updateState(day, value);
@@ -586,8 +580,8 @@ export default class DayPickerInput extends React.Component {
         <Input
           ref={el => (this.input = el)}
           placeholder={this.props.placeholder}
+          value={this.state.value}
           {...inputProps}
-          value={this.state.value || this.state.typedValue}
           onChange={this.handleInputChange}
           onFocus={this.handleInputFocus}
           onBlur={this.handleInputBlur}

--- a/test/daypickerinput/events.js
+++ b/test/daypickerinput/events.js
@@ -128,33 +128,11 @@ describe('DayPickerInput', () => {
         wrapper.update();
         expect(wrapper.find('input')).toHaveProp('value', ' ');
       });
-      it("should call `onDayChange` if the input's value is empty", () => {
-        const onDayChange = jest.fn();
-        const wrapper = mount(<DayPickerInput onDayChange={onDayChange} />);
-        const input = wrapper.find('input');
-        input.simulate('change', { target: { value: '' } });
-        expect(onDayChange).toHaveBeenCalledWith(
-          undefined,
-          {},
-          expect.anything()
-        );
-      });
       it("should update the input's value if the value is not a valid date", () => {
         const wrapper = mount(<DayPickerInput />);
         const input = wrapper.find('input');
         input.simulate('change', { target: { value: 'foo' } });
         expect(wrapper.find('input')).toHaveProp('value', 'foo');
-      });
-      it('should call `onDayChange` with `undefined` if the value is not a valid date', () => {
-        const onDayChange = jest.fn();
-        const wrapper = mount(<DayPickerInput onDayChange={onDayChange} />);
-        const input = wrapper.find('input');
-        input.simulate('change', { target: { value: 'foo' } });
-        expect(onDayChange).toHaveBeenCalledWith(
-          undefined,
-          {},
-          expect.anything()
-        );
       });
       it("should update the input's value and the displayed month", () => {
         const wrapper = mount(<DayPickerInput />);
@@ -417,25 +395,6 @@ describe('DayPickerInput', () => {
           },
           expect.anything()
         );
-      });
-      it('should call `onDayChange` when typing an invalid day', () => {
-        const onDayChange = jest.fn();
-        const wrapper = mount(
-          <DayPickerInput onDayChange={onDayChange} clickUnselectsDay />
-        );
-        wrapper.update();
-        wrapper
-          .find('input')
-          .simulate('change', { target: { value: '02/07/x' } });
-        wrapper.update();
-        expect(onDayChange).toHaveBeenCalledWith(
-          undefined,
-          {},
-          expect.anything()
-        );
-        wrapper.setState({ typedValue: '02/07/x', value: '' });
-        expect(wrapper.state('typedValue')).toBe('02/07/x');
-        expect(wrapper.find('input')).toHaveProp('value', '02/07/x');
       });
       it('should not call `onDayChange` if the day is disabled', () => {
         const onDayChange = jest.fn();


### PR DESCRIPTION
👋🏽 Thanks for opening a pull request!
#1255 
* Please explain clearly your changes. If they involve a lot of code, let discuss them first in on our chat: https://spectrum.chat/react-day-picker?tab=chat
* 🙏🏽 Please **DO NOT** build files or update the docs in your pull request – as this may cause git conflicts. Thanks!

The above issue happen when the value of the Input is controlled by something other than the **Input** and the **DayPicker**. In this case, it's the reset button that changes the value to `""`. When we type invalid characters, the following line kicks in:
https://github.com/gpbl/react-day-picker/blob/aeb3e9e8f8aa4dc0cb8ed8400b0a388946e2104e/src/DayPickerInput.js#L431-L436
As you can see, the onChange being called with `undefined`, which sets the `dateStart` state of the App.js to be `undefined` everytime. The state is then passed down as value prop for the **DayPickerInput** component. So no matter what we type, the value prop is forever `undefined`. Then input the **DayPickerInput**, it's always an empty string. This part I don't know, but perhaps because of the defaultProps:
https://github.com/gpbl/react-day-picker/blob/aeb3e9e8f8aa4dc0cb8ed8400b0a388946e2104e/src/DayPickerInput.js#L141-L143
When the reset button is clicked, it sets the `dateStart` to empty string => value prop is empty string, but since it has always been an empty string, it doesn't register that the value prop has changed. And since the button doesn't trigger `handle` functions either, nothing happens to the input.
My PR does 2 things:

1. It forces the onChange to be called with whatever we type in, so the value prop will actually change as well. When the reset button is clicked, it will detect the new prop.
2. We have to update the typedValue as well, because otherwise value will be an empty string, but the typedValue will be the same, which prevents the input displaying the correct value due to this line:
https://github.com/gpbl/react-day-picker/blob/aeb3e9e8f8aa4dc0cb8ed8400b0a388946e2104e/src/DayPickerInput.js#L590

I have also removed 3 test cases, all of which expect the onChange to be called with `undefined`, but since we are calling it with whatever we type in, we don't really need those cases anymore. Or if you want I can update the test cases to be called with whatever typed in. Please let me know.