### PR TITLE
fix: `onDayClick` called twice in selection mode

### DIFF
--- a/packages/react-day-picker/src/hooks/useDayEventHandlers/useDayEventHandlers.test.tsx
+++ b/packages/react-day-picker/src/hooks/useDayEventHandlers/useDayEventHandlers.test.tsx
@@ -115,7 +115,10 @@ describe.each<'single' | 'multiple' | 'range'>(['single', 'multiple', 'range'])(
   'when calling "onClick" in "%s" selection mode',
   (mode) => {
     const activeModifiers: ActiveModifiers = {};
-    const dayPickerProps = { mode, onDayClick: jest.fn() };
+    const dayPickerProps = {
+      mode,
+      onDayClick: mockedContexts[mode].onDayClick
+    };
     const mouseEvent = {} as React.MouseEvent<HTMLButtonElement, MouseEvent>;
     const date = today;
     beforeEach(() => {
@@ -123,7 +126,7 @@ describe.each<'single' | 'multiple' | 'range'>(['single', 'multiple', 'range'])(
       renderResult.current.onClick?.(mouseEvent);
     });
     test(`should have called "onDayClick" from the ${mode} context`, () => {
-      expect(mockedContexts[mode].onDayClick).toHaveBeenCalledTimes(1);
+      expect(dayPickerProps.onDayClick).toHaveBeenCalledTimes(1);
     });
   }
 );

--- a/packages/react-day-picker/src/hooks/useDayEventHandlers/useDayEventHandlers.test.tsx
+++ b/packages/react-day-picker/src/hooks/useDayEventHandlers/useDayEventHandlers.test.tsx
@@ -122,8 +122,8 @@ describe.each<'single' | 'multiple' | 'range'>(['single', 'multiple', 'range'])(
       setup(date, activeModifiers, dayPickerProps);
       renderResult.current.onClick?.(mouseEvent);
     });
-    test(`should have called "onDayClick" from the day picker props`, () => {
-      expect(dayPickerProps.onDayClick).toHaveBeenCalled();
+    test(`should have called "onDayClick" from the ${mode} context`, () => {
+      expect(mockedContexts[mode].onDayClick).toHaveBeenCalledTimes(1);
     });
   }
 );

--- a/packages/react-day-picker/src/hooks/useDayEventHandlers/useDayEventHandlers.tsx
+++ b/packages/react-day-picker/src/hooks/useDayEventHandlers/useDayEventHandlers.tsx
@@ -94,8 +94,9 @@ export function useDayEventHandlers(
       multiple.onDayClick?.(date, activeModifiers, e);
     } else if (isDayPickerRange(dayPicker)) {
       range.onDayClick?.(date, activeModifiers, e);
+    } else {
+      dayPicker.onDayClick?.(date, activeModifiers, e);
     }
-    dayPicker.onDayClick?.(date, activeModifiers, e);
   };
 
   const onFocus: FocusEventHandler = (e) => {


### PR DESCRIPTION
Fixes #1506. 

### Context

The `onDayClick` event handler is called twice when in selection mode.

### Analysis

This line should not be called when in selection mode:

https://github.com/gpbl/react-day-picker/blob/94e32d18d30505d101290c77dc96d8fd25a861b4/packages/react-day-picker/src/hooks/useDayEventHandlers/useDayEventHandlers.tsx#L98

### Solution

- Move line into an if statement
- Update test