### PR TITLE
Fix add on select month property for navbar element

### DIFF
--- a/docs/src/pages/api/DayPicker.js
+++ b/docs/src/pages/api/DayPicker.js
@@ -363,6 +363,9 @@ export default () => (
         <li>
           <code>onNextClick: () ⇒ void</code>
         </li>
+        <li>
+          <code>onSelectMonth: (selectedMonth: Date) ⇒ void</code>
+        </li>
       </ul>
       <h3>
         <Anchor id="numberOfMonths" />

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -304,6 +304,13 @@ export class DayPicker extends Component {
     this.showMonth(nextMonth);
   }
 
+  showSelectedMonth = (selectedMonth) => {
+    if(!this.allowMonth(selectedMonth)){
+      return;
+    }
+    this.showMonth(selectedMonth);
+  };
+
   focus() {
     this.wrapper.focus();
   }
@@ -519,6 +526,7 @@ export class DayPicker extends Component {
       previousMonth: this.getPreviousNavigableMonth(),
       showPreviousButton: this.allowPreviousMonth(),
       showNextButton: this.allowNextMonth(),
+      onSelectMonth: this.showSelectedMonth,
       onNextClick: this.showNextMonth,
       onPreviousClick: this.showPreviousMonth,
       dir: attributes.dir,

--- a/test/daypicker/methods.js
+++ b/test/daypicker/methods.js
@@ -178,6 +178,57 @@ describe('DayPicker’s methods', () => {
     });
   });
 
+  describe('showSelectedMonth()', () => {
+    it('should show selected month', () => {
+      const instance = shallow(
+        <DayPicker initialMonth={new Date(2015, 7)} />
+      ).instance();
+      instance.showSelectedMonth(new Date(2016, 7));
+      expect(instance.state.currentMonth.getFullYear()).toBe(2016);
+      expect(instance.state.currentMonth.getMonth()).toBe(7);
+      expect(instance.state.currentMonth.getDate()).toBe(1);
+    });
+
+    it('should not change the month when canChangeMonth is set to false', () => {
+      const instance = shallow(
+        <DayPicker
+          initialMonth={new Date(2015, 7)}
+          canChangeMonth={false}
+        />
+      ).instance();
+      instance.showSelectedMonth(new Date(2016, 7));
+      expect(instance.state.currentMonth.getFullYear()).toBe(2015);
+      expect(instance.state.currentMonth.getMonth()).toBe(7);
+      expect(instance.state.currentMonth.getDate()).toBe(1);
+    });
+
+    it('should not change the month when selected date is later than toMonth', () => {
+      const instance = shallow(
+        <DayPicker
+          initialMonth={new Date(2015, 7)}
+          toMonth={new Date(2015, 9)}
+        />
+      ).instance();
+      instance.showSelectedMonth(new Date(2016, 7));
+      expect(instance.state.currentMonth.getFullYear()).toBe(2015);
+      expect(instance.state.currentMonth.getMonth()).toBe(7);
+      expect(instance.state.currentMonth.getDate()).toBe(1);
+    });
+
+    it('should not change the month when selected date is earlier than fromMonth', () => {
+      const instance = shallow(
+        <DayPicker
+          initialMonth={new Date(2015, 7)}
+          fromMonth={new Date(2015, 5)}
+        />
+      ).instance();
+      instance.showSelectedMonth(new Date(2015, 3));
+      expect(instance.state.currentMonth.getFullYear()).toBe(2015);
+      expect(instance.state.currentMonth.getMonth()).toBe(7);
+      expect(instance.state.currentMonth.getDate()).toBe(1);
+    });
+  });
+
   describe('showMonth()', () => {
     it('should show the specified month', () => {
       const instance = shallow(


### PR DESCRIPTION
https://github.com/gpbl/react-day-picker/issues/1397

I have added one method _showSelectedMonth_, also a few unit tests to cover all corner cases and updated API reference for the _navbarElement_ property. 

DayPicker.js
```
  showSelectedMonth = (selectedMonth) => {
    if(!this.allowMonth(selectedMonth)){
      return;
    }
    this.showMonth(selectedMonth);
  };
```
daypicker/methods.js
```
  describe('showSelectedMonth()', () => {
    it('should show selected month', () => {
      const instance = shallow(
        <DayPicker initialMonth={new Date(2015, 7)} />
      ).instance();
      instance.showSelectedMonth(new Date(2016, 7));
      expect(instance.state.currentMonth.getFullYear()).toBe(2016);
      expect(instance.state.currentMonth.getMonth()).toBe(7);
      expect(instance.state.currentMonth.getDate()).toBe(1);
    });

    it('should not change the month when canChangeMonth is set to false', () => {
      const instance = shallow(
        <DayPicker
          initialMonth={new Date(2015, 7)}
          canChangeMonth={false}
        />
      ).instance();
      instance.showSelectedMonth(new Date(2016, 7));
      expect(instance.state.currentMonth.getFullYear()).toBe(2015);
      expect(instance.state.currentMonth.getMonth()).toBe(7);
      expect(instance.state.currentMonth.getDate()).toBe(1);
    });

    it('should not change the month when selected date is later than toMonth', () => {
      const instance = shallow(
        <DayPicker
          initialMonth={new Date(2015, 7)}
          toMonth={new Date(2015, 9)}
        />
      ).instance();
      instance.showSelectedMonth(new Date(2016, 7));
      expect(instance.state.currentMonth.getFullYear()).toBe(2015);
      expect(instance.state.currentMonth.getMonth()).toBe(7);
      expect(instance.state.currentMonth.getDate()).toBe(1);
    });

    it('should not change the month when selected date is earlier than fromMonth', () => {
      const instance = shallow(
        <DayPicker
          initialMonth={new Date(2015, 7)}
          fromMonth={new Date(2015, 5)}
        />
      ).instance();
      instance.showSelectedMonth(new Date(2015, 3));
      expect(instance.state.currentMonth.getFullYear()).toBe(2015);
      expect(instance.state.currentMonth.getMonth()).toBe(7);
      expect(instance.state.currentMonth.getDate()).toBe(1);
    });
  });
```

docs/src/pages/api/DayPicker.js
```
     <li>
          <code>onSelectMonth: (selectedMonth: Date) ⇒ void</code>
     </li>
```
