### PR TITLE
Update day button aria-label to improve screen reader experience

### DIFF
--- a/packages/react-day-picker/src/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/packages/react-day-picker/src/components/Table/__snapshots__/Table.test.tsx.snap
@@ -146,7 +146,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="1st February (Saturday)"
+          aria-label="1st February 2020 (Saturday)"
           class="rdp-day"
         >
           1
@@ -160,7 +160,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="2nd February (Sunday)"
+          aria-label="2nd February 2020 (Sunday)"
           class="rdp-day"
         >
           2
@@ -170,7 +170,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="3rd February (Monday)"
+          aria-label="3rd February 2020 (Monday)"
           class="rdp-day"
         >
           3
@@ -180,7 +180,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="4th February (Tuesday)"
+          aria-label="4th February 2020 (Tuesday)"
           class="rdp-day"
         >
           4
@@ -190,7 +190,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="5th February (Wednesday)"
+          aria-label="5th February 2020 (Wednesday)"
           class="rdp-day"
         >
           5
@@ -200,7 +200,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="6th February (Thursday)"
+          aria-label="6th February 2020 (Thursday)"
           class="rdp-day"
         >
           6
@@ -210,7 +210,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="7th February (Friday)"
+          aria-label="7th February 2020 (Friday)"
           class="rdp-day"
         >
           7
@@ -220,7 +220,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="8th February (Saturday)"
+          aria-label="8th February 2020 (Saturday)"
           class="rdp-day"
         >
           8
@@ -234,7 +234,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="9th February (Sunday)"
+          aria-label="9th February 2020 (Sunday)"
           class="rdp-day"
         >
           9
@@ -244,7 +244,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="10th February (Monday)"
+          aria-label="10th February 2020 (Monday)"
           class="rdp-day"
         >
           10
@@ -254,7 +254,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="11th February (Tuesday)"
+          aria-label="11th February 2020 (Tuesday)"
           class="rdp-day"
         >
           11
@@ -264,7 +264,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="12th February (Wednesday)"
+          aria-label="12th February 2020 (Wednesday)"
           class="rdp-day"
         >
           12
@@ -274,7 +274,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="13th February (Thursday)"
+          aria-label="13th February 2020 (Thursday)"
           class="rdp-day"
         >
           13
@@ -284,7 +284,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="14th February (Friday)"
+          aria-label="14th February 2020 (Friday)"
           class="rdp-day"
         >
           14
@@ -294,7 +294,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="15th February (Saturday)"
+          aria-label="15th February 2020 (Saturday)"
           class="rdp-day"
         >
           15
@@ -308,7 +308,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="16th February (Sunday)"
+          aria-label="16th February 2020 (Sunday)"
           class="rdp-day"
         >
           16
@@ -318,7 +318,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="17th February (Monday)"
+          aria-label="17th February 2020 (Monday)"
           class="rdp-day"
         >
           17
@@ -328,7 +328,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="18th February (Tuesday)"
+          aria-label="18th February 2020 (Tuesday)"
           class="rdp-day"
         >
           18
@@ -338,7 +338,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="19th February (Wednesday)"
+          aria-label="19th February 2020 (Wednesday)"
           class="rdp-day"
         >
           19
@@ -348,7 +348,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="20th February (Thursday)"
+          aria-label="20th February 2020 (Thursday)"
           class="rdp-day"
         >
           20
@@ -358,7 +358,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="21st February (Friday)"
+          aria-label="21st February 2020 (Friday)"
           class="rdp-day"
         >
           21
@@ -368,7 +368,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="22nd February (Saturday)"
+          aria-label="22nd February 2020 (Saturday)"
           class="rdp-day"
         >
           22
@@ -382,7 +382,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="23rd February (Sunday)"
+          aria-label="23rd February 2020 (Sunday)"
           class="rdp-day"
         >
           23
@@ -392,7 +392,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="24th February (Monday)"
+          aria-label="24th February 2020 (Monday)"
           class="rdp-day"
         >
           24
@@ -402,7 +402,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="25th February (Tuesday)"
+          aria-label="25th February 2020 (Tuesday)"
           class="rdp-day"
         >
           25
@@ -412,7 +412,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="26th February (Wednesday)"
+          aria-label="26th February 2020 (Wednesday)"
           class="rdp-day"
         >
           26
@@ -422,7 +422,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="27th February (Thursday)"
+          aria-label="27th February 2020 (Thursday)"
           class="rdp-day"
         >
           27
@@ -432,7 +432,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="28th February (Friday)"
+          aria-label="28th February 2020 (Friday)"
           class="rdp-day"
         >
           28
@@ -442,7 +442,7 @@ exports[`should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="29th February (Saturday)"
+          aria-label="29th February 2020 (Saturday)"
           class="rdp-day"
         >
           29
@@ -612,7 +612,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="1st February (Saturday)"
+          aria-label="1st February 2020 (Saturday)"
           class="rdp-day"
         >
           1
@@ -635,7 +635,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="2nd February (Sunday)"
+          aria-label="2nd February 2020 (Sunday)"
           class="rdp-day"
         >
           2
@@ -645,7 +645,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="3rd February (Monday)"
+          aria-label="3rd February 2020 (Monday)"
           class="rdp-day"
         >
           3
@@ -655,7 +655,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="4th February (Tuesday)"
+          aria-label="4th February 2020 (Tuesday)"
           class="rdp-day"
         >
           4
@@ -665,7 +665,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="5th February (Wednesday)"
+          aria-label="5th February 2020 (Wednesday)"
           class="rdp-day"
         >
           5
@@ -675,7 +675,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="6th February (Thursday)"
+          aria-label="6th February 2020 (Thursday)"
           class="rdp-day"
         >
           6
@@ -685,7 +685,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="7th February (Friday)"
+          aria-label="7th February 2020 (Friday)"
           class="rdp-day"
         >
           7
@@ -695,7 +695,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="8th February (Saturday)"
+          aria-label="8th February 2020 (Saturday)"
           class="rdp-day"
         >
           8
@@ -718,7 +718,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="9th February (Sunday)"
+          aria-label="9th February 2020 (Sunday)"
           class="rdp-day"
         >
           9
@@ -728,7 +728,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="10th February (Monday)"
+          aria-label="10th February 2020 (Monday)"
           class="rdp-day"
         >
           10
@@ -738,7 +738,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="11th February (Tuesday)"
+          aria-label="11th February 2020 (Tuesday)"
           class="rdp-day"
         >
           11
@@ -748,7 +748,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="12th February (Wednesday)"
+          aria-label="12th February 2020 (Wednesday)"
           class="rdp-day"
         >
           12
@@ -758,7 +758,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="13th February (Thursday)"
+          aria-label="13th February 2020 (Thursday)"
           class="rdp-day"
         >
           13
@@ -768,7 +768,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="14th February (Friday)"
+          aria-label="14th February 2020 (Friday)"
           class="rdp-day"
         >
           14
@@ -778,7 +778,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="15th February (Saturday)"
+          aria-label="15th February 2020 (Saturday)"
           class="rdp-day"
         >
           15
@@ -801,7 +801,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="16th February (Sunday)"
+          aria-label="16th February 2020 (Sunday)"
           class="rdp-day"
         >
           16
@@ -811,7 +811,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="17th February (Monday)"
+          aria-label="17th February 2020 (Monday)"
           class="rdp-day"
         >
           17
@@ -821,7 +821,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="18th February (Tuesday)"
+          aria-label="18th February 2020 (Tuesday)"
           class="rdp-day"
         >
           18
@@ -831,7 +831,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="19th February (Wednesday)"
+          aria-label="19th February 2020 (Wednesday)"
           class="rdp-day"
         >
           19
@@ -841,7 +841,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="20th February (Thursday)"
+          aria-label="20th February 2020 (Thursday)"
           class="rdp-day"
         >
           20
@@ -851,7 +851,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="21st February (Friday)"
+          aria-label="21st February 2020 (Friday)"
           class="rdp-day"
         >
           21
@@ -861,7 +861,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="22nd February (Saturday)"
+          aria-label="22nd February 2020 (Saturday)"
           class="rdp-day"
         >
           22
@@ -884,7 +884,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="23rd February (Sunday)"
+          aria-label="23rd February 2020 (Sunday)"
           class="rdp-day"
         >
           23
@@ -894,7 +894,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="24th February (Monday)"
+          aria-label="24th February 2020 (Monday)"
           class="rdp-day"
         >
           24
@@ -904,7 +904,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="25th February (Tuesday)"
+          aria-label="25th February 2020 (Tuesday)"
           class="rdp-day"
         >
           25
@@ -914,7 +914,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="26th February (Wednesday)"
+          aria-label="26th February 2020 (Wednesday)"
           class="rdp-day"
         >
           26
@@ -924,7 +924,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="27th February (Thursday)"
+          aria-label="27th February 2020 (Thursday)"
           class="rdp-day"
         >
           27
@@ -934,7 +934,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="28th February (Friday)"
+          aria-label="28th February 2020 (Friday)"
           class="rdp-day"
         >
           28
@@ -944,7 +944,7 @@ exports[`when showing the week numbers should render correctly 1`] = `
         class="rdp-cell"
       >
         <div
-          aria-label="29th February (Saturday)"
+          aria-label="29th February 2020 (Saturday)"
           class="rdp-day"
         >
           29

--- a/packages/react-day-picker/src/contexts/DayPicker/labels/labelDay.test.ts
+++ b/packages/react-day-picker/src/contexts/DayPicker/labels/labelDay.test.ts
@@ -3,5 +3,5 @@ import { labelDay } from './labelDay';
 const day = new Date(2022, 10, 21);
 
 test('should return the day label', () => {
-  expect(labelDay(day, {})).toEqual('21st November (Monday)');
+  expect(labelDay(day, {})).toEqual('21st November 2022 (Monday)');
 });

--- a/packages/react-day-picker/src/contexts/DayPicker/labels/labelDay.ts
+++ b/packages/react-day-picker/src/contexts/DayPicker/labels/labelDay.ts
@@ -6,5 +6,5 @@ import { DayLabel } from 'types/Labels';
  * The default ARIA label for the day button.
  */
 export const labelDay: DayLabel = (day, activeModifiers, options): string => {
-  return format(day, 'do MMMM (EEEE)', options);
+  return format(day, 'do MMMM yyyy (EEEE)', options);
 };

--- a/packages/react-day-picker/test/po.ts
+++ b/packages/react-day-picker/test/po.ts
@@ -3,7 +3,7 @@ import { format } from 'date-fns';
 
 export function getDayButton(day: Date) {
   return screen.getByRole('button', {
-    name: format(day, 'do MMMM (EEEE)')
+    name: format(day, 'do MMMM yyyy (EEEE)')
   });
 }
 
@@ -29,19 +29,19 @@ export function getAllEnabledDays() {
 
 export function getDayButtons(day: Date) {
   return screen.getByRole('button', {
-    name: format(day, 'do MMMM (EEEE)')
+    name: format(day, 'do MMMM yyyy (EEEE)')
   });
 }
 
 export function queryDayButton(day: Date) {
   return screen.queryByRole('button', {
-    name: format(day, 'do MMMM (EEEE)')
+    name: format(day, 'do MMMM yyyy (EEEE)')
   });
 }
 
 export function getDayCell(day: Date) {
   return screen.getByRole('cell', {
-    name: format(day, 'do MMMM (EEEE)')
+    name: format(day, 'do MMMM yyyy (EEEE)')
   });
 }
 export function getWeekButton(week: number) {

--- a/website/test-integration/examples/__snapshots__/range.test.tsx.snap
+++ b/website/test-integration/examples/__snapshots__/range.test.tsx.snap
@@ -191,7 +191,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="1st November (Sunday)"
+                aria-label="1st November 2020 (Sunday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -204,7 +204,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="2nd November (Monday)"
+                aria-label="2nd November 2020 (Monday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -217,7 +217,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="3rd November (Tuesday)"
+                aria-label="3rd November 2020 (Tuesday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -230,7 +230,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="4th November (Wednesday)"
+                aria-label="4th November 2020 (Wednesday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -243,7 +243,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="5th November (Thursday)"
+                aria-label="5th November 2020 (Thursday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -256,7 +256,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="6th November (Friday)"
+                aria-label="6th November 2020 (Friday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -269,7 +269,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="7th November (Saturday)"
+                aria-label="7th November 2020 (Saturday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -286,7 +286,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="8th November (Sunday)"
+                aria-label="8th November 2020 (Sunday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -299,7 +299,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="9th November (Monday)"
+                aria-label="9th November 2020 (Monday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -312,7 +312,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="10th November (Tuesday)"
+                aria-label="10th November 2020 (Tuesday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -325,7 +325,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="11th November (Wednesday)"
+                aria-label="11th November 2020 (Wednesday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -338,7 +338,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="12th November (Thursday)"
+                aria-label="12th November 2020 (Thursday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -351,7 +351,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="13th November (Friday)"
+                aria-label="13th November 2020 (Friday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -364,7 +364,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="14th November (Saturday)"
+                aria-label="14th November 2020 (Saturday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -381,7 +381,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="15th November (Sunday)"
+                aria-label="15th November 2020 (Sunday)"
                 aria-pressed="true"
                 class="rdp-button_reset rdp-button rdp-day rdp-day_selected rdp-day_range_start"
                 name="day"
@@ -395,7 +395,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="16th November (Monday)"
+                aria-label="16th November 2020 (Monday)"
                 aria-pressed="true"
                 class="rdp-button_reset rdp-button rdp-day rdp-day_selected rdp-day_range_middle"
                 name="day"
@@ -409,7 +409,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="17th November (Tuesday)"
+                aria-label="17th November 2020 (Tuesday)"
                 aria-pressed="true"
                 class="rdp-button_reset rdp-button rdp-day rdp-day_selected rdp-day_range_middle"
                 name="day"
@@ -423,7 +423,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="18th November (Wednesday)"
+                aria-label="18th November 2020 (Wednesday)"
                 aria-pressed="true"
                 class="rdp-button_reset rdp-button rdp-day rdp-day_selected rdp-day_range_middle"
                 name="day"
@@ -437,7 +437,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="19th November (Thursday)"
+                aria-label="19th November 2020 (Thursday)"
                 aria-pressed="true"
                 class="rdp-button_reset rdp-button rdp-day rdp-day_selected rdp-day_range_end"
                 name="day"
@@ -451,7 +451,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="20th November (Friday)"
+                aria-label="20th November 2020 (Friday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -464,7 +464,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="21st November (Saturday)"
+                aria-label="21st November 2020 (Saturday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -481,7 +481,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="22nd November (Sunday)"
+                aria-label="22nd November 2020 (Sunday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -494,7 +494,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="23rd November (Monday)"
+                aria-label="23rd November 2020 (Monday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -507,7 +507,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="24th November (Tuesday)"
+                aria-label="24th November 2020 (Tuesday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -520,7 +520,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="25th November (Wednesday)"
+                aria-label="25th November 2020 (Wednesday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -533,7 +533,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="26th November (Thursday)"
+                aria-label="26th November 2020 (Thursday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -546,7 +546,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="27th November (Friday)"
+                aria-label="27th November 2020 (Friday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -559,7 +559,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="28th November (Saturday)"
+                aria-label="28th November 2020 (Saturday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -576,7 +576,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="29th November (Sunday)"
+                aria-label="29th November 2020 (Sunday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -589,7 +589,7 @@ exports[`should match the snapshot 1`] = `
               class="rdp-cell"
             >
               <button
-                aria-label="30th November (Monday)"
+                aria-label="30th November 2020 (Monday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -827,7 +827,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="1st November (Sunday)"
+                aria-label="1st November 2020 (Sunday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -840,7 +840,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="2nd November (Monday)"
+                aria-label="2nd November 2020 (Monday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -853,7 +853,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="3rd November (Tuesday)"
+                aria-label="3rd November 2020 (Tuesday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -866,7 +866,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="4th November (Wednesday)"
+                aria-label="4th November 2020 (Wednesday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -879,7 +879,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="5th November (Thursday)"
+                aria-label="5th November 2020 (Thursday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -892,7 +892,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="6th November (Friday)"
+                aria-label="6th November 2020 (Friday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -905,7 +905,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="7th November (Saturday)"
+                aria-label="7th November 2020 (Saturday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -922,7 +922,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="8th November (Sunday)"
+                aria-label="8th November 2020 (Sunday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -935,7 +935,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="9th November (Monday)"
+                aria-label="9th November 2020 (Monday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -948,7 +948,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="10th November (Tuesday)"
+                aria-label="10th November 2020 (Tuesday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -961,7 +961,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="11th November (Wednesday)"
+                aria-label="11th November 2020 (Wednesday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -974,7 +974,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="12th November (Thursday)"
+                aria-label="12th November 2020 (Thursday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -987,7 +987,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="13th November (Friday)"
+                aria-label="13th November 2020 (Friday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -1000,7 +1000,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="14th November (Saturday)"
+                aria-label="14th November 2020 (Saturday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -1017,7 +1017,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="15th November (Sunday)"
+                aria-label="15th November 2020 (Sunday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -1030,7 +1030,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="16th November (Monday)"
+                aria-label="16th November 2020 (Monday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -1043,7 +1043,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="17th November (Tuesday)"
+                aria-label="17th November 2020 (Tuesday)"
                 aria-pressed="true"
                 class="rdp-button_reset rdp-button rdp-day rdp-day_selected rdp-day_range_end rdp-day_range_start"
                 name="day"
@@ -1057,7 +1057,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="18th November (Wednesday)"
+                aria-label="18th November 2020 (Wednesday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -1070,7 +1070,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="19th November (Thursday)"
+                aria-label="19th November 2020 (Thursday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -1083,7 +1083,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="20th November (Friday)"
+                aria-label="20th November 2020 (Friday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -1096,7 +1096,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="21st November (Saturday)"
+                aria-label="21st November 2020 (Saturday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -1113,7 +1113,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="22nd November (Sunday)"
+                aria-label="22nd November 2020 (Sunday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -1126,7 +1126,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="23rd November (Monday)"
+                aria-label="23rd November 2020 (Monday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -1139,7 +1139,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="24th November (Tuesday)"
+                aria-label="24th November 2020 (Tuesday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -1152,7 +1152,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="25th November (Wednesday)"
+                aria-label="25th November 2020 (Wednesday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -1165,7 +1165,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="26th November (Thursday)"
+                aria-label="26th November 2020 (Thursday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -1178,7 +1178,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="27th November (Friday)"
+                aria-label="27th November 2020 (Friday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -1191,7 +1191,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="28th November (Saturday)"
+                aria-label="28th November 2020 (Saturday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -1208,7 +1208,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="29th November (Sunday)"
+                aria-label="29th November 2020 (Sunday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"
@@ -1221,7 +1221,7 @@ exports[`when a day in the range is clicked when the day is clicked again when a
               class="rdp-cell"
             >
               <button
-                aria-label="30th November (Monday)"
+                aria-label="30th November 2020 (Monday)"
                 class="rdp-button_reset rdp-button rdp-day"
                 name="day"
                 tabindex="-1"

--- a/website/test-integration/examples/outside-days.test.tsx
+++ b/website/test-integration/examples/outside-days.test.tsx
@@ -18,6 +18,6 @@ describe('when displaying November 2021', () => {
     const firstDayElement = container
       .getElementsByTagName('tr')[1]
       .getElementsByTagName('td')[0];
-    expect(firstDayElement).toHaveAccessibleName('31st October (Sunday)');
+    expect(firstDayElement).toHaveAccessibleName('31st October 2021 (Sunday)');
   });
 });


### PR DESCRIPTION
### Context

Hello! Firstly just wanted to say thank you for such a great library. I am a developer working on an [open source design system](https://github.com/steelthreads/agds-next) which uses `react-day-picker` for our [date picker component](https://steelthreads.github.io/agds-next/packages/forms/date-picker). 

We've been doing some accessibility user testing sessions and a few of our screen reader users have said it would be nice to include the year in the label for each of the buttons inside the calendar. Without the year rendered in the label, if they forget what year they are in they need to jump to the top of the table to find that information.

### Solution

The solution is very straight forward, we are just updating the default aria label of the day button to include the full year.

```diff
- <button aria-label="21st November (Monday)" {...} />
+ <button aria-label="21st November 2022 (Monday)" {...} />
```
