### PR TITLE
fix: rdp class not added to root element when using className 

### DIFF
--- a/packages/react-day-picker/src/components/Root/Root.test.tsx
+++ b/packages/react-day-picker/src/components/Root/Root.test.tsx
@@ -63,7 +63,7 @@ describe('when using the "className" prop', () => {
     setup(props);
   });
   test('should append the class name to the root element', () => {
-    expect(container.firstChild).toHaveClass('foo');
+    expect(container.firstChild).toHaveClass('rdp foo');
   });
 });
 

--- a/packages/react-day-picker/src/components/Root/Root.tsx
+++ b/packages/react-day-picker/src/components/Root/Root.tsx
@@ -30,7 +30,7 @@ export function Root(): JSX.Element {
   ]);
 
   // Apply classnames according to props
-  const classNames = [dayPicker.className ?? dayPicker.classNames.root];
+  const classNames = [dayPicker.classNames.root, dayPicker.className];
   if (dayPicker.numberOfMonths > 1) {
     classNames.push(dayPicker.classNames.multiple_months);
   }

--- a/packages/react-day-picker/src/types/DayPickerBase.ts
+++ b/packages/react-day-picker/src/types/DayPickerBase.ts
@@ -41,7 +41,7 @@ export type DaySelectionMode = 'single' | 'multiple' | 'range' | 'default';
  * The base props for the {@link DayPicker} component and the {@link DayPickerContext}.
  */
 export interface DayPickerBase {
-  /** The CSS class to add to the container element. */
+  /** The CSS class to add to the container element. To change the name of the class instead, use `classNames.root`. */
   className?: string;
   /**
    * Change the class names of the HTML elements.


### PR DESCRIPTION
### Context

Recently we moved the CSS variables into the `.rdp` class in #1499, but this made the issue in #1503 to surface.

### Analysis

In the code we are replacing the value of className instead of appending it.

### Solution

Append the class name instead of replacing it. To replace it, use `classNames.root`.
