### PR TITLE
fix: use parsed fromDate/toDate in useInput

### DIFF
--- a/packages/react-day-picker/src/hooks/useInput/useInput.ts
+++ b/packages/react-day-picker/src/hooks/useInput/useInput.ts
@@ -158,8 +158,8 @@ export function useInput(options: UseInputOptions = {}): UseInputValue {
     onMonthChange: handleMonthChange,
     selected: selectedDay,
     locale,
-    fromDate: options?.fromDate,
-    toDate: options?.toDate,
+    fromDate,
+    toDate,
     today
   };
 


### PR DESCRIPTION
### Context

`dayPickerProps` returned from `useInput` ignores `fromYear`/`toYear` and `fromMonth`/`toMonth` set on the options.

### Analysis

Only `option.fromDate`/`options.toDate` is included in `dayPickerProps`. This seems like an oversight and either the parsed `fromDate`/`toDate` should be used or all of the original from/to props should be added.

### Solution

Use the parsed `fromDate`/`toDate` instead of `options.fromDate`/`options.toDate`.
