### PR TITLE
fix: add onSelect to the DayPickerContextValue

### DIFF
--- a/packages/react-day-picker/src/contexts/DayPicker/DayPickerContext.tsx
+++ b/packages/react-day-picker/src/contexts/DayPicker/DayPickerContext.tsx
@@ -4,9 +4,12 @@ import { DayPickerProps } from 'DayPicker';
 
 import { CaptionLayout } from 'components/Caption';
 import { DayPickerBase, DaySelectionMode } from 'types/DayPickerBase';
-import { DayPickerMultipleProps } from 'types/DayPickerMultiple';
-import { DayPickerRangeProps } from 'types/DayPickerRange';
-import { DayPickerSingleProps } from 'types/DayPickerSingle';
+import {
+  DayPickerMultipleProps,
+  isDayPickerMultiple
+} from 'types/DayPickerMultiple';
+import { DayPickerRangeProps, isDayPickerRange } from 'types/DayPickerRange';
+import { DayPickerSingleProps, isDayPickerSingle } from 'types/DayPickerSingle';
 import { Formatters } from 'types/Formatters';
 import { Labels } from 'types/Labels';
 import { Matcher } from 'types/Matchers';
@@ -69,9 +72,17 @@ export function DayPickerProvider(props: DayPickerProviderProps): JSX.Element {
   const { fromDate, toDate } = parseFromToProps(initialProps);
 
   let captionLayout = initialProps.captionLayout ?? defaults.captionLayout;
-
   if (captionLayout !== 'buttons' && (!fromDate || !toDate)) {
     captionLayout = 'buttons';
+  }
+
+  let onSelect;
+  if (
+    isDayPickerSingle(initialProps) ||
+    isDayPickerMultiple(initialProps) ||
+    isDayPickerRange(initialProps)
+  ) {
+    onSelect = initialProps.onSelect;
   }
 
   const value: DayPickerContextValue = {
@@ -131,6 +142,7 @@ export function DayPickerProvider(props: DayPickerProviderProps): JSX.Element {
     onMonthChange: initialProps.onMonthChange,
     onNextClick: initialProps.onNextClick,
     onPrevClick: initialProps.onPrevClick,
+    onSelect,
     onWeekNumberClick: initialProps.onWeekNumberClick,
     pagedNavigation: initialProps.pagedNavigation,
     reverseMonths: initialProps.reverseMonths,

--- a/packages/react-day-picker/src/contexts/DayPicker/useDayPicker.test.ts
+++ b/packages/react-day-picker/src/contexts/DayPicker/useDayPicker.test.ts
@@ -8,7 +8,7 @@ import { freezeBeforeAll } from 'test/utils';
 import { CaptionLayout } from 'components/Caption';
 import { DayPickerContextValue, useDayPicker } from 'contexts/DayPicker';
 import { getDefaultContextValue } from 'contexts/DayPicker/defaultContextValue';
-import { CustomComponents } from 'types/DayPickerBase';
+import { CustomComponents, DaySelectionMode } from 'types/DayPickerBase';
 import { Formatters } from 'types/Formatters';
 import { Labels } from 'types/Labels';
 import { DayModifiers, ModifiersClassNames } from 'types/Modifiers';
@@ -293,5 +293,17 @@ describe('when passing "components" from props', () => {
       ...defaults.components,
       ...components
     });
+  });
+});
+
+describe('when in selection mode', () => {
+  const mode: DaySelectionMode = 'multiple';
+  const onSelect = jest.fn();
+  const dayPickerProps: DayPickerProps = { mode, onSelect };
+  beforeEach(() => {
+    setup(dayPickerProps);
+  });
+  test('should return the "onSelect" event handler', () => {
+    expect(renderResult.current.onSelect).toBe(onSelect);
   });
 });


### PR DESCRIPTION
The `DayPickerContextValue` should contain the `onSelect` event handler. While this was added in the docs, it wasn't actually available.