### PR TITLE
fix: page keys not working when using setMonth

### DIFF
--- a/packages/react-day-picker/src/components/CaptionDropdowns/CaptionDropdowns.tsx
+++ b/packages/react-day-picker/src/components/CaptionDropdowns/CaptionDropdowns.tsx
@@ -12,12 +12,11 @@ import { MonthChangeEventHandler } from 'types/EventHandlers';
  * Render a caption with the dropdowns to navigate between months and years.
  */
 export function CaptionDropdowns(props: CaptionProps): JSX.Element {
-  const { classNames, styles, onMonthChange, components } = useDayPicker();
+  const { classNames, styles, components } = useDayPicker();
   const { goToMonth } = useNavigation();
 
   const handleMonthChange: MonthChangeEventHandler = (newMonth) => {
     goToMonth(newMonth);
-    onMonthChange?.(newMonth);
   };
   const CaptionLabelComponent = components?.CaptionLabel ?? CaptionLabel;
   const captionLabel = (

--- a/packages/react-day-picker/src/components/CaptionNavigation/CaptionNavigation.tsx
+++ b/packages/react-day-picker/src/components/CaptionNavigation/CaptionNavigation.tsx
@@ -12,7 +12,7 @@ import { useNavigation } from 'contexts/Navigation';
  * Render a caption with a button-based navigation.
  */
 export function CaptionNavigation(props: CaptionProps): JSX.Element {
-  const { numberOfMonths, onMonthChange, dir, components } = useDayPicker();
+  const { numberOfMonths, dir, components } = useDayPicker();
   const { previousMonth, nextMonth, goToMonth, displayMonths } =
     useNavigation();
 
@@ -32,13 +32,11 @@ export function CaptionNavigation(props: CaptionProps): JSX.Element {
   const handlePreviousClick: React.MouseEventHandler = () => {
     if (!previousMonth) return;
     goToMonth(previousMonth);
-    onMonthChange?.(previousMonth);
   };
 
   const handleNextClick: React.MouseEventHandler = () => {
     if (!nextMonth) return;
     goToMonth(nextMonth);
-    onMonthChange?.(nextMonth);
   };
 
   const CaptionLabelComponent = components?.CaptionLabel ?? CaptionLabel;

--- a/packages/react-day-picker/src/contexts/Navigation/useNavigation.test.ts
+++ b/packages/react-day-picker/src/contexts/Navigation/useNavigation.test.ts
@@ -57,11 +57,15 @@ describe('when rendered', () => {
   });
   describe('when goToDate is called with a date from another month', () => {
     const newDate = addMonths(today, 10);
+    const onMonthChange = jest.fn();
     beforeEach(() => {
+      setup({ onMonthChange });
       result.current.goToDate(newDate);
     });
     test('should go to the specified month', () => {
-      expect(result.current.currentMonth).toEqual(startOfMonth(newDate));
+      const date = startOfMonth(newDate);
+      expect(result.current.currentMonth).toEqual(date);
+      expect(onMonthChange).toBeCalledWith(date);
     });
   });
   describe('when isDateDisplayed is called', () => {

--- a/packages/react-day-picker/src/contexts/Navigation/useNavigationState.test.ts
+++ b/packages/react-day-picker/src/contexts/Navigation/useNavigationState.test.ts
@@ -20,17 +20,21 @@ function setup(dayPickerProps?: DayPickerBase) {
 
 describe('when goToMonth is called', () => {
   test('should set the month in state', () => {
-    const result = setup();
+    const onMonthChange = jest.fn();
+    const result = setup({ onMonthChange });
     const month = addMonths(today, 2);
     result.current[1](month);
     expect(result.current[0]).toEqual(startOfMonth(month));
+    expect(onMonthChange).toBeCalledWith(startOfMonth(month));
   });
   describe('when navigation is disabled', () => {
     test('should not set the month in state', () => {
-      const result = setup({ disableNavigation: true });
+      const onMonthChange = jest.fn();
+      const result = setup({ disableNavigation: true, onMonthChange });
       const month = addMonths(today, 2);
       result.current[1](month);
       expect(result.current[0]).toEqual(startOfMonth(today));
+      expect(onMonthChange).not.toBeCalled();
     });
   });
 });

--- a/packages/react-day-picker/src/contexts/Navigation/useNavigationState.ts
+++ b/packages/react-day-picker/src/contexts/Navigation/useNavigationState.ts
@@ -18,7 +18,9 @@ export function useNavigationState(): [
 
   const goToMonth = (date: Date) => {
     if (context.disableNavigation) return;
-    setMonth(startOfMonth(date));
+    const month = startOfMonth(date);
+    setMonth(month);
+    context.onMonthChange?.(month);
   };
 
   return [month, goToMonth];


### PR DESCRIPTION
### Context

Fixes #1496 

### Analysis

react-day-picker should call `onMonthChange` every time when `goToMonth` is called. However, in `goToDate` in `NavigationContext`, `onMonthChange` is not called and this is the cause of #1496.

https://github.com/gpbl/react-day-picker/blob/fe80fbbb41ab23ccfb76bbd341e765627e91efd1/packages/react-day-picker/src/contexts/Navigation/NavigationContext.tsx#L61-L65

### Solution

I moved `onMonthChange` call to inside `goToMonth` to make sure `onMonthChange` is called every time when `goToMonth` is called.
