### PR TITLE
fix: toMonth to include the full month

### DIFF
--- a/packages/react-day-picker/src/contexts/DayPicker/utils/parseFromToProps.test.ts
+++ b/packages/react-day-picker/src/contexts/DayPicker/utils/parseFromToProps.test.ts
@@ -25,13 +25,13 @@ describe('when "fromYear" is passed in', () => {
 
 describe('when "toMonth" is passed in', () => {
   const toMonth = new Date(2021, 4, 3);
-  const expectedToDate = new Date(2021, 4, 1);
+  const expectedToDate = new Date(2021, 4, 31);
   const { toDate } = parseFromToProps({ toMonth });
-  test('"toDate" should be the start of that month', () => {
+  test('"toDate" should be the end of that month', () => {
     expect(toDate).toEqual(expectedToDate);
   });
   describe('when "fromYear" is passed in', () => {
-    test('"toDate" should be the start of that month', () => {
+    test('"toDate" should be the end of that month', () => {
       expect(toDate).toEqual(expectedToDate);
     });
   });

--- a/packages/react-day-picker/src/contexts/DayPicker/utils/parseFromToProps.ts
+++ b/packages/react-day-picker/src/contexts/DayPicker/utils/parseFromToProps.ts
@@ -1,4 +1,4 @@
-import { startOfDay, startOfMonth } from 'date-fns';
+import { startOfDay, startOfMonth, endOfMonth } from 'date-fns';
 
 import { DayPickerBase } from 'types/DayPickerBase';
 
@@ -18,7 +18,7 @@ export function parseFromToProps(
     fromDate = new Date(fromYear, 0, 1);
   }
   if (toMonth) {
-    toDate = startOfMonth(toMonth);
+    toDate = endOfMonth(toMonth);
   } else if (toYear) {
     toDate = new Date(toYear, 11, 31);
   }


### PR DESCRIPTION
If `toMonth` prop passed, we should limit date to the end of the month. Otherwise you cant disable dates in the same month as `toMonth` because it limits to the first day of month. Example: https://codesandbox.io/s/react-day-picker-base-forked-3b557v 
