### PR TITLE
fix: do not focus disabled or hidden days

### DIFF
--- a/packages/react-day-picker/src/contexts/Focus/FocusContext.tsx
+++ b/packages/react-day-picker/src/contexts/Focus/FocusContext.tsx
@@ -85,7 +85,13 @@ export function FocusProvider(props: { children: ReactNode }): JSX.Element {
 
   const moveFocus = (moveBy: MoveFocusBy, direction: MoveFocusDirection) => {
     if (!focusedDay) return;
-    const nextFocused = getNextFocus(focusedDay, moveBy, direction, dayPicker);
+    const nextFocused = getNextFocus(
+      focusedDay,
+      moveBy,
+      direction,
+      dayPicker,
+      modifiers
+    );
     if (isSameDay(focusedDay, nextFocused)) return undefined;
     navigation.goToDate(nextFocused, focusedDay);
     focus(nextFocused);

--- a/packages/react-day-picker/src/contexts/Focus/utils/getNextFocus.test.tsx
+++ b/packages/react-day-picker/src/contexts/Focus/utils/getNextFocus.test.tsx
@@ -2,6 +2,12 @@
 import { addDays, format, parseISO } from 'date-fns';
 
 import {
+  InternalModifier,
+  InternalModifiers,
+  Modifiers
+} from 'types/Modifiers';
+
+import {
   getNextFocus,
   MoveFocusBy,
   MoveFocusDirection,
@@ -109,10 +115,10 @@ describe.each(tests)(
 );
 
 describe('when reaching the "fromDate"', () => {
-  const focusedDate = new Date();
-  const fromDate = addDays(focusedDate, -1);
+  const focusedDay = new Date();
+  const fromDate = addDays(focusedDay, -1);
   test('next focus should be "fromDate"', () => {
-    const nextFocus = getNextFocus(focusedDate, 'day', 'before', {
+    const nextFocus = getNextFocus(focusedDay, 'day', 'before', {
       fromDate
     });
     expect(nextFocus).toStrictEqual(fromDate);
@@ -120,12 +126,114 @@ describe('when reaching the "fromDate"', () => {
 });
 
 describe('when reaching the "toDate"', () => {
-  const focusedDate = new Date();
-  const toDate = addDays(focusedDate, 1);
+  const focusedDay = new Date();
+  const toDate = addDays(focusedDay, 1);
   test('next focus should be "toDate"', () => {
-    const nextFocus = getNextFocus(focusedDate, 'day', 'after', {
+    const nextFocus = getNextFocus(focusedDay, 'day', 'after', {
       toDate
     });
     expect(nextFocus).toStrictEqual(toDate);
   });
 });
+
+const emptyModifiers: Modifiers = {
+  outside: [],
+  disabled: [],
+  selected: [],
+  hidden: [],
+  today: [],
+  range_start: [],
+  range_end: [],
+  range_middle: []
+};
+
+type ModifiersTest = {
+  focusedDay: string;
+  skippedDay: string;
+  moveBy: MoveFocusBy;
+  moveDirection: MoveFocusDirection;
+  modifierName: InternalModifier;
+  expectedNextFocus: string;
+  fromDate?: string;
+  toDate?: string;
+};
+
+const modifiersTest: ModifiersTest[] = [
+  {
+    focusedDay: '2022-08-17',
+    skippedDay: '2022-08-18',
+    moveBy: 'day',
+    moveDirection: 'after',
+    modifierName: InternalModifier.Hidden,
+    expectedNextFocus: '2022-08-19'
+  },
+  {
+    focusedDay: '2022-08-17',
+    skippedDay: '2022-08-18',
+    moveBy: 'day',
+    moveDirection: 'after',
+    modifierName: InternalModifier.Disabled,
+    expectedNextFocus: '2022-08-19'
+  },
+  {
+    focusedDay: '2022-08-17',
+    skippedDay: '2022-08-16',
+    moveBy: 'day',
+    moveDirection: 'before',
+    modifierName: InternalModifier.Hidden,
+    expectedNextFocus: '2022-08-15'
+  },
+  {
+    focusedDay: '2022-08-17',
+    skippedDay: '2022-08-16',
+    moveBy: 'day',
+    moveDirection: 'before',
+    modifierName: InternalModifier.Disabled,
+    expectedNextFocus: '2022-08-15'
+  },
+  {
+    focusedDay: '2022-08-17',
+    skippedDay: '2022-08-16',
+    fromDate: '2022-08-01',
+    moveBy: 'month',
+    moveDirection: 'before',
+    modifierName: InternalModifier.Disabled,
+    expectedNextFocus: '2022-08-01'
+  },
+  {
+    focusedDay: '2022-08-17',
+    skippedDay: '2022-08-16',
+    toDate: '2022-08-31',
+    moveBy: 'month',
+    moveDirection: 'after',
+    modifierName: InternalModifier.Disabled,
+    expectedNextFocus: '2022-08-31'
+  }
+];
+describe.each(modifiersTest)(
+  'when focusing the $moveBy $moveDirection $focusedDay with $modifierName modifier',
+  (modifierTest) => {
+    const modifiers: InternalModifiers = {
+      ...emptyModifiers,
+      [modifierTest.modifierName]: [parseISO(modifierTest.skippedDay)]
+    };
+    const options = {
+      fromDate: modifierTest.fromDate
+        ? parseISO(modifierTest.fromDate)
+        : undefined,
+      toDate: modifierTest.toDate ? parseISO(modifierTest.toDate) : undefined
+    };
+    test(`should skip the ${modifierTest.modifierName} day`, () => {
+      const nextFocus = getNextFocus(
+        parseISO(modifierTest.focusedDay),
+        modifierTest.moveBy,
+        modifierTest.moveDirection,
+        options,
+        modifiers
+      );
+      expect(format(nextFocus, 'yyyy-MM-dd')).toBe(
+        modifierTest.expectedNextFocus
+      );
+    });
+  }
+);

--- a/packages/react-day-picker/src/contexts/Focus/utils/getNextFocus.tsx
+++ b/packages/react-day-picker/src/contexts/Focus/utils/getNextFocus.tsx
@@ -8,6 +8,8 @@ import min from 'date-fns/min';
 import startOfWeek from 'date-fns/startOfWeek';
 
 import { DayPickerContextValue } from 'contexts/DayPicker';
+import { getActiveModifiers } from 'contexts/Modifiers';
+import { Modifiers } from 'types/Modifiers';
 
 export type MoveFocusBy =
   | 'day'
@@ -28,7 +30,8 @@ export function getNextFocus(
   focusedDay: Date,
   moveBy: MoveFocusBy,
   direction: MoveFocusDirection,
-  options: MoveFocusOptions
+  options: MoveFocusOptions,
+  modifiers?: Modifiers
 ): Date {
   const { weekStartsOn, fromDate, toDate, locale } = options;
 
@@ -50,6 +53,14 @@ export function getNextFocus(
     newFocusedDay = max([fromDate, newFocusedDay]);
   } else if (direction === 'after' && toDate) {
     newFocusedDay = min([toDate, newFocusedDay]);
+  }
+  if (modifiers) {
+    const activeModifiers = getActiveModifiers(newFocusedDay, modifiers);
+    const isFocusable = !activeModifiers.disabled && !activeModifiers.hidden;
+
+    if (!isFocusable) {
+      return getNextFocus(newFocusedDay, moveBy, direction, options, modifiers);
+    }
   }
 
   return newFocusedDay;


### PR DESCRIPTION
### Context

When moving with keyboard, hidden or disabled days still get the focus – even if not visible.

### Analysis

The `getNextFocus` we introduced in does not check if the next focused day is disabled/hidden.

### Solution

Update `getNextFocus` to skip the disabled/hidden days.