### PR TITLE
Fix: home/end buttons behavior with startOfWeek

### DIFF
--- a/packages/react-day-picker/src/contexts/Focus/FocusContext.tsx
+++ b/packages/react-day-picker/src/contexts/Focus/FocusContext.tsx
@@ -7,6 +7,7 @@ import addYears from 'date-fns/addYears';
 import endOfWeek from 'date-fns/endOfWeek';
 import startOfWeek from 'date-fns/startOfWeek';
 
+import { useDayPicker } from 'contexts/DayPicker';
 import { useModifiers } from '../Modifiers';
 import { useNavigation } from '../Navigation';
 import { getInitialFocusTarget } from './utils/getInitialFocusTarget';
@@ -65,6 +66,8 @@ export function FocusProvider(props: { children: ReactNode }): JSX.Element {
     modifiers
   );
 
+  const { weekStartsOn } = useDayPicker();
+
   // TODO: cleanup and test obscure code below
   const focusTarget =
     focusedDay ?? (lastFocused && navigation.isDateDisplayed(lastFocused))
@@ -106,14 +109,14 @@ export function FocusProvider(props: { children: ReactNode }): JSX.Element {
 
   const focusStartOfWeek = (): void => {
     if (!focusedDay) return;
-    const dayToFocus = startOfWeek(focusedDay);
+    const dayToFocus = startOfWeek(focusedDay, { weekStartsOn });
     navigation.goToDate(dayToFocus, focusedDay);
     focus(dayToFocus);
   };
 
   const focusEndOfWeek = (): void => {
     if (!focusedDay) return;
-    const dayToFocus = endOfWeek(focusedDay);
+    const dayToFocus = endOfWeek(focusedDay, { weekStartsOn });
     navigation.goToDate(dayToFocus, focusedDay);
     focus(dayToFocus);
   };

--- a/website/test-integration/examples/keyboard.test.tsx
+++ b/website/test-integration/examples/keyboard.test.tsx
@@ -240,3 +240,28 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
     });
   });
 });
+
+describe('when week is set to start on a Monday', () => {
+  const day = setDate(today, 10);
+  const startOfWeekDay = startOfWeek(day, { weekStartsOn: 1 });
+  const endOfWeekDay = endOfWeek(day, { weekStartsOn: 1 });
+
+  beforeEach(() => {
+    setup({ mode: 'single', weekStartsOn: 1 });
+  });
+
+  beforeEach(() => focusDay(day));
+
+  describe('when Home is pressed', () => {
+    beforeEach(pressHome);
+    it('should focus the start of the week being Monday', () => {
+      expect(getDayButton(startOfWeekDay)).toHaveFocus();
+    });
+  });
+  describe('when End is pressed', () => {
+    beforeEach(pressEnd);
+    it('should focus the end of the week being Sunday', () => {
+      expect(getDayButton(endOfWeekDay)).toHaveFocus();
+    });
+  });
+});


### PR DESCRIPTION
### Context

I thought I might as well give it a go myself with this issue:
https://github.com/gpbl/react-day-picker/issues/1491

I did this in the blind as I could not trigger a `develop` script in react-day-picker package. Maybe docs need some update?

### Analysis

Forgot to take user prop weekStartsOn into consideration when focusing start or end of week using home and end keys

### Solution

I used `weekStartsOn` from the dayPicker context and used it as second parameter in date-fns `startOfWeek` and `endOfWeek` 
