### PR TITLE
fix(docs): incorrect function matcher example

### DIFF
--- a/packages/react-day-picker/src/types/Matchers.ts
+++ b/packages/react-day-picker/src/types/Matchers.ts
@@ -42,7 +42,7 @@
  *
  * // will match when the function return true
  * const functionMatcher: Matcher = (day: Date) => {
- *  return (new Date()).getMonth() === 2 // match when month is March
+ *  return day.getMonth() === 2 // match when month is March
  * };
  * ```
  *


### PR DESCRIPTION
### Context

Docs regarding `Matchers` have an example for `functionMatcher` which is incorrect.

### Analysis

Prop `day` is passed but is unused.

### Solution

Replace `new Day()` with `day`.
