### PR TITLE
chore: Adding opacity to differentiate outside days

### DIFF
--- a/packages/react-day-picker/src/style.css
+++ b/packages/react-day-picker/src/style.css
@@ -274,6 +274,10 @@
   background-color: var(--rdp-accent-color);
 }
 
+.rdp-day_outside {
+  opacity: 0.5;
+}
+
 .rdp-day_selected:focus-visible {
   /* Since the background is the same use again the outline */
   outline: var(--rdp-outline);


### PR DESCRIPTION
closes #1591 

Explain the context of this Pull Request: why are you proposing this change? What is the issue? Include links to issues or discussions.

Steps
1.When showOutsideDays feature is enabled, outside days of the months looks no different than the selected month. This can cause some confusion to the user
2. Render DayPicker with showOutsideDays option
Expected behavior
If we add style to differentiate the days for outside month, users can find the difference between the selected month days against the outside days


Current behaviour
<img width="418" alt="Screen Shot 2022-10-28 at 7 10 38 AM" src="https://user-images.githubusercontent.com/116823465/198713569-fc6d3497-14e9-46ec-8c1d-11a507c0360e.png">

After fix 
<img width="342" alt="Screen Shot 2022-10-28 at 7 13 34 AM" src="https://user-images.githubusercontent.com/116823465/198713600-b821a92d-3f27-452a-9d13-aa87e9a472c3.png">



Solution
Add opacity as 0.5 for rdp-day_outside class
