### PR TITLE
website: improve layout for the examples

### DIFF
--- a/react-day-picker.code-workspace
+++ b/react-day-picker.code-workspace
@@ -48,7 +48,14 @@
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "cSpell.enabled": true,
-    "cSpell.words": ["miércoles", "septiembre", "TOFIX", "vhidden"],
+    "cSpell.words": [
+      "codesandbox",
+      "miércoles",
+      "Sandpack",
+      "septiembre",
+      "TOFIX",
+      "vhidden"
+    ],
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
     "editor.formatOnType": true,

--- a/website/package.json
+++ b/website/package.json
@@ -28,7 +28,8 @@
     "react": "^17.0.2",
     "react-day-picker": "workspace:*",
     "react-dom": "^17.0.2",
-    "react-popper": "^2.3.0"
+    "react-popper": "^2.3.0",
+    "react-shadow": "^19.0.3"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^2.0.1",

--- a/website/src/components/RenderExample.tsx
+++ b/website/src/components/RenderExample.tsx
@@ -1,15 +1,34 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import React from 'react';
 
-/** Renders an example component from the examples directory.  */
-export function RenderExample(props: { fileName: string }) {
-  try {
-    require(`../../examples/${props.fileName}`).default;
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error('Error requiring %s', `../../examples/${props.fileName}`, e);
-    return <pre>{e.message}</pre>;
-  }
-  const Component = require(`../../examples/${props.fileName}`).default;
-  return <Component />;
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import root from 'react-shadow';
+
+export function RenderExample(props: {
+  name: string;
+  rootStyle?: React.CSSProperties;
+}) {
+  return (
+    <BrowserOnly>
+      {() => {
+        try {
+          require(`@site/examples/${props.name}`).default;
+        } catch (e) {
+          return <pre>{e.message}</pre>;
+        }
+        const Component = require(`@site/examples/${props.name}`).default;
+        const libStyle =
+          require(`!raw-loader!react-day-picker/dist/style.css`).default;
+        const style = require(`!raw-loader!./shadow-dom-styles.css`).default;
+
+        return (
+          <root.div style={props.rootStyle}>
+            <style type="text/css">{libStyle}</style>
+            <style type="text/css">{style}</style>
+            <Component />
+          </root.div>
+        );
+      }}
+    </BrowserOnly>
+  );
 }

--- a/website/src/components/shadow-dom-styles.css
+++ b/website/src/components/shadow-dom-styles.css
@@ -1,0 +1,14 @@
+.shadowRoot {
+  background-color: white;
+  overflow: auto;
+}
+
+html[data-theme='dark'] .shadowRoot {
+  color: white;
+}
+
+code {
+  font-size: small;
+  font-family: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
+}

--- a/website/src/custom.css
+++ b/website/src/custom.css
@@ -7,9 +7,8 @@
   --ifm-color-primary-light: #dc515e;
   --ifm-color-primary-lighter: #de5c68;
   --ifm-color-primary-lightest: #e57e88;
-  --ifm-font-family-monospace: 'SFMono', Menlo, Monaco, 'Fira Mono',
-    'DejaVu Sans Mono', Menlo, Consolas, 'Liberation Mono', Monaco,
-    'Lucida Console', monospace;
+  --ifm-font-family-monospace: 'Fira Mono', 'DejaVu Sans Mono', Menlo, Consolas,
+    'Liberation Mono', Monaco, 'Lucida Console', monospace;
   --ifm-transition-fast: 120ms;
   --ifm-code-border-radius: 4px;
   --ifm-toc-border-color: transparent;
@@ -17,6 +16,7 @@
   --ifm-navbar-shadow: none;
   --ifm-navbar-height: 75px;
   --ifm-global-radius: 1rem;
+  --ifm-code-font-size: 13px;
   --menu-background: var(--ifm-color-emphasis-100);
   --ifm-tabs-padding-vertical: 8px;
   --ifm-menu-color: inherit;
@@ -89,6 +89,12 @@ body {
 [class*='codeBlockLines'] {
   background-color: var(--menu-background) !important;
 }
+
+div[class*='codeBlockContainer'] {
+  box-shadow: none;
+  -webkit-font-smoothing: subpixel-antialiased;
+}
+
 .docusaurus-highlight-code-line {
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));
@@ -160,12 +166,9 @@ html[data-theme='dark'] .dialog-sheet {
 
 /* #region: sandpack styles */
 .sp-wrapper {
-  box-shadow: 0px 0.8px 2px rgba(0, 0, 0, 0.032),
-    0px 2.7px 6.7px rgba(0, 0, 0, 0.048), 0px 12px 30px rgba(0, 0, 0, 0.08) !important;
   border-radius: var(--ifm-global-radius) !important;
 }
 .sp-layout {
-  --sp-border-radius: var(--ifm-global-radius);
   margin-bottom: var(--ifm-leading);
   border: 0 !important;
 }
@@ -188,55 +191,8 @@ html[data-theme='dark'] .dialog-sheet {
 .sp-preview-container,
 .sp-loading {
   background-color: var(--menu-background) !important;
-  /* box-shadow: 0px 0.8px 2px rgba(0,0,0,0.032),0px 12px 30px rgba(0,0,0,0.08) !important; */
-  /* border-radius: var(--ifm-global-radius); */
 }
 
-/* #endregion */
-
-/* #region: rdp */
-.rdp {
-  margin: 1rem;
-}
-.rdp table .rdp-tfoot td {
-  padding-top: 1rem;
-}
-
-.rdp-tfoot form {
-  text-align: center;
-}
-
-.rdp-tfoot button {
-  border-style: solid;
-  border-width: 1px;
-  border-radius: 8px;
-  display: inline-block;
-  font-size: 0.875em;
-  padding: 0.3rem 0.8rem;
-  text-align: center;
-  user-select: none;
-  vertical-align: baseline;
-  white-space: nowrap;
-}
-
-.rdp table thead tr {
-  /* remove docusaurus styling */
-  all: revert;
-}
-.rdp table td {
-  /* remove docusaurus styling */
-  all: revert;
-}
-.rdp-tfoot button:not(:disabled) {
-  cursor: pointer;
-  background-color: var(--ifm-color-secondary-light);
-  border-color: var(--ifm-color-secondary-darkest);
-}
-
-.rdp-tfoot button:disabled {
-  background-color: var(--ifm-color-secondary-lighter);
-  border-color: var(--ifm-color-secondary-light);
-}
 /* #endregion */
 
 /* #region: markdown docs  */
@@ -259,76 +215,6 @@ html[data-theme='dark'] .dialog-sheet {
   height: 1px;
   border: none;
   background-color: var(--ifm-color-emphasis-200);
-}
-
-/* #endregion */
-
-/* #region markdown api */
-
-[id^='defined-in'],
-[id^='inherited-from'] {
-  display: inline-block;
-  margin-top: 0 !important;
-  margin-bottom: 0 !important;
-}
-[id^='defined-in'],
-[id^='defined-in'] + *,
-[id^='inherited-from'],
-[id^='inherited-from'] + * {
-  font-size: small;
-  margin-bottom: 0.5em !important;
-}
-[id^='defined-in'] + * {
-  margin-bottom: 2em !important;
-}
-
-#hierarchy {
-  font-size: 1rem;
-}
-
-#hierarchy + ul {
-  /* list-style: none; */
-}
-
-#hierarchy + ul p {
-  margin: 0;
-}
-
-#hierarchy + ul code {
-  background-color: transparent;
-}
-
-#properties,
-#methods {
-  padding-bottom: 0.5em;
-}
-
-#properties ~ h3,
-#methods ~ h3 {
-  display: inline-block;
-  padding-bottom: 0.5em;
-}
-
-#properties ~ hr,
-#methods ~ hr,
-#hierarchy ~ hr {
-  display: none;
-}
-
-#properties ~ h3 + p,
-#methods ~ h3 + p,
-#hierarchy ~ h3 + p {
-  font-family: var(--ifm-font-family-monospace);
-}
-
-#properties ~ h3 + p code,
-#methods ~ h3 + p code,
-#hierarchy ~ h3 + p code {
-  --ifm-code-font-size: inherits;
-  opacity: 0.9;
-  border: 0;
-  font-family: var(--ifm-font-family-monospace);
-  background-color: transparent;
 }
 
 /* #endregion */

--- a/website/src/pages/render.tsx
+++ b/website/src/pages/render.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import React from 'react';
-import { useLocation } from 'react-router-dom';
 
 import BrowserOnly from '@docusaurus/BrowserOnly';
+import { useLocation } from '@docusaurus/router';
+
+import { RenderExample } from '../components/RenderExample';
 
 /**
  * Create a page at `/render` URL that renders the examples from the examples
@@ -13,19 +15,12 @@ export default function Render(): JSX.Element {
   return (
     <BrowserOnly>
       {() => {
-        const fileName = new URLSearchParams(location.search).get('example');
-        try {
-          require(`../../examples/${fileName}`).default;
-        } catch (e) {
-          // eslint-disable-next-line no-console
-          console.error('Error requiring %s', `../../examples/${fileName}`, e);
-          return <pre>{e.message}</pre>;
-        }
-        const Component = require(`../../examples/${fileName}`).default;
+        const name = new URLSearchParams(location.search).get('example');
         return (
-          <main>
-            <Component />
-          </main>
+          <RenderExample
+            rootStyle={{ padding: 0, borderRadius: 0, minHeight: '100vh' }}
+            name={name}
+          />
         );
       }}
     </BrowserOnly>

--- a/website/src/theme/CodeBlock/CodeBlock.module.css
+++ b/website/src/theme/CodeBlock/CodeBlock.module.css
@@ -4,13 +4,14 @@
   margin-top: -1em;
 }
 
-.nav {
+/* Toolbar */
+.toolbar {
   padding: 0.5em 0;
   font-size: small;
   text-align: right;
 }
 
-.nav button {
+.toolbar button {
   box-sizing: border-box;
   appearance: none;
   position: relative;
@@ -30,11 +31,11 @@
 
   color: var(--ifm-link-hover-color);
 }
-.nav button:hover {
+.toolbar button:hover {
   text-decoration: var(--ifm-link-hover-decoration);
 }
-.nav button:disabled,
-.nav button[aria-disabled='true'] {
+.toolbar button:disabled,
+.toolbar button[aria-disabled='true'] {
   cursor: default;
   pointer-events: none;
 }

--- a/website/src/theme/CodeBlock/CodeBlock.module.css
+++ b/website/src/theme/CodeBlock/CodeBlock.module.css
@@ -1,0 +1,57 @@
+.root {
+  margin: 2.5rem 0;
+  position: relative;
+  margin-top: -1em;
+}
+
+.nav {
+  padding: 0.5em 0;
+  font-size: small;
+  text-align: right;
+}
+
+.nav button {
+  box-sizing: border-box;
+  appearance: none;
+  position: relative;
+  margin: 0;
+  padding: 0;
+  border: none;
+  cursor: pointer;
+  background: none;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  display: inline-block;
+  color: inherit;
+
+  -moz-appearance: none;
+  -webkit-appearance: none;
+
+  color: var(--ifm-link-hover-color);
+}
+.nav button:hover {
+  text-decoration: var(--ifm-link-hover-decoration);
+}
+.nav button:disabled,
+.nav button[aria-disabled='true'] {
+  cursor: default;
+  pointer-events: none;
+}
+
+.container {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.container > div:first-child {
+  flex-grow: 50;
+  flex-shrink: 50;
+  min-width: 350px;
+}
+
+.container > div:last-child {
+  flex-grow: 50;
+  flex-shrink: 50;
+  min-height: 400px;
+}

--- a/website/src/theme/CodeBlock/index.tsx
+++ b/website/src/theme/CodeBlock/index.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import React from 'react';
 
-import { useHistory } from '@docusaurus/router';
 import { RenderExample } from '@site/src/components/RenderExample';
 import CodeBlock from '@theme-original/CodeBlock';
 
@@ -24,7 +23,6 @@ export default function CodeBlockWithSandpack(props: {
   toolbar: 'true' | 'false';
 }) {
   const [edit, toggleEdit] = React.useState(props.show === 'editor');
-  const history = useHistory();
   if (props.className !== 'language-include-example') {
     return (
       <CodeBlock

--- a/website/src/theme/CodeBlock/index.tsx
+++ b/website/src/theme/CodeBlock/index.tsx
@@ -50,7 +50,7 @@ export default function CodeBlockWithSandpack(props: {
   return (
     <div className={styles.root}>
       {props['toolbar'] !== 'false' && (
-        <div className={styles.nav}>
+        <div className={styles.toolbar}>
           <button onClick={() => toggleEdit(!edit)}>
             {edit ? 'Toggle Preview' : 'Toggle Editor'}
           </button>

--- a/website/src/theme/CodeBlock/index.tsx
+++ b/website/src/theme/CodeBlock/index.tsx
@@ -1,30 +1,45 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 import React from 'react';
 
+import { useHistory } from '@docusaurus/router';
+import { RenderExample } from '@site/src/components/RenderExample';
 import CodeBlock from '@theme-original/CodeBlock';
 
+import styles from './CodeBlock.module.css';
 import { CustomSandPack } from './CustomSandpack';
 
 /**
  * This "swizzled" docusaurus component will display a Sandpack using the example filename.
+ *
  * See https://docusaurus.io/docs/swizzling for info about swizzling components.
  * */
 export default function CodeBlockWithSandpack(props: {
   children: string;
   className: string;
-  dependencies: string;
+  title?: string;
+  dependencies?: string;
+  /** Toggle between editor or preview in the codeblock example. */
+  show?: 'editor' | 'preview';
+  /** Show the toolbar with the toggle links. Defaults to 'true'. */
+  toolbar: 'true' | 'false';
 }) {
+  const [edit, toggleEdit] = React.useState(props.show === 'editor');
+  const history = useHistory();
   if (props.className !== 'language-include-example') {
     return (
-      <CodeBlock className="language-jsx" {...props}>
+      <CodeBlock
+        metastring={undefined}
+        title={props.title}
+        language="jsx"
+        {...props}
+      >
         {props.children}
       </CodeBlock>
     );
   }
   const fileName = props.children.replace(/\n*/gi, '');
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const src = require(`!!raw-loader!../../../examples/${fileName}`)
+  const src = require(`!!raw-loader!@site/examples/${fileName}`)
     .default as string;
-
   const dependencies: Record<string, string> = props.dependencies
     ?.split(',')
     .reduce(
@@ -32,5 +47,41 @@ export default function CodeBlockWithSandpack(props: {
       {}
     );
 
-  return <CustomSandPack dependencies={dependencies} src={src} />;
+  return (
+    <div className={styles.root}>
+      {props['toolbar'] !== 'false' && (
+        <div className={styles.nav}>
+          <button onClick={() => toggleEdit(!edit)}>
+            {edit ? 'Toggle Preview' : 'Toggle Editor'}
+          </button>
+          {' | '}
+          <button
+            title="Open the rendered example in a new window."
+            onClick={() => {
+              const win = window.open(`/render?example=${fileName}`, '_blank');
+              win.focus();
+            }}
+          >
+            New Window ↗
+          </button>
+        </div>
+      )}
+      {!edit && (
+        <div className={styles.container}>
+          <CodeBlock
+            metastring={undefined}
+            title={props.title}
+            language="jsx"
+            {...props}
+          >
+            {src}
+          </CodeBlock>
+          <div>
+            <RenderExample name={fileName} />
+          </div>
+        </div>
+      )}
+      {edit && <CustomSandPack dependencies={dependencies} src={src} />}
+    </div>
+  );
 }

--- a/website/src/theme/CodeBlock/sandpack-app/index.html
+++ b/website/src/theme/CodeBlock/sandpack-app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>react-day-picker example</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/website/src/theme/CodeBlock/sandpack-app/index.tsx
+++ b/website/src/theme/CodeBlock/sandpack-app/index.tsx
@@ -2,12 +2,12 @@ import React, { StrictMode } from 'react';
 
 /** Root file used by the Sandpack */
 import 'react-day-picker/dist/style.css';
-import ReactDOM from 'react-dom';
+import { render } from 'react-dom';
 
 import App from './App';
 import './styles.css';
 
-ReactDOM.render(
+render(
   <StrictMode>
     <App />
   </StrictMode>,

--- a/website/src/theme/CodeBlock/sandpack-app/styles.css
+++ b/website/src/theme/CodeBlock/sandpack-app/styles.css
@@ -1,1 +1,0 @@
-/* Placeholder file. Will be replaced by mini.css */

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -7,7 +7,8 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "paths": {
-      "@examples/*": ["./examples/*"]
+      "@examples/*": ["./examples/*"],
+      "@site/*": ["./*"]
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5083,6 +5083,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/js-cookie@npm:2.2.6":
+  version: 2.2.6
+  resolution: "@types/js-cookie@npm:2.2.6"
+  checksum: 97c50ff6cd0a27409b028aad94b0c4eb5cc43623532a1bdbbcccdb200539593eff3cc7f0d874b6b9bee586167638e3a10093c811ff6603ff2a9639564c82b3b1
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:*, @types/json-schema@npm:^7.0.4, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.9
   resolution: "@types/json-schema@npm:7.0.9"
@@ -5790,6 +5797,13 @@ __metadata:
     "@webassemblyjs/ast": 1.11.1
     "@xtuc/long": 4.2.2
   checksum: f15ae4c2441b979a3b4fce78f3d83472fb22350c6dc3fd34bfe7c3da108e0b2360718734d961bba20e7716cb8578e964b870da55b035e209e50ec9db0378a3f7
+  languageName: node
+  linkType: hard
+
+"@xobotyi/scrollbar-width@npm:1.9.5":
+  version: 1.9.5
+  resolution: "@xobotyi/scrollbar-width@npm:1.9.5"
+  checksum: e880c8696bd6c7eedaad4e89cc7bcfcd502c22dc6c061288ffa7f5a4fe5dab4aa2358bdd68e7357bf0334dc8b56724ed9bee05e010b60d83a3bb0d855f3d886f
   languageName: node
   linkType: hard
 
@@ -7411,6 +7425,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"copy-to-clipboard@npm:^3.2.0":
+  version: 3.3.2
+  resolution: "copy-to-clipboard@npm:3.3.2"
+  dependencies:
+    toggle-selection: ^1.0.6
+  checksum: 968ec7ec3d0cf3067542b63dd244ba5d05e743899d7a0361fb0a3130e731d277f5ea54ea4d90fc88cc66eea2e4c67dc2dd8698e4ed360f921af5aa7c60b889ac
+  languageName: node
+  linkType: hard
+
 "copy-webpack-plugin@npm:^11.0.0":
   version: 11.0.0
   resolution: "copy-webpack-plugin@npm:11.0.0"
@@ -7550,6 +7573,16 @@ __metadata:
   peerDependencies:
     postcss: ^8.0.9
   checksum: 69ce1c2e0e854c043dccbb613f15e2911e2e12dd656d18cdae831baa6a6a8f9ef0d6560c456e3b41d28835e5e013bfdf9114eeba206564b1513ea968a3633c1f
+  languageName: node
+  linkType: hard
+
+"css-in-js-utils@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "css-in-js-utils@npm:2.0.1"
+  dependencies:
+    hyphenate-style-name: ^1.0.2
+    isobject: ^3.0.1
+  checksum: c9964c4708216954c468b69bbee2d971fd759ada4f40637b8ca4d3f79caba4818d0532a4f190ac560227c08742ad063ffec7a30afddc4d96b66a18c3a008f0d8
   languageName: node
   linkType: hard
 
@@ -7862,6 +7895,13 @@ __metadata:
   version: 3.0.10
   resolution: "csstype@npm:3.0.10"
   checksum: 20a8fa324f2b33ddf94aa7507d1b6ab3daa6f3cc308888dc50126585d7952f2471de69b2dbe0635d1fdc31223fef8e070842691877e725caf456e2378685a631
+  languageName: node
+  linkType: hard
+
+"csstype@npm:^3.0.6":
+  version: 3.1.0
+  resolution: "csstype@npm:3.1.0"
+  checksum: 644e986cefab86525f0b674a06889cfdbb1f117e5b7d1ce0fc55b0423ecc58807a1ea42ecc75c4f18999d14fc42d1d255f84662a45003a52bb5840e977eb2ffd
   languageName: node
   linkType: hard
 
@@ -8496,6 +8536,15 @@ __metadata:
   dependencies:
     is-arrayish: ^0.2.1
   checksum: c1c2b8b65f9c91b0f9d75f0debaa7ec5b35c266c2cac5de412c1a6de86d4cbae04ae44e510378cb14d032d0645a36925d0186f8bb7367bcc629db256b743a001
+  languageName: node
+  linkType: hard
+
+"error-stack-parser@npm:^2.0.6":
+  version: 2.1.4
+  resolution: "error-stack-parser@npm:2.1.4"
+  dependencies:
+    stackframe: ^1.3.4
+  checksum: 3b916d2d14c6682f287c8bfa28e14672f47eafe832701080e420e7cdbaebb2c50293868256a95706ac2330fe078cf5664713158b49bc30d7a5f2ac229ded0e18
   languageName: node
   linkType: hard
 
@@ -9146,12 +9195,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-shallow-equal@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "fast-shallow-equal@npm:1.0.0"
+  checksum: ae89318ce43c0c46410d9511ac31520d59cfe675bad3d0b1cb5f900b2d635943d788b8370437178e91ae0d0412decc394229c03e69925ade929a8c02da241610
+  languageName: node
+  linkType: hard
+
 "fast-url-parser@npm:1.1.3":
   version: 1.1.3
   resolution: "fast-url-parser@npm:1.1.3"
   dependencies:
     punycode: ^1.3.2
   checksum: 5043d0c4a8d775ff58504d56c096563c11b113e4cb8a2668c6f824a1cd4fb3812e2fdf76537eb24a7ce4ae7def6bd9747da630c617cf2a4b6ce0c42514e4f21c
+  languageName: node
+  linkType: hard
+
+"fastest-stable-stringify@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "fastest-stable-stringify@npm:2.0.2"
+  checksum: 5e2cb166c7bb6f16ac25a1e4be17f6b8d2923234c80739e12c9d21dea376b3128b2c63f90aa2aae7746cfec4dcf188d1d4eb6a964bb484ca133f17c8e9acfacc
   languageName: node
   linkType: hard
 
@@ -10313,6 +10376,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"humps@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "humps@npm:2.0.1"
+  checksum: 7d5a674cfca2f34c04562f6fd0d129b4c43a5caf85fcc1c9eacf5d0729554c9375db362c4232519b37369c94dd2560d85f96ad4091a8fbf4af4e625ab5214a30
+  languageName: node
+  linkType: hard
+
+"hyphenate-style-name@npm:^1.0.2":
+  version: 1.0.4
+  resolution: "hyphenate-style-name@npm:1.0.4"
+  checksum: 4f5bf4b055089754924babebaa23c17845937bcca6aee95d5d015f8fa1e6814279002bd6a9e541e3fac2cd02519fc76305396727066c57c8e21a7e73e7a12137
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:0.4.24":
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
@@ -10480,6 +10557,15 @@ __metadata:
   version: 0.1.1
   resolution: "inline-style-parser@npm:0.1.1"
   checksum: 5d545056a3e1f2bf864c928a886a0e1656a3517127d36917b973de581bd54adc91b4bf1febcb0da054f204b4934763f1a4e09308b4d55002327cf1d48ac5d966
+  languageName: node
+  linkType: hard
+
+"inline-style-prefixer@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "inline-style-prefixer@npm:6.0.1"
+  dependencies:
+    css-in-js-utils: ^2.0.0
+  checksum: 0bfa6fa89faa21e425c71425910c37c7b35a16ea753586c408fcc9246c84937c1b8184e6ce792139cda5de5cce8e1bc9eb0ba9f30968bdc97e7a06ece21c0737
   languageName: node
   linkType: hard
 
@@ -11582,6 +11668,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-cookie@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "js-cookie@npm:2.2.1"
+  checksum: 9b1fb980a1c5e624fd4b28ea4867bb30c71e04c4484bb3a42766344c533faa684de9498e443425479ec68609e96e27b60614bfe354877c449c631529b6d932f2
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -12501,6 +12594,25 @@ __metadata:
   version: 2.1.9
   resolution: "mylas@npm:2.1.9"
   checksum: 5339f9009bc931c7f5a22991e4965839c503a29d4b2e2159af23119d09724188ac704e3bb0d53bb8a161e106c3d19d8bcd78bae727b287cbe07bd269254f4eb9
+  languageName: node
+  linkType: hard
+
+"nano-css@npm:^5.2.1":
+  version: 5.3.5
+  resolution: "nano-css@npm:5.3.5"
+  dependencies:
+    css-tree: ^1.1.2
+    csstype: ^3.0.6
+    fastest-stable-stringify: ^2.0.2
+    inline-style-prefixer: ^6.0.0
+    rtl-css-js: ^1.14.0
+    sourcemap-codec: ^1.4.8
+    stacktrace-js: ^2.0.2
+    stylis: ^4.0.6
+  peerDependencies:
+    react: "*"
+    react-dom: "*"
+  checksum: 8d4e59a2a29477221af47320d850a7dcee1ac51774fb5a0dce6ee59b22174c7149f75108235de85559581fbb2b93aa222a2b32ea53c93ba3f5d322c4d098c355
   languageName: node
   linkType: hard
 
@@ -14384,6 +14496,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-shadow@npm:^19.0.3":
+  version: 19.0.3
+  resolution: "react-shadow@npm:19.0.3"
+  dependencies:
+    humps: ^2.0.1
+    react-use: ^15.3.3
+  peerDependencies:
+    prop-types: ^15.0.0
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.0.0 || ^17.0.0
+  checksum: eb789ac10a85bf872406493189916a60aacec07a4eaaaf5b15d7fc8f7de3bfb9b1531f17dd899c6270700b6e964c828355798bc06e688c71a372272cbd8a5729
+  languageName: node
+  linkType: hard
+
 "react-textarea-autosize@npm:^8.3.2":
   version: 8.3.3
   resolution: "react-textarea-autosize@npm:8.3.3"
@@ -14394,6 +14520,41 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
   checksum: da3d0192825df3d9f27eef33e7eddf928359a7e3e2b01ae7f7f672ecf4e5c1f7a34f27bdde9ccc24e2e9fbe1d1b9dd2a39c7d47323c9bdf63e7b9bd05c325a71
+  languageName: node
+  linkType: hard
+
+"react-universal-interface@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "react-universal-interface@npm:0.6.2"
+  peerDependencies:
+    react: "*"
+    tslib: "*"
+  checksum: 070a7e9e3cdd8b0ec91a2ac9ac0a8df6bcb3fd183d2775bf0f439b9870fc1faf5b4fa9fe9741abd5187f0a35be645cb4004e1c9ebda9ada7e5d0a624f94910cb
+  languageName: node
+  linkType: hard
+
+"react-use@npm:^15.3.3":
+  version: 15.3.8
+  resolution: "react-use@npm:15.3.8"
+  dependencies:
+    "@types/js-cookie": 2.2.6
+    "@xobotyi/scrollbar-width": 1.9.5
+    copy-to-clipboard: ^3.2.0
+    fast-deep-equal: ^3.1.3
+    fast-shallow-equal: ^1.0.0
+    js-cookie: ^2.2.1
+    nano-css: ^5.2.1
+    react-universal-interface: ^0.6.2
+    resize-observer-polyfill: ^1.5.1
+    screenfull: ^5.0.0
+    set-harmonic-interval: ^1.0.1
+    throttle-debounce: ^2.1.0
+    ts-easing: ^0.2.0
+    tslib: ^2.0.0
+  peerDependencies:
+    react: ^16.8.0  || ^17.0.0
+    react-dom: ^16.8.0  || ^17.0.0
+  checksum: 732a21f7c2295556d9cd501188644b9191f85370b5dc6347277e06c52dfe2ecf376c869056084ee7c7d4e57b8c5f723a3f00ee818f6cf59409b93cf704dbef33
   languageName: node
   linkType: hard
 
@@ -14718,6 +14879,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resize-observer-polyfill@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "resize-observer-polyfill@npm:1.5.1"
+  checksum: 57e7f79489867b00ba43c9c051524a5c8f162a61d5547e99333549afc23e15c44fd43f2f318ea0261ea98c0eb3158cca261e6f48d66e1ed1cd1f340a43977094
+  languageName: node
+  linkType: hard
+
 "resolve-cwd@npm:^3.0.0":
   version: 3.0.0
   resolution: "resolve-cwd@npm:3.0.0"
@@ -14898,6 +15066,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rtl-css-js@npm:^1.14.0":
+  version: 1.16.0
+  resolution: "rtl-css-js@npm:1.16.0"
+  dependencies:
+    "@babel/runtime": ^7.1.2
+  checksum: 51756329f691cacd3e1b48f0f9d04a69338a90013f2d2942ca1ae3b069c952f70055f5fd76c66921e9a5cb956276252376a847c3294bd0ee54be9ceb32ea868c
+  languageName: node
+  linkType: hard
+
 "rtl-detect@npm:^1.0.4":
   version: 1.0.4
   resolution: "rtl-detect@npm:1.0.4"
@@ -15026,6 +15203,13 @@ __metadata:
     ajv-formats: ^2.1.1
     ajv-keywords: ^5.0.0
   checksum: c843e92fdd1a5c145dbb6ffdae33e501867f9703afac67bdf35a685e49f85b1dcc10ea250033175a64bd9d31f0555bc6785b8359da0c90bcea30cf6dfbb55a8f
+  languageName: node
+  linkType: hard
+
+"screenfull@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "screenfull@npm:5.2.0"
+  checksum: 21eae33b780eb4679ea0ea2d14734b11168cf35049c45a2bf24ddeb39c67a788e7a8fb46d8b61ca6d8367fd67ce9dd4fc8bfe476489249c7189c2a79cf83f51a
   languageName: node
   linkType: hard
 
@@ -15199,6 +15383,13 @@ __metadata:
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
   checksum: 6e65a05f7cf7ebdf8b7c75b101e18c0b7e3dff4940d480efed8aad3a36a4005140b660fa1d804cb8bce911cac290441dc728084a30504d3516ac2ff7ad607b02
+  languageName: node
+  linkType: hard
+
+"set-harmonic-interval@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "set-harmonic-interval@npm:1.0.1"
+  checksum: c122b831c2e0b1fb812e5e9d065094b9d174bd0576f9a779ab7a7d8881c8f6dd7d5fcab9a2553da15eea670eb598f9dd4d5162b626d45cc9c529706aa1444a84
   languageName: node
   linkType: hard
 
@@ -15423,6 +15614,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map@npm:0.5.6":
+  version: 0.5.6
+  resolution: "source-map@npm:0.5.6"
+  checksum: 390b3f5165c9631a74fb6fb55ba61e62a7f9b7d4026ae0e2bfc2899c241d71c1bccb8731c496dc7f7cb79a5f523406eb03d8c5bebe8448ee3fc38168e2d209c8
+  languageName: node
+  linkType: hard
+
 "source-map@npm:^0.5.0, source-map@npm:^0.5.6":
   version: 0.5.7
   resolution: "source-map@npm:0.5.7"
@@ -15451,7 +15649,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sourcemap-codec@npm:^1.4.4":
+"sourcemap-codec@npm:^1.4.4, sourcemap-codec@npm:^1.4.8":
   version: 1.4.8
   resolution: "sourcemap-codec@npm:1.4.8"
   checksum: b57981c05611afef31605732b598ccf65124a9fcb03b833532659ac4d29ac0f7bfacbc0d6c5a28a03e84c7510e7e556d758d0bb57786e214660016fb94279316
@@ -15515,12 +15713,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stack-generator@npm:^2.0.5":
+  version: 2.0.10
+  resolution: "stack-generator@npm:2.0.10"
+  dependencies:
+    stackframe: ^1.3.4
+  checksum: 4fc3978a934424218a0aa9f398034e1f78153d5ff4f4ff9c62478c672debb47dd58de05b09fc3900530cbb526d72c93a6e6c9353bacc698e3b1c00ca3dda0c47
+  languageName: node
+  linkType: hard
+
 "stack-utils@npm:^2.0.3":
   version: 2.0.5
   resolution: "stack-utils@npm:2.0.5"
   dependencies:
     escape-string-regexp: ^2.0.0
   checksum: 76b69da0f5b48a34a0f93c98ee2a96544d2c4ca2557f7eef5ddb961d3bdc33870b46f498a84a7c4f4ffb781df639840e7ebf6639164ed4da5e1aeb659615b9c7
+  languageName: node
+  linkType: hard
+
+"stackframe@npm:^1.3.4":
+  version: 1.3.4
+  resolution: "stackframe@npm:1.3.4"
+  checksum: bae1596873595c4610993fa84f86a3387d67586401c1816ea048c0196800c0646c4d2da98c2ee80557fd9eff05877efe33b91ba6cd052658ed96ddc85d19067d
+  languageName: node
+  linkType: hard
+
+"stacktrace-gps@npm:^3.0.4":
+  version: 3.1.2
+  resolution: "stacktrace-gps@npm:3.1.2"
+  dependencies:
+    source-map: 0.5.6
+    stackframe: ^1.3.4
+  checksum: 85daa232d138239b6ae0f4bcdd87d15d302a045d93625db17614030945b5314e204b5fbcf9bee5b6f4f9e6af5fca05f65c27fe910894b861ef6853b99470aa1c
+  languageName: node
+  linkType: hard
+
+"stacktrace-js@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "stacktrace-js@npm:2.0.2"
+  dependencies:
+    error-stack-parser: ^2.0.6
+    stack-generator: ^2.0.5
+    stacktrace-gps: ^3.0.4
+  checksum: 081e786d56188ac04ac6604c09cd863b3ca2b4300ec061366cf68c3e4ad9edaa34fb40deea03cc23a05f442aa341e9171f47313f19bd588f9bec6c505a396286
   languageName: node
   linkType: hard
 
@@ -15736,6 +15971,13 @@ __metadata:
   peerDependencies:
     postcss: ^8.2.15
   checksum: 310b3452c11fd443b0d327aa2d5b43ae7479407339204b7ad11cf2e16d33b690c1cbf47a21b737ef112411e53563f0f996c5fa3642d135c896329950a008277f
+  languageName: node
+  linkType: hard
+
+"stylis@npm:^4.0.6":
+  version: 4.1.1
+  resolution: "stylis@npm:4.1.1"
+  checksum: e9b0a086996a94c44d45933287731313f6ecdbf9334410231d882d31a1890fb36e34a7b163487e2d7f992c2044e4cb37179810fc6f758f359a431343c2374ed2
   languageName: node
   linkType: hard
 
@@ -15979,6 +16221,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"throttle-debounce@npm:^2.1.0":
+  version: 2.3.0
+  resolution: "throttle-debounce@npm:2.3.0"
+  checksum: 6d90aa2ddb294f8dad13d854a1cfcd88fdb757469669a096a7da10f515ee466857ac1e750649cb9da931165c6f36feb448318e7cb92570f0a3679d20e860a925
+  languageName: node
+  linkType: hard
+
 "thunky@npm:^1.0.2":
   version: 1.1.0
   resolution: "thunky@npm:1.1.0"
@@ -16047,6 +16296,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"toggle-selection@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "toggle-selection@npm:1.0.6"
+  checksum: a90dc80ed1e7b18db8f4e16e86a5574f87632dc729cfc07d9ea3ced50021ad42bb4e08f22c0913e0b98e3837b0b717e0a51613c65f30418e21eb99da6556a74c
+  languageName: node
+  linkType: hard
+
 "toidentifier@npm:1.0.1":
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
@@ -16106,6 +16362,13 @@ __metadata:
   version: 1.0.5
   resolution: "trough@npm:1.0.5"
   checksum: d6c8564903ed00e5258bab92134b020724dbbe83148dc72e4bf6306c03ed8843efa1bcc773fa62410dd89161ecb067432dd5916501793508a9506cacbc408e25
+  languageName: node
+  linkType: hard
+
+"ts-easing@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "ts-easing@npm:0.2.0"
+  checksum: e67ee862acca3b2e2718e736f31999adcef862d0df76d76a0e138588728d8a87dfec9978556044640bd0e90203590ad88ac2fe8746d0e9959b8d399132315150
   languageName: node
   linkType: hard
 
@@ -16215,17 +16478,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.0.0, tslib@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "tslib@npm:2.4.0"
+  checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^2.0.3, tslib@npm:^2.1.0":
   version: 2.3.1
   resolution: "tslib@npm:2.3.1"
   checksum: de17a98d4614481f7fcb5cd53ffc1aaf8654313be0291e1bfaee4b4bb31a20494b7d218ff2e15017883e8ea9626599b3b0e0229c18383ba9dce89da2adf15cb9
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "tslib@npm:2.4.0"
-  checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
   languageName: node
   linkType: hard
 
@@ -17147,6 +17410,7 @@ __metadata:
     react-day-picker: "workspace:*"
     react-dom: ^17.0.2
     react-popper: ^2.3.0
+    react-shadow: ^19.0.3
     ts-jest: ^27.1.4
     typedoc: ^0.23.10
     typedoc-plugin-markdown: ^3.13.4


### PR DESCRIPTION
To better develop react-day-picker, I am changing website so that the examples are rendered in a shadow-dom instead of the sandpack app.