### PR TITLE
fix(docs): minor typo in upgrading content

### DIFF
--- a/website/docs/guides/upgrading.md
+++ b/website/docs/guides/upgrading.md
@@ -1,6 +1,6 @@
 # Upgrading from v7
 
-v8 is a mayor upgrade for DayPicker with new props and styles. We include here a quick reference for helping the upgrade from v7.
+v8 is a major upgrade for DayPicker with new props and styles. We include here a quick reference for helping the upgrade from v7.
 
 :::note v7 is frozen
 


### PR DESCRIPTION
### Context

There is a minor typo on the v7 -> v8 upgrade docs, where "mayor" was used instead of "major". This PR corrects the typo on that documentation page.

Visible in the first paragraph sentence on https://react-day-picker.js.org/guides/upgrading

### Analysis

N/A

### Solution

Fix typo
