### PR TITLE
chore: split Caption into smaller components

### DIFF
--- a/packages/react-day-picker/src/components/Caption/Caption.test.tsx
+++ b/packages/react-day-picker/src/components/Caption/Caption.test.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
 import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { addMonths, setMonth, setYear } from 'date-fns';
 import { DayPickerProps } from 'DayPicker';
 
 import {
@@ -11,10 +9,8 @@ import {
   getNextButton,
   getPrevButton,
   getYearDropdown,
-  queryMonthDropdown,
   queryNextButton,
-  queryPrevButton,
-  queryYearDropdown
+  queryPrevButton
 } from 'test/po';
 import { customRender } from 'test/render';
 import { freezeBeforeAll } from 'test/utils';
@@ -24,8 +20,6 @@ import { CustomComponents } from 'types/DayPickerBase';
 import { Caption, CaptionProps } from './Caption';
 
 const today = new Date(2021, 8);
-const fromYear = 2020;
-const toYear = 2025;
 
 freezeBeforeAll(today);
 
@@ -60,24 +54,14 @@ describe('when using a custom CaptionLabel component', () => {
 });
 
 describe('when the caption layout is "dropdown"', () => {
-  let container: HTMLElement;
-
+  const dayPickerProps: DayPickerProps = {
+    captionLayout: 'dropdown',
+    fromYear: 2020,
+    toYear: 2025
+  };
+  const props = { displayMonth: today };
   beforeEach(() => {
-    const dayPickerProps: DayPickerProps = {
-      captionLayout: 'dropdown',
-      fromYear,
-      toYear,
-      classNames: { caption_dropdowns: 'foo_dropdowns' },
-      styles: { caption_dropdowns: { color: 'red' } }
-    };
-    const view = customRender(<Caption displayMonth={today} />, dayPickerProps);
-    container = view.container;
-  });
-  test('should use the `caption_dropdowns` class name', () => {
-    expect(container.firstChild?.firstChild).toHaveClass('foo_dropdowns');
-  });
-  test('should use the `caption_dropdowns` style', () => {
-    expect(container.firstChild?.firstChild).toHaveStyle({ color: 'red' });
+    setup(props, dayPickerProps);
   });
   test('should render the month drop-down', () => {
     expect(getMonthDropdown()).toBeInTheDocument();
@@ -87,63 +71,10 @@ describe('when the caption layout is "dropdown"', () => {
   });
 });
 
-describe('when a month is selected', () => {
-  const dayPickerProps: DayPickerProps = {
-    captionLayout: 'dropdown',
-    fromYear,
-    toYear,
-    onMonthChange: jest.fn()
-  };
-  beforeEach(() => {
-    customRender(<Caption displayMonth={today} />, dayPickerProps);
-  });
-  describe('from the months drop-down', () => {
-    const newMonth = setMonth(today, 0);
-    beforeEach(() => {
-      userEvent.selectOptions(
-        getMonthDropdown(),
-        newMonth.getMonth().toString()
-      );
-    });
-    test('should call the `onMonthChange` callback', () => {
-      expect(dayPickerProps.onMonthChange).toHaveBeenCalledWith(newMonth);
-    });
-  });
-  describe('from the years drop-down', () => {
-    const newYear = setYear(today, 2022);
-    beforeEach(() => {
-      userEvent.selectOptions(
-        getYearDropdown(),
-        newYear.getFullYear().toString()
-      );
-    });
-    test('should call the `onMonthChange` callback', () => {
-      expect(dayPickerProps.onMonthChange).toHaveBeenCalledWith(newYear);
-    });
-  });
-});
-
-describe('when the caption layout is "dropdown" but no date limits are set', () => {
-  const dayPickerProps: DayPickerProps = {
-    captionLayout: 'dropdown'
-  };
-  beforeEach(() => {
-    customRender(<Caption displayMonth={today} />, dayPickerProps);
-  });
-  test('should not render the drop-downs', () => {
-    expect(queryMonthDropdown()).toBeNull();
-    expect(queryYearDropdown()).toBeNull();
-  });
-});
-
 describe('when the caption layout is "buttons"', () => {
   const dayPickerProps: DayPickerProps = {
     captionLayout: 'buttons'
   };
-  test('should render the caption label', () => {
-    customRender(<Caption displayMonth={today} />, dayPickerProps);
-    expect(getMonthCaption()).toHaveTextContent('September 2021');
-  });
   test('should render the next month button', () => {
     customRender(<Caption displayMonth={today} />, dayPickerProps);
     expect(getNextButton()).toBeInTheDocument();
@@ -151,117 +82,5 @@ describe('when the caption layout is "buttons"', () => {
   test('should render the previous month button', () => {
     customRender(<Caption displayMonth={today} />, dayPickerProps);
     expect(getPrevButton()).toBeInTheDocument();
-  });
-
-  describe('when displaying the first of multiple months', () => {
-    const numberOfMonths = 3;
-    beforeEach(() => {
-      customRender(<Caption displayMonth={today} />, {
-        ...dayPickerProps,
-        numberOfMonths
-      });
-    });
-    test('should not display the next month button', () => {
-      expect(queryNextButton()).toBeNull();
-    });
-    test('should show the previous month button', () => {
-      expect(getPrevButton()).toBeInTheDocument();
-    });
-  });
-
-  describe('when displaying the last of multiple months', () => {
-    const numberOfMonths = 3;
-    beforeEach(() => {
-      const lastMonth = addMonths(today, numberOfMonths - 1);
-      customRender(<Caption displayMonth={lastMonth} />, {
-        ...dayPickerProps,
-        numberOfMonths
-      });
-    });
-    test('should hide the previous month button', () => {
-      expect(queryPrevButton()).toBeNull();
-    });
-    test('should show the next month button', () => {
-      expect(getNextButton()).toBeInTheDocument();
-    });
-  });
-
-  describe('when displaying a month in the middle of multiple months', () => {
-    const numberOfMonths = 3;
-    beforeEach(() => {
-      const lastMonth = addMonths(today, numberOfMonths - 2);
-      customRender(<Caption displayMonth={lastMonth} />, {
-        ...dayPickerProps,
-        numberOfMonths
-      });
-    });
-    test('should not render the previous month button', () => {
-      expect(queryPrevButton()).toBeNull();
-    });
-    test('should not render the next month button', () => {
-      expect(queryNextButton()).toBeNull();
-    });
-  });
-
-  describe('when clicking the previous button', () => {
-    describe('and a previous month is defined', () => {
-      const testContext = {
-        ...dayPickerProps,
-        onMonthChange: jest.fn()
-      };
-      const previousMonth = addMonths(today, -1);
-      beforeEach(() => {
-        customRender(<Caption displayMonth={today} />, testContext);
-        userEvent.click(getPrevButton());
-      });
-      test('should call the `onMonthChange` callback', () => {
-        expect(testContext.onMonthChange).toHaveBeenCalledWith(previousMonth);
-      });
-    });
-    describe('and the previous month is not defined', () => {
-      const testContext = {
-        ...dayPickerProps,
-        fromDate: today,
-        onMonthChange: jest.fn()
-      };
-      beforeEach(() => {
-        customRender(<Caption displayMonth={today} />, testContext);
-        userEvent.click(getPrevButton());
-      });
-      test('should call the `onMonthChange` callback', () => {
-        expect(testContext.onMonthChange).not.toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('when clicking the next month button', () => {
-    describe('and the next month is defined', () => {
-      const testContext = {
-        ...dayPickerProps,
-        onMonthChange: jest.fn()
-      };
-      const nextMonth = addMonths(today, 1);
-      beforeEach(() => {
-        customRender(<Caption displayMonth={today} />, testContext);
-        userEvent.click(getNextButton());
-      });
-      test('should call the `onMonthChange` callback', () => {
-        expect(testContext.onMonthChange).toHaveBeenCalledWith(nextMonth);
-      });
-    });
-    describe('and the next month is not defined', () => {
-      const testContext = {
-        ...dayPickerProps,
-        toDate: today,
-        onMonthChange: jest.fn()
-      };
-      beforeEach(() => {
-        customRender(<Caption displayMonth={today} />, testContext);
-        userEvent.click(getNextButton());
-      });
-      test('should call the `onMonthChange` callback', () => {
-        expect(testContext.onMonthChange).not.toHaveBeenCalled();
-      });
-    });
   });
 });

--- a/packages/react-day-picker/src/components/Caption/Caption.tsx
+++ b/packages/react-day-picker/src/components/Caption/Caption.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { CaptionDropdowns } from 'components/CaptionDropdowns';
 import { CaptionLabel } from 'components/CaptionLabel';
-import { CaptionNavigation } from 'components/CaptionNavigation/CaptionNavigation';
+import { CaptionNavigation } from 'components/CaptionNavigation';
 import { useDayPicker } from 'contexts/DayPicker';
 
 /** Represent the props of the [[Caption]] component. */

--- a/packages/react-day-picker/src/components/Caption/Caption.tsx
+++ b/packages/react-day-picker/src/components/Caption/Caption.tsx
@@ -1,14 +1,9 @@
 import React from 'react';
 
-import { isSameMonth } from 'date-fns';
-
+import { CaptionDropdowns } from 'components/CaptionDropdowns';
 import { CaptionLabel } from 'components/CaptionLabel';
-import { MonthsDropdown } from 'components/MonthsDropdown';
-import { Navigation } from 'components/Navigation';
-import { YearsDropdown } from 'components/YearsDropdown';
+import { CaptionNavigation } from 'components/CaptionNavigation/CaptionNavigation';
 import { useDayPicker } from 'contexts/DayPicker';
-import { useNavigation } from 'contexts/Navigation';
-import { MonthChangeEventHandler } from 'types/EventHandlers';
 
 /** Represent the props of the [[Caption]] component. */
 export interface CaptionProps {
@@ -27,99 +22,33 @@ export interface CaptionProps {
 export type CaptionLayout = 'dropdown' | 'buttons';
 
 /**
- * Render the caption of a month, which includes title and navigation buttons.
- * The caption has a different layout when setting the [[DayPickerProps.captionLayout]] prop.
+ * Render the caption of a month. The caption has a different layout when
+ * setting the [[DayPickerProps.captionLayout]] prop.
  */
 export function Caption(props: CaptionProps): JSX.Element {
-  const {
-    classNames,
-    numberOfMonths,
-    disableNavigation,
-    styles,
-    captionLayout,
-    onMonthChange,
-    dir,
-    components
-  } = useDayPicker();
-
-  const { previousMonth, nextMonth, goToMonth, displayMonths } =
-    useNavigation();
-
-  const handlePreviousClick: React.MouseEventHandler = () => {
-    if (!previousMonth) return;
-    goToMonth(previousMonth);
-    onMonthChange?.(previousMonth);
-  };
-
-  const handleNextClick: React.MouseEventHandler = () => {
-    if (!nextMonth) return;
-    goToMonth(nextMonth);
-    onMonthChange?.(nextMonth);
-  };
-
-  const handleMonthChange: MonthChangeEventHandler = (newMonth) => {
-    goToMonth(newMonth);
-    onMonthChange?.(newMonth);
-  };
-
-  const displayIndex = displayMonths.findIndex((month) =>
-    isSameMonth(props.displayMonth, month)
-  );
-  let isFirst = displayIndex === 0;
-  let isLast = displayIndex === displayMonths.length - 1;
-  if (dir === 'rtl') {
-    [isLast, isFirst] = [isFirst, isLast];
-  }
-
-  const hideNext = numberOfMonths > 1 && (isFirst || !isLast);
-  const hidePrevious = numberOfMonths > 1 && (isLast || !isFirst);
+  const { classNames, disableNavigation, styles, captionLayout, components } =
+    useDayPicker();
 
   const CaptionLabelComponent = components?.CaptionLabel ?? CaptionLabel;
-  const captionLabel = (
-    <CaptionLabelComponent id={props.id} displayMonth={props.displayMonth} />
-  );
 
-  let captionContent;
+  let caption: JSX.Element;
   if (disableNavigation) {
-    captionContent = captionLabel;
+    caption = (
+      <CaptionLabelComponent id={props.id} displayMonth={props.displayMonth} />
+    );
   } else if (captionLayout === 'dropdown') {
-    captionContent = (
-      <div
-        className={classNames.caption_dropdowns}
-        style={styles.caption_dropdowns}
-      >
-        {/* Caption label is visually hidden but for a11y. */}
-        <div className={classNames.vhidden}>{captionLabel}</div>
-        <MonthsDropdown
-          onChange={handleMonthChange}
-          displayMonth={props.displayMonth}
-        />
-        <YearsDropdown
-          onChange={handleMonthChange}
-          displayMonth={props.displayMonth}
-        />
-      </div>
+    caption = (
+      <CaptionDropdowns displayMonth={props.displayMonth} id={props.id} />
     );
   } else {
-    captionContent = (
-      <>
-        {captionLabel}
-        <Navigation
-          displayMonth={props.displayMonth}
-          hideNext={hideNext}
-          hidePrevious={hidePrevious}
-          nextMonth={nextMonth}
-          previousMonth={previousMonth}
-          onPreviousClick={handlePreviousClick}
-          onNextClick={handleNextClick}
-        />
-      </>
+    caption = (
+      <CaptionNavigation displayMonth={props.displayMonth} id={props.id} />
     );
   }
 
   return (
     <div className={classNames.caption} style={styles.caption}>
-      {captionContent}
+      {caption}
     </div>
   );
 }

--- a/packages/react-day-picker/src/components/CaptionDropdowns/CaptionDropdowns.test.tsx
+++ b/packages/react-day-picker/src/components/CaptionDropdowns/CaptionDropdowns.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { setMonth, setYear } from 'date-fns';
+import { DayPickerProps } from 'DayPicker';
+
+import {
+  getMonthDropdown,
+  getYearDropdown,
+  queryMonthDropdown,
+  queryYearDropdown
+} from 'test/po';
+import { customRender } from 'test/render';
+import { freezeBeforeAll } from 'test/utils';
+
+import { CaptionProps } from 'components/Caption';
+import { CustomComponents } from 'types/DayPickerBase';
+
+import { CaptionDropdowns } from './CaptionDropdowns';
+
+const today = new Date(2021, 8);
+const fromYear = 2020;
+const toYear = 2025;
+
+freezeBeforeAll(today);
+
+function setup(props: CaptionProps, dayPickerProps?: DayPickerProps) {
+  customRender(<CaptionDropdowns {...props} />, dayPickerProps);
+}
+
+describe('when using a custom CaptionLabel component', () => {
+  const components: CustomComponents = {
+    CaptionLabel: () => <>custom label foo</>
+  };
+  const props = { displayMonth: today };
+  beforeEach(() => {
+    setup(props, { components });
+  });
+  test('it should render the custom component instead', () => {
+    expect(screen.getByText('custom label foo')).toBeInTheDocument();
+  });
+});
+
+describe('when rendered with custom styles or classnames', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    const dayPickerProps: DayPickerProps = {
+      captionLayout: 'dropdown',
+      fromYear,
+      toYear,
+      classNames: { caption_dropdowns: 'foo_dropdowns' },
+      styles: { caption_dropdowns: { color: 'red' } }
+    };
+    const view = customRender(
+      <CaptionDropdowns displayMonth={today} />,
+      dayPickerProps
+    );
+    container = view.container;
+  });
+  test('should use the `caption_dropdowns` class name', () => {
+    expect(container.firstChild).toHaveClass('foo_dropdowns');
+  });
+  test('should use the `caption_dropdowns` style', () => {
+    expect(container.firstChild).toHaveStyle({ color: 'red' });
+  });
+  test('should render the month drop-down', () => {
+    expect(getMonthDropdown()).toBeInTheDocument();
+  });
+  test('should render the year drop-down', () => {
+    expect(getYearDropdown()).toBeInTheDocument();
+  });
+});
+
+describe('when a month is selected', () => {
+  const dayPickerProps: DayPickerProps = {
+    captionLayout: 'dropdown',
+    fromYear,
+    toYear,
+    onMonthChange: jest.fn()
+  };
+  beforeEach(() => {
+    customRender(<CaptionDropdowns displayMonth={today} />, dayPickerProps);
+  });
+  describe('from the months drop-down', () => {
+    const newMonth = setMonth(today, 0);
+    beforeEach(() => {
+      userEvent.selectOptions(
+        getMonthDropdown(),
+        newMonth.getMonth().toString()
+      );
+    });
+    test('should call the `onMonthChange` callback', () => {
+      expect(dayPickerProps.onMonthChange).toHaveBeenCalledWith(newMonth);
+    });
+  });
+  describe('from the years drop-down', () => {
+    const newYear = setYear(today, 2022);
+    beforeEach(() => {
+      userEvent.selectOptions(
+        getYearDropdown(),
+        newYear.getFullYear().toString()
+      );
+    });
+    test('should call the `onMonthChange` callback', () => {
+      expect(dayPickerProps.onMonthChange).toHaveBeenCalledWith(newYear);
+    });
+  });
+});
+
+describe('when no date limits are set', () => {
+  const dayPickerProps: DayPickerProps = {
+    captionLayout: 'dropdown'
+  };
+  beforeEach(() => {
+    customRender(<CaptionDropdowns displayMonth={today} />, dayPickerProps);
+  });
+  test('should not render the drop-downs', () => {
+    expect(queryMonthDropdown()).toBeNull();
+    expect(queryYearDropdown()).toBeNull();
+  });
+});

--- a/packages/react-day-picker/src/components/CaptionDropdowns/CaptionDropdowns.tsx
+++ b/packages/react-day-picker/src/components/CaptionDropdowns/CaptionDropdowns.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import { CaptionProps } from 'components/Caption/Caption';
+import { CaptionLabel } from 'components/CaptionLabel';
+import { MonthsDropdown } from 'components/MonthsDropdown';
+import { YearsDropdown } from 'components/YearsDropdown';
+import { useDayPicker } from 'contexts/DayPicker';
+import { useNavigation } from 'contexts/Navigation';
+import { MonthChangeEventHandler } from 'types/EventHandlers';
+
+/**
+ * Render a caption with the dropdowns to navigate between months and years.
+ */
+export function CaptionDropdowns(props: CaptionProps): JSX.Element {
+  const { classNames, styles, onMonthChange, components } = useDayPicker();
+  const { goToMonth } = useNavigation();
+
+  const handleMonthChange: MonthChangeEventHandler = (newMonth) => {
+    goToMonth(newMonth);
+    onMonthChange?.(newMonth);
+  };
+  const CaptionLabelComponent = components?.CaptionLabel ?? CaptionLabel;
+  const captionLabel = (
+    <CaptionLabelComponent id={props.id} displayMonth={props.displayMonth} />
+  );
+  return (
+    <div
+      className={classNames.caption_dropdowns}
+      style={styles.caption_dropdowns}
+    >
+      {/* Caption label is visually hidden but for a11y. */}
+      <div className={classNames.vhidden}>{captionLabel}</div>
+      <MonthsDropdown
+        onChange={handleMonthChange}
+        displayMonth={props.displayMonth}
+      />
+      <YearsDropdown
+        onChange={handleMonthChange}
+        displayMonth={props.displayMonth}
+      />
+    </div>
+  );
+}

--- a/packages/react-day-picker/src/components/CaptionDropdowns/index.ts
+++ b/packages/react-day-picker/src/components/CaptionDropdowns/index.ts
@@ -1,0 +1,1 @@
+export * from './CaptionDropdowns';

--- a/packages/react-day-picker/src/components/CaptionNavigation/CaptionNavigation.test.tsx
+++ b/packages/react-day-picker/src/components/CaptionNavigation/CaptionNavigation.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { addMonths } from 'date-fns';
+import { DayPickerProps } from 'DayPicker';
+
+import {
+  getMonthCaption,
+  getNextButton,
+  getPrevButton,
+  queryNextButton,
+  queryPrevButton
+} from 'test/po';
+import { customRender } from 'test/render';
+import { freezeBeforeAll } from 'test/utils';
+
+import { CaptionProps } from 'components/Caption';
+import { CustomComponents } from 'types/DayPickerBase';
+
+import { CaptionNavigation } from './CaptionNavigation';
+
+const today = new Date(2021, 8);
+
+freezeBeforeAll(today);
+
+function setup(props: CaptionProps, dayPickerProps?: DayPickerProps) {
+  customRender(<CaptionNavigation {...props} />, dayPickerProps);
+}
+
+describe('when using a custom CaptionLabel component', () => {
+  const components: CustomComponents = {
+    CaptionLabel: () => <>custom label foo</>
+  };
+  const props = { displayMonth: today };
+  beforeEach(() => {
+    setup(props, { components });
+  });
+  test('it should render the custom component instead', () => {
+    expect(screen.getByText('custom label foo')).toBeInTheDocument();
+  });
+});
+
+describe('when rendered', () => {
+  const dayPickerProps: DayPickerProps = {
+    captionLayout: 'buttons'
+  };
+  test('should render the caption label', () => {
+    customRender(<CaptionNavigation displayMonth={today} />, dayPickerProps);
+    expect(getMonthCaption()).toHaveTextContent('September 2021');
+  });
+  test('should render the next month button', () => {
+    customRender(<CaptionNavigation displayMonth={today} />, dayPickerProps);
+    expect(getNextButton()).toBeInTheDocument();
+  });
+  test('should render the previous month button', () => {
+    customRender(<CaptionNavigation displayMonth={today} />, dayPickerProps);
+    expect(getPrevButton()).toBeInTheDocument();
+  });
+
+  describe('when displaying the first of multiple months', () => {
+    const numberOfMonths = 3;
+    beforeEach(() => {
+      customRender(<CaptionNavigation displayMonth={today} />, {
+        ...dayPickerProps,
+        numberOfMonths
+      });
+    });
+    test('should not display the next month button', () => {
+      expect(queryNextButton()).toBeNull();
+    });
+    test('should show the previous month button', () => {
+      expect(getPrevButton()).toBeInTheDocument();
+    });
+  });
+
+  describe('when displaying the last of multiple months', () => {
+    const numberOfMonths = 3;
+    beforeEach(() => {
+      const lastMonth = addMonths(today, numberOfMonths - 1);
+      customRender(<CaptionNavigation displayMonth={lastMonth} />, {
+        ...dayPickerProps,
+        numberOfMonths
+      });
+    });
+    test('should hide the previous month button', () => {
+      expect(queryPrevButton()).toBeNull();
+    });
+    test('should show the next month button', () => {
+      expect(getNextButton()).toBeInTheDocument();
+    });
+  });
+
+  describe('when displaying a month in the middle of multiple months', () => {
+    const numberOfMonths = 3;
+    beforeEach(() => {
+      const lastMonth = addMonths(today, numberOfMonths - 2);
+      customRender(<CaptionNavigation displayMonth={lastMonth} />, {
+        ...dayPickerProps,
+        numberOfMonths
+      });
+    });
+    test('should not render the previous month button', () => {
+      expect(queryPrevButton()).toBeNull();
+    });
+    test('should not render the next month button', () => {
+      expect(queryNextButton()).toBeNull();
+    });
+  });
+
+  describe('when clicking the previous button', () => {
+    describe('and a previous month is defined', () => {
+      const testContext = {
+        ...dayPickerProps,
+        onMonthChange: jest.fn()
+      };
+      const previousMonth = addMonths(today, -1);
+      beforeEach(() => {
+        customRender(<CaptionNavigation displayMonth={today} />, testContext);
+        userEvent.click(getPrevButton());
+      });
+      test('should call the `onMonthChange` callback', () => {
+        expect(testContext.onMonthChange).toHaveBeenCalledWith(previousMonth);
+      });
+    });
+    describe('and the previous month is not defined', () => {
+      const testContext = {
+        ...dayPickerProps,
+        fromDate: today,
+        onMonthChange: jest.fn()
+      };
+      beforeEach(() => {
+        customRender(<CaptionNavigation displayMonth={today} />, testContext);
+        userEvent.click(getPrevButton());
+      });
+      test('should call the `onMonthChange` callback', () => {
+        expect(testContext.onMonthChange).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when clicking the next month button', () => {
+    describe('and the next month is defined', () => {
+      const testContext = {
+        ...dayPickerProps,
+        onMonthChange: jest.fn()
+      };
+      const nextMonth = addMonths(today, 1);
+      beforeEach(() => {
+        customRender(<CaptionNavigation displayMonth={today} />, testContext);
+        userEvent.click(getNextButton());
+      });
+      test('should call the `onMonthChange` callback', () => {
+        expect(testContext.onMonthChange).toHaveBeenCalledWith(nextMonth);
+      });
+    });
+    describe('and the next month is not defined', () => {
+      const testContext = {
+        ...dayPickerProps,
+        toDate: today,
+        onMonthChange: jest.fn()
+      };
+      beforeEach(() => {
+        customRender(<CaptionNavigation displayMonth={today} />, testContext);
+        userEvent.click(getNextButton());
+      });
+      test('should call the `onMonthChange` callback', () => {
+        expect(testContext.onMonthChange).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/packages/react-day-picker/src/components/CaptionNavigation/CaptionNavigation.tsx
+++ b/packages/react-day-picker/src/components/CaptionNavigation/CaptionNavigation.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+import isSameMonth from 'date-fns/isSameMonth';
+
+import { CaptionProps } from 'components/Caption/Caption';
+import { CaptionLabel } from 'components/CaptionLabel';
+import { Navigation } from 'components/Navigation';
+import { useDayPicker } from 'contexts/DayPicker';
+import { useNavigation } from 'contexts/Navigation';
+
+/**
+ * Render a caption with a button-based navigation.
+ */
+export function CaptionNavigation(props: CaptionProps): JSX.Element {
+  const { numberOfMonths, onMonthChange, dir, components } = useDayPicker();
+  const { previousMonth, nextMonth, goToMonth, displayMonths } =
+    useNavigation();
+
+  const displayIndex = displayMonths.findIndex((month) =>
+    isSameMonth(props.displayMonth, month)
+  );
+
+  let isFirst = displayIndex === 0;
+  let isLast = displayIndex === displayMonths.length - 1;
+  if (dir === 'rtl') {
+    [isLast, isFirst] = [isFirst, isLast];
+  }
+
+  const hideNext = numberOfMonths > 1 && (isFirst || !isLast);
+  const hidePrevious = numberOfMonths > 1 && (isLast || !isFirst);
+
+  const handlePreviousClick: React.MouseEventHandler = () => {
+    if (!previousMonth) return;
+    goToMonth(previousMonth);
+    onMonthChange?.(previousMonth);
+  };
+
+  const handleNextClick: React.MouseEventHandler = () => {
+    if (!nextMonth) return;
+    goToMonth(nextMonth);
+    onMonthChange?.(nextMonth);
+  };
+
+  const CaptionLabelComponent = components?.CaptionLabel ?? CaptionLabel;
+  const captionLabel = (
+    <CaptionLabelComponent id={props.id} displayMonth={props.displayMonth} />
+  );
+
+  return (
+    <>
+      {captionLabel}
+      <Navigation
+        displayMonth={props.displayMonth}
+        hideNext={hideNext}
+        hidePrevious={hidePrevious}
+        nextMonth={nextMonth}
+        previousMonth={previousMonth}
+        onPreviousClick={handlePreviousClick}
+        onNextClick={handleNextClick}
+      />
+    </>
+  );
+}

--- a/packages/react-day-picker/src/components/CaptionNavigation/index.ts
+++ b/packages/react-day-picker/src/components/CaptionNavigation/index.ts
@@ -1,0 +1,1 @@
+export * from './CaptionNavigation';

--- a/packages/react-day-picker/src/index.ts
+++ b/packages/react-day-picker/src/index.ts
@@ -2,7 +2,9 @@ export * from './DayPicker';
 
 export * from 'components/Button';
 export * from 'components/Caption';
+export * from 'components/CaptionDropdowns';
 export * from 'components/CaptionLabel';
+export * from 'components/CaptionNavigation';
 export * from 'components/Day';
 export * from 'components/DayContent';
 export * from 'components/Dropdown';


### PR DESCRIPTION
This PR splits the Caption components into two smaller `CaptionNavigation` and `CaptionDropdowns`. The change should make easier to customize the Caption component.

See related discussion: https://github.com/gpbl/react-day-picker/discussions/1425