### PR TITLE
website: remove extraneous symbols from range-min-max example

### DIFF
--- a/website/examples/range-min-max.tsx
+++ b/website/examples/range-min-max.tsx
@@ -13,7 +13,7 @@ export default function App() {
     } else if (range.to) {
       footer = (
         <p>
-          {format(range.from, 'PPP')}–${format(range.to, 'PPP')}`
+          {format(range.from, 'PPP')}–{format(range.to, 'PPP')}
         </p>
       );
     }


### PR DESCRIPTION
The current code gives output like this:
> April 25th, 2022–$April 26th, 2022`

I removed the `$` and the `` ` ``