### PR TITLE
changed: add names to fields and buttons

### DIFF
--- a/packages/react-day-picker/src/components/Day/Day.test.tsx
+++ b/packages/react-day-picker/src/components/Day/Day.test.tsx
@@ -54,8 +54,9 @@ describe('when a selection mode is set', () => {
   beforeEach(() => {
     setup(props, dayPickerProps);
   });
-  test('should render a button', () => {
+  test('should render a button named "day"', () => {
     expect(container.firstChild?.nodeName).toBe('BUTTON');
+    expect(container.firstChild).toHaveAttribute('name', 'day');
   });
 });
 

--- a/packages/react-day-picker/src/components/Day/Day.tsx
+++ b/packages/react-day-picker/src/components/Day/Day.tsx
@@ -26,5 +26,5 @@ export function Day(props: DayProps): JSX.Element {
   if (!dayRender.isButton) {
     return <div {...dayRender.divProps} />;
   }
-  return <Button ref={buttonRef} {...dayRender.buttonProps} />;
+  return <Button name="day" ref={buttonRef} {...dayRender.buttonProps} />;
 }

--- a/packages/react-day-picker/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/react-day-picker/src/components/Dropdown/Dropdown.test.tsx
@@ -19,6 +19,7 @@ function setup(props: DropdownProps, dayPickerProps?: DayPickerProps) {
 }
 
 const props: Required<DropdownProps> = {
+  name: 'dropdown',
   'aria-label': 'foo',
   onChange: jest.fn(),
   caption: 'Some caption',

--- a/packages/react-day-picker/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-day-picker/src/components/Dropdown/Dropdown.tsx
@@ -5,6 +5,7 @@ import { useDayPicker } from 'contexts/DayPicker';
 
 /** The props for the {@link Dropdown} component. */
 export interface DropdownProps {
+  name?: string;
   caption?: React.ReactNode;
   children?: React.SelectHTMLAttributes<HTMLSelectElement>['children'];
   className?: string;
@@ -30,6 +31,7 @@ export function Dropdown(props: DropdownProps): JSX.Element {
         {props['aria-label']}
       </span>
       <select
+        name={props.name}
         aria-label={props['aria-label']}
         className={dayPicker.classNames.dropdown}
         style={dayPicker.styles.dropdown}

--- a/packages/react-day-picker/src/components/MonthsDropdown/MonthsDropdown.test.tsx
+++ b/packages/react-day-picker/src/components/MonthsDropdown/MonthsDropdown.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { differenceInMonths } from 'date-fns';
+import { addMonths, differenceInMonths } from 'date-fns';
 import { DayPickerProps } from 'DayPicker';
 
 import { customRender } from 'test/render';
@@ -29,6 +29,16 @@ const props: MonthsDropdownProps = {
   displayMonth: today,
   onChange: jest.fn()
 };
+
+describe('when fromDate and toDate are passed in', () => {
+  beforeEach(() => {
+    setup(props, { fromDate: new Date(), toDate: addMonths(new Date(), 1) });
+  });
+  test('should render the dropdown element', () => {
+    expect(root).toMatchSnapshot();
+    expect(select).toHaveAttribute('name', 'months');
+  });
+});
 
 describe('when "fromDate" is not set', () => {
   beforeEach(() => {

--- a/packages/react-day-picker/src/components/MonthsDropdown/MonthsDropdown.tsx
+++ b/packages/react-day-picker/src/components/MonthsDropdown/MonthsDropdown.tsx
@@ -58,6 +58,7 @@ export function MonthsDropdown(props: MonthsDropdownProps): JSX.Element {
 
   return (
     <DropdownComponent
+      name="months"
       aria-label={labelMonthDropdown()}
       className={classNames.dropdown_month}
       style={styles.dropdown_month}

--- a/packages/react-day-picker/src/components/MonthsDropdown/__snapshots__/MonthsDropdown.test.tsx.snap
+++ b/packages/react-day-picker/src/components/MonthsDropdown/__snapshots__/MonthsDropdown.test.tsx.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`when fromDate and toDate are passed in should render the dropdown element 1`] = `
+<div
+  class="rdp-dropdown_month"
+>
+  <span
+    class="rdp-vhidden"
+  >
+    Month: 
+  </span>
+  <select
+    aria-label="Month: "
+    class="rdp-dropdown"
+    name="months"
+  >
+    <option
+      value="0"
+    >
+      January
+    </option>
+    <option
+      value="1"
+    >
+      February
+    </option>
+  </select>
+  <div
+    aria-hidden="true"
+    class="rdp-caption_label"
+  >
+    January
+    <svg
+      class="rdp-dropdown_icon"
+      data-testid="iconDropdown"
+      height="8px"
+      viewBox="0 0 120 120"
+      width="8px"
+    >
+      <path
+        d="M4.22182541,48.2218254 C8.44222828,44.0014225 15.2388494,43.9273804 19.5496459,47.9996989 L19.7781746,48.2218254 L60,88.443 L100.221825,48.2218254 C104.442228,44.0014225 111.238849,43.9273804 115.549646,47.9996989 L115.778175,48.2218254 C119.998577,52.4422283 120.07262,59.2388494 116.000301,63.5496459 L115.778175,63.7781746 L67.7781746,111.778175 C63.5577717,115.998577 56.7611506,116.07262 52.4503541,112.000301 L52.2218254,111.778175 L4.22182541,63.7781746 C-0.0739418023,59.4824074 -0.0739418023,52.5175926 4.22182541,48.2218254 Z"
+        fill="currentColor"
+        fill-rule="nonzero"
+      />
+    </svg>
+  </div>
+</div>
+`;

--- a/packages/react-day-picker/src/components/Navigation/Navigation.test.tsx
+++ b/packages/react-day-picker/src/components/Navigation/Navigation.test.tsx
@@ -56,6 +56,12 @@ describe('when rendered', () => {
     const icons = root.getElementsByTagName('svg');
     expect(icons[1]).toHaveTextContent('IconRight');
   });
+  test('the previous button should be named "previous-month"', () => {
+    expect(getPrevButton()).toHaveAttribute('name', 'previous-month');
+  });
+  test('the next button should be named "next-month"', () => {
+    expect(getPrevButton()).toHaveAttribute('name', 'next-month');
+  });
   beforeEach(() => {
     userEvent.click(getPrevButton());
   });

--- a/packages/react-day-picker/src/components/Navigation/Navigation.test.tsx
+++ b/packages/react-day-picker/src/components/Navigation/Navigation.test.tsx
@@ -60,7 +60,7 @@ describe('when rendered', () => {
     expect(getPrevButton()).toHaveAttribute('name', 'previous-month');
   });
   test('the next button should be named "next-month"', () => {
-    expect(getPrevButton()).toHaveAttribute('name', 'next-month');
+    expect(getNextButton()).toHaveAttribute('name', 'next-month');
   });
   beforeEach(() => {
     userEvent.click(getPrevButton());

--- a/packages/react-day-picker/src/components/Navigation/Navigation.tsx
+++ b/packages/react-day-picker/src/components/Navigation/Navigation.tsx
@@ -57,6 +57,7 @@ export function Navigation(props: NavigationProps): JSX.Element {
     <div className={classNames.nav} style={styles.nav}>
       {!props.hidePrevious && (
         <Button
+          name="previous-month"
           aria-label={previousLabel}
           className={previousClassName}
           style={styles.nav_button_previous}
@@ -78,6 +79,7 @@ export function Navigation(props: NavigationProps): JSX.Element {
       )}
       {!props.hideNext && (
         <Button
+          name="next-month"
           aria-label={nextLabel}
           className={nextClassName}
           style={styles.nav_button_next}

--- a/packages/react-day-picker/src/components/WeekNumber/WeekNumber.test.tsx
+++ b/packages/react-day-picker/src/components/WeekNumber/WeekNumber.test.tsx
@@ -27,12 +27,19 @@ describe('without "onWeekNumberClick" prop', () => {
 
 describe('with "onWeekNumberClick" prop', () => {
   const dayPickerProps: DayPickerProps = { onWeekNumberClick: jest.fn() };
-  const { container } = setup(props, dayPickerProps);
+  let container: HTMLElement;
+  beforeEach(() => {
+    container = setup(props, dayPickerProps).container;
+  });
   test('it should return a button element', () => {
+    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(container.firstChild).toHaveAttribute('name', 'week-number');
     expect(container.firstChild).toMatchSnapshot();
   });
   describe('when the button element is clicked', () => {
-    userEvent.click(screen.getByRole('button'));
+    beforeEach(async () => {
+      await userEvent.click(screen.getByRole('button'));
+    });
     test('should call onWeekNumberClick', () => {
       expect(dayPickerProps.onWeekNumberClick).toHaveBeenCalledWith(
         props.number,

--- a/packages/react-day-picker/src/components/WeekNumber/WeekNumber.tsx
+++ b/packages/react-day-picker/src/components/WeekNumber/WeekNumber.tsx
@@ -47,6 +47,7 @@ export function WeekNumber(props: WeekNumberProps): JSX.Element {
 
   return (
     <Button
+      name="week-number"
       aria-label={label}
       className={classNames.weeknumber}
       style={styles.weeknumber}

--- a/packages/react-day-picker/src/components/WeekNumber/__snapshots__/WeekNumber.test.tsx.snap
+++ b/packages/react-day-picker/src/components/WeekNumber/__snapshots__/WeekNumber.test.tsx.snap
@@ -1,6 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`with "onWeekNumberClick" prop it should return a button element 1`] = `null`;
+exports[`with "onWeekNumberClick" prop it should return a button element 1`] = `
+<button
+  aria-label="Week n. 10"
+  class="rdp-button_reset rdp-button rdp-weeknumber"
+  name="week-number"
+  type="button"
+>
+  10
+</button>
+`;
 
 exports[`without "onWeekNumberClick" prop it should return a span element 1`] = `
 <span

--- a/packages/react-day-picker/src/components/YearsDropdown/YearsDropdown.test.tsx
+++ b/packages/react-day-picker/src/components/YearsDropdown/YearsDropdown.test.tsx
@@ -36,7 +36,7 @@ describe('when fromDate and toDate are passed in', () => {
   });
   test('should render the dropdown element', () => {
     expect(root).toMatchSnapshot();
-    expect(select).toHaveAttribute('name', 'months');
+    expect(select).toHaveAttribute('name', 'years');
   });
 });
 

--- a/packages/react-day-picker/src/components/YearsDropdown/YearsDropdown.test.tsx
+++ b/packages/react-day-picker/src/components/YearsDropdown/YearsDropdown.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { differenceInYears } from 'date-fns';
+import { addMonths, differenceInYears } from 'date-fns';
 import { DayPickerProps } from 'DayPicker';
 
 import { customRender } from 'test/render';
@@ -29,6 +29,16 @@ const props: YearsDropdownProps = {
   displayMonth: today,
   onChange: jest.fn()
 };
+
+describe('when fromDate and toDate are passed in', () => {
+  beforeEach(() => {
+    setup(props, { fromDate: new Date(), toDate: addMonths(new Date(), 1) });
+  });
+  test('should render the dropdown element', () => {
+    expect(root).toMatchSnapshot();
+    expect(select).toHaveAttribute('name', 'months');
+  });
+});
 
 describe('when "fromDate" is not set', () => {
   beforeEach(() => {

--- a/packages/react-day-picker/src/components/YearsDropdown/YearsDropdown.tsx
+++ b/packages/react-day-picker/src/components/YearsDropdown/YearsDropdown.tsx
@@ -59,6 +59,7 @@ export function YearsDropdown(props: YearsDropdownProps): JSX.Element {
 
   return (
     <DropdownComponent
+      name="years"
       aria-label={labelYearDropdown()}
       className={classNames.dropdown_year}
       style={styles.dropdown_year}

--- a/packages/react-day-picker/src/components/YearsDropdown/__snapshots__/YearsDropdown.test.tsx.snap
+++ b/packages/react-day-picker/src/components/YearsDropdown/__snapshots__/YearsDropdown.test.tsx.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`when fromDate and toDate are passed in should render the dropdown element 1`] = `
+<div
+  class="rdp-dropdown_year"
+>
+  <span
+    class="rdp-vhidden"
+  >
+    Year: 
+  </span>
+  <select
+    aria-label="Year: "
+    class="rdp-dropdown"
+    name="years"
+  >
+    <option
+      value="2021"
+    >
+      2021
+    </option>
+  </select>
+  <div
+    aria-hidden="true"
+    class="rdp-caption_label"
+  >
+    2021
+    <svg
+      class="rdp-dropdown_icon"
+      data-testid="iconDropdown"
+      height="8px"
+      viewBox="0 0 120 120"
+      width="8px"
+    >
+      <path
+        d="M4.22182541,48.2218254 C8.44222828,44.0014225 15.2388494,43.9273804 19.5496459,47.9996989 L19.7781746,48.2218254 L60,88.443 L100.221825,48.2218254 C104.442228,44.0014225 111.238849,43.9273804 115.549646,47.9996989 L115.778175,48.2218254 C119.998577,52.4422283 120.07262,59.2388494 116.000301,63.5496459 L115.778175,63.7781746 L67.7781746,111.778175 C63.5577717,115.998577 56.7611506,116.07262 52.4503541,112.000301 L52.2218254,111.778175 L4.22182541,63.7781746 C-0.0739418023,59.4824074 -0.0739418023,52.5175926 4.22182541,48.2218254 Z"
+        fill="currentColor"
+        fill-rule="nonzero"
+      />
+    </svg>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Buttons and input fields have no names, which makes difficult to discriminate them when using custom components. This PR add the missing names.