### PR TITLE
Update range mode onSelect docs

### DIFF
--- a/website/docs/basics/selecting-days.md
+++ b/website/docs/basics/selecting-days.md
@@ -42,7 +42,7 @@ multiple-min-max
 
 ## Selecting a Range of days
 
-Use `mode="range"` and `onSelectRange` to allow the selection of multiple days.
+Use `mode="range"` and `onSelect` to allow the selection of multiple days.
 
 ```include-example
 range


### PR DESCRIPTION
### Context

In the docs, it is said that an "onSelectRange" prop is available for the range mode, however, such prop doesn't exist and instead "onSelect" can be used.