### PR TITLE
docs: change example to use current year

### DIFF
--- a/website/examples/useinput.tsx
+++ b/website/examples/useinput.tsx
@@ -5,8 +5,8 @@ import { DayPicker, useInput } from 'react-day-picker';
 export default function App() {
   const { inputProps, dayPickerProps } = useInput({
     defaultSelected: new Date(),
-    fromYear: 2020,
-    toYear: 2022,
+    fromYear: 2021,
+    toYear: 2023,
     format: 'PP',
     required: true
   });


### PR DESCRIPTION
This seems like a good idea 😊
Bumped both years + 1, perhaps this should even be set to 2021 - 2025 so this will be relevant for a while.

### Context

Explain the context of this Pull Request: why are you proposing this change? What is the issue? Include links to issues or discussions.

### Analysis

Describe in details why the current code is not working as expected, or why you need to improve it.

### Solution

Explain the reasoning behind the changes implemented in this PR.
