### PR TITLE
fix: matcherToArray should return a copy of the array

### DIFF
--- a/packages/react-day-picker/src/contexts/Modifiers/utils/matcherToArray.test.ts
+++ b/packages/react-day-picker/src/contexts/Modifiers/utils/matcherToArray.test.ts
@@ -10,8 +10,11 @@ describe('when a Matcher is passed in', () => {
 });
 
 describe('when an array of Matchers is passed in', () => {
-  test('should return the array', () => {
-    expect(matcherToArray([matcher])).toStrictEqual([matcher]);
+  test('should return a copy of the array', () => {
+    const value = [matcher, matcher];
+    const result = matcherToArray(value);
+    expect(result).toStrictEqual(value);
+    expect(result).not.toBe(value);
   });
 });
 

--- a/packages/react-day-picker/src/contexts/Modifiers/utils/matcherToArray.ts
+++ b/packages/react-day-picker/src/contexts/Modifiers/utils/matcherToArray.ts
@@ -5,7 +5,7 @@ export function matcherToArray(
   matcher: Matcher | Matcher[] | undefined
 ): Matcher[] {
   if (Array.isArray(matcher)) {
-    return matcher;
+    return [...matcher];
   } else if (matcher !== undefined) {
     return [matcher];
   } else {


### PR DESCRIPTION
Fix #1604 