### PR TITLE
website(tests): wrap user events with `act`

### DIFF
--- a/packages/react-day-picker/test/utils/focusDaysGrid.ts
+++ b/packages/react-day-picker/test/utils/focusDaysGrid.ts
@@ -1,13 +1,14 @@
 import { fireEvent } from '@testing-library/dom';
+import { act } from '@testing-library/react';
 import { UserEvent } from '@testing-library/user-event/dist/types/setup/setup';
 
 import { getFocusedElement } from '../selectors';
 
 export async function focusDaysGrid(user: UserEvent) {
   // Make sure nothing is focused
-  await fireEvent.blur(getFocusedElement());
+  await act(() => fireEvent.blur(getFocusedElement()));
   // By pressing tab 3 times
-  await user.tab();
-  await user.tab();
-  await user.tab();
+  await act(() => user.tab());
+  await act(() => user.tab());
+  await act(() => user.tab());
 }

--- a/website/test-integration/examples/controlled.test.tsx
+++ b/website/test-integration/examples/controlled.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { axe } from '@site/test/axe';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { act } from 'react-dom/test-utils';
 
 import { getMonthCaption } from 'react-day-picker/test/selectors';
 import { freezeBeforeAll } from 'react-day-picker/test/utils';
@@ -26,7 +27,7 @@ test('should not have AXE violations', async () => {
 describe('when the "Go to today" button is clicked', () => {
   beforeEach(async () => {
     render(<Example />);
-    await user.click(getTodayButton());
+    await act(() => user.click(getTodayButton()));
   });
   test('the button should be disabled', async () => {
     expect(getTodayButton()).toBeDisabled();

--- a/website/test-integration/examples/custom-multiple.test.tsx
+++ b/website/test-integration/examples/custom-multiple.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { axe } from '@site/test/axe';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { act } from 'react-dom/test-utils';
 
 import { getDayButton, getTableFooter } from 'react-day-picker/test/selectors';
 import { freezeBeforeAll } from 'react-day-picker/test/utils';
@@ -24,7 +25,7 @@ test('should not have AXE violations', async () => {
 
 describe('when a day is clicked', () => {
   const day1 = new Date(2021, 10, 1);
-  beforeEach(() => user.click(getDayButton(day1)));
+  beforeEach(() => act(() => user.click(getDayButton(day1))));
   test('should appear as selected', () => {
     expect(getDayButton(day1)).toHaveAttribute('aria-selected', 'true');
   });
@@ -33,7 +34,7 @@ describe('when a day is clicked', () => {
   });
   describe('when a second day is clicked', () => {
     const day2 = new Date(2021, 10, 2);
-    beforeEach(() => user.click(getDayButton(day2)));
+    beforeEach(() => act(() => user.click(getDayButton(day2))));
     test('the first day should appear as selected', () => {
       expect(getDayButton(day1)).toHaveAttribute('aria-selected', 'true');
     });

--- a/website/test-integration/examples/custom-single.test.tsx
+++ b/website/test-integration/examples/custom-single.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { axe } from '@site/test/axe';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { act } from 'react-dom/test-utils';
 
 import { getDayButton, getTableFooter } from 'react-day-picker/test/selectors';
 import { freezeBeforeAll } from 'react-day-picker/test/utils';
@@ -24,7 +25,7 @@ test('should not have AXE violations', async () => {
 
 describe('when a day is clicked', () => {
   const day = new Date(2021, 10, 1);
-  beforeEach(() => user.click(getDayButton(day)));
+  beforeEach(() => act(() => user.click(getDayButton(day))));
   test('should appear as selected', () => {
     expect(getDayButton(day)).toHaveAttribute('aria-selected', 'true');
   });

--- a/website/test-integration/examples/date-picker-dialog.test.tsx
+++ b/website/test-integration/examples/date-picker-dialog.test.tsx
@@ -41,7 +41,7 @@ test('should not have AXE violations', async () => {
 
 describe('when clicking the dialog button', () => {
   beforeEach(async () => {
-    await user.click(getDialogButton());
+    await act(() => user.click(getDialogButton()));
     await waitPopper();
   });
   test('should not have AXE violations', async () => {
@@ -56,7 +56,7 @@ describe('when clicking the dialog button', () => {
   describe('when clicking a day', () => {
     const date = today;
     beforeEach(async () => {
-      await user.click(getDayButton(date));
+      await act(() => user.click(getDayButton(date)));
       await waitPopper();
     });
     test('should not have AXE violations', async () => {
@@ -71,8 +71,8 @@ describe('when clicking the dialog button', () => {
     describe('when typing a new date into the input', () => {
       const newDate = tomorrow;
       beforeEach(async () => {
-        await user.clear(getInput());
-        await user.type(getInput(), format(newDate, 'y-MM-dd'));
+        await act(() => user.clear(getInput()));
+        await act(() => user.type(getInput(), format(newDate, 'y-MM-dd')));
         await waitPopper();
       });
       test('should not have AXE violations', async () => {
@@ -83,7 +83,7 @@ describe('when clicking the dialog button', () => {
       });
       describe('when clicking the dialog button', () => {
         beforeEach(async () => {
-          await user.click(getDialogButton());
+          await act(() => user.click(getDialogButton()));
           await waitPopper();
         });
         test('the new date should be selected', () => {

--- a/website/test-integration/examples/dropdown-buttons.test.tsx
+++ b/website/test-integration/examples/dropdown-buttons.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
@@ -43,7 +43,9 @@ test('should render the previous month button', () => {
 
 describe('when choosing a month', () => {
   const monthName = 'January';
-  beforeEach(() => user.selectOptions(getMonthDropdown(), monthName));
+  beforeEach(() =>
+    act(() => user.selectOptions(getMonthDropdown(), monthName))
+  );
   test('should not have AXE violations', async () => {
     expect(await axe(container)).toHaveNoViolations();
   });

--- a/website/test-integration/examples/dropdown.test.tsx
+++ b/website/test-integration/examples/dropdown.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
@@ -33,7 +33,9 @@ test('should display the month dropdown', () => {
 
 describe('when choosing a month', () => {
   const monthName = 'January';
-  beforeEach(() => user.selectOptions(getMonthDropdown(), monthName));
+  beforeEach(() =>
+    act(() => user.selectOptions(getMonthDropdown(), monthName))
+  );
   test('should display the month', () => {
     expect(getMonthGrid()).toHaveAccessibleName(`${monthName} 2022`);
   });

--- a/website/test-integration/examples/focus-recursive.test.tsx
+++ b/website/test-integration/examples/focus-recursive.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
@@ -20,13 +20,13 @@ let container: HTMLElement;
 
 beforeEach(async () => {
   container = render(<Example />).container;
-  await user.tab();
-  await user.tab();
-  await user.tab();
-  await user.type(getFocusedElement(), '{arrowdown}');
-  await user.type(getFocusedElement(), '{arrowdown}');
-  await user.type(getFocusedElement(), '{arrowdown}');
-  await user.type(getFocusedElement(), '{arrowdown}');
+  await act(() => user.tab());
+  await act(() => user.tab());
+  await act(() => user.tab());
+  await act(() => user.type(getFocusedElement(), '{arrowdown}'));
+  await act(() => user.type(getFocusedElement(), '{arrowdown}'));
+  await act(() => user.type(getFocusedElement(), '{arrowdown}'));
+  await act(() => user.type(getFocusedElement(), '{arrowdown}'));
 });
 
 test('the first selected day should have focus', () => {

--- a/website/test-integration/examples/formatters.test.tsx
+++ b/website/test-integration/examples/formatters.test.tsx
@@ -13,8 +13,6 @@ beforeEach(() => {
   render(<Example />);
 });
 
-describe('when displaying November 2021', () => {
-  test('should display the autumn emoji', () => {
-    expect(screen.getByRole('img', { name: 'autumn' })).toBeInTheDocument();
-  });
+test('should display the autumn emoji', () => {
+  expect(screen.getByRole('img', { name: 'autumn' })).toBeInTheDocument();
 });

--- a/website/test-integration/examples/from-to-month.test.tsx
+++ b/website/test-integration/examples/from-to-month.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { differenceInMonths } from 'date-fns';
 
@@ -32,7 +32,7 @@ describe('when navigating to the last month', () => {
   const nOfMonths = differenceInMonths(toDate, fromDate);
   beforeEach(async () => {
     for (let i = 0; i < nOfMonths; i++) {
-      await user.click(getNextButton());
+      await act(() => user.click(getNextButton()));
     }
   });
 

--- a/website/test-integration/examples/from-to-year.test.tsx
+++ b/website/test-integration/examples/from-to-year.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { differenceInMonths } from 'date-fns';
 
@@ -33,7 +33,7 @@ describe('when navigating to the last month', () => {
   const nOfMonths = differenceInMonths(toDate, fromDate);
   beforeEach(async () => {
     for (let i = 0; i < nOfMonths; i++) {
-      await user.click(getNextButton());
+      await act(() => user.click(getNextButton()));
     }
   });
   test('should not have AXE violations', async () => {

--- a/website/test-integration/examples/keyboard-focus.test.tsx
+++ b/website/test-integration/examples/keyboard-focus.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { addDays, addMonths, startOfMonth } from 'date-fns';
 import { DayPickerProps } from 'react-day-picker';
@@ -32,7 +32,7 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
   describe('when pressing Tab', () => {
     beforeEach(async () => {
       setup({ mode: 'single', dir });
-      await user.tab();
+      await act(() => user.tab());
     });
     test('should not have AXE violations', async () => {
       expect(await axe(container)).toHaveNoViolations();
@@ -41,17 +41,17 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
       expect(getPrevButton()).toHaveFocus();
     });
     describe('when pressing Tab a second time', () => {
-      beforeEach(async () => user.tab());
+      beforeEach(async () => act(() => user.tab()));
       test('should focus on the Next Month button', () => {
         expect(getNextButton()).toHaveFocus();
       });
       describe('when pressing Tab a third time', () => {
-        beforeEach(async () => user.tab());
+        beforeEach(async () => act(() => user.tab()));
         test('should have the current day selected', () => {
           expect(getDayButton(today)).toHaveFocus();
         });
 
-        const tests: [key: string, handler: () => void][] = [
+        const tests: [key: string, handler: () => Promise<void>][] = [
           ['ArrowDown', () => user.type(getFocusedElement(), '{arrowdown}')],
           ['ArrowUp', () => user.type(getFocusedElement(), '{arrowup}')],
           ['ArrowLeft', () => user.type(getFocusedElement(), '{arrowleft}')],
@@ -59,17 +59,17 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
         ];
         describe.each(tests)(`when pressing %s`, (key, handler) => {
           let focusedElement: Element;
-          beforeEach(() => {
-            handler();
+          beforeEach(async () => {
+            await act(() => handler());
             focusedElement = getFocusedElement();
           });
           describe('when the next button is focused', () => {
-            beforeEach(() => getNextButton().focus());
+            beforeEach(() => act(() => getNextButton().focus()));
             test(`the element focused with ${key} should have lost the focus`, () => {
               expect(focusedElement).not.toHaveFocus();
             });
             describe('when pressing Tab', () => {
-              beforeEach(async () => user.tab());
+              beforeEach(async () => act(() => user.tab()));
               test(`the element focused with ${key} should have focus again`, () => {
                 expect(focusedElement).toHaveFocus();
               });
@@ -77,9 +77,9 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
           });
           describe('when navigating to the next month', () => {
             beforeEach(async () => {
-              await user.tab({ shift: true });
-              await user.keyboard('{enter}');
-              await user.tab();
+              await act(() => user.tab({ shift: true }));
+              await act(() => user.keyboard('{enter}'));
+              await act(() => user.tab());
             });
             test('the first active day of the next month should have focus', () => {
               const startOfNextMonth = startOfMonth(addMonths(today, 1));

--- a/website/test-integration/examples/keyboard.test.tsx
+++ b/website/test-integration/examples/keyboard.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   addDays,
@@ -42,13 +42,13 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
     expect(await axe(container)).toHaveNoViolations();
   });
   describe('when clicking the previous month button', () => {
-    beforeEach(async () => user.click(getPrevButton()));
+    beforeEach(async () => act(() => user.click(getPrevButton())));
     test('should display the previous month', () => {
       expect(getMonthCaption()).toHaveTextContent('May 2022');
     });
   });
   describe('when clicking the next month button', () => {
-    beforeEach(async () => user.click(getNextButton()));
+    beforeEach(async () => act(() => user.click(getNextButton())));
 
     test('should display the next month', () => {
       expect(getMonthCaption()).toHaveTextContent('July 2022');
@@ -68,12 +68,14 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
     const startOfWeekDay = startOfWeek(day);
     const endOfWeekDay = endOfWeek(day);
 
-    beforeEach(() => getDayButton(day).focus());
+    beforeEach(() => act(() => getDayButton(day).focus()));
     test('the day button should be focused', () => {
       expect(getFocusedElement()).toBe(getDayButton(day));
     });
     describe('when the Arrow Left is pressed', () => {
-      beforeEach(async () => user.type(getFocusedElement(), '{arrowleft}'));
+      beforeEach(async () =>
+        act(() => user.type(getFocusedElement(), '{arrowleft}'))
+      );
       if (dir === 'rtl') {
         test('should focus the next day', () => {
           expect(getDayButton(nextDay)).toHaveFocus();
@@ -88,7 +90,9 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
       }
     });
     describe('when the Arrow Right is pressed', () => {
-      beforeEach(async () => user.type(getFocusedElement(), '{arrowright}'));
+      beforeEach(async () =>
+        act(() => user.type(getFocusedElement(), '{arrowright}'))
+      );
       if (dir === 'rtl') {
         test('should display the previous month', () => {
           expect(getMonthCaption()).toHaveTextContent('May 2022');
@@ -103,7 +107,9 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
       }
     });
     describe('when the Arrow Up is pressed', () => {
-      beforeEach(async () => user.type(getFocusedElement(), '{arrowup}'));
+      beforeEach(async () =>
+        act(() => user.type(getFocusedElement(), '{arrowup}'))
+      );
       test('should display the previous month', () => {
         expect(getMonthCaption()).toHaveTextContent('May 2022');
       });
@@ -112,7 +118,9 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
       });
     });
     describe('when the Arrow Down is pressed', () => {
-      beforeEach(async () => user.type(getFocusedElement(), '{arrowdown}'));
+      beforeEach(async () =>
+        act(() => user.type(getFocusedElement(), '{arrowdown}'))
+      );
       test('should display the same month', () => {
         expect(getMonthCaption()).toHaveTextContent('June 2022');
       });
@@ -121,7 +129,9 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
       });
     });
     describe('when Page Up is pressed', () => {
-      beforeEach(async () => user.type(getFocusedElement(), '{pageup}'));
+      beforeEach(async () =>
+        act(() => user.type(getFocusedElement(), '{pageup}'))
+      );
       it('should display the previous month', () => {
         expect(getMonthCaption()).toHaveTextContent('May 2022');
       });
@@ -130,7 +140,9 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
       });
     });
     describe('when Page Down is pressed', () => {
-      beforeEach(async () => user.type(getFocusedElement(), '{pagedown}'));
+      beforeEach(async () =>
+        act(() => user.type(getFocusedElement(), '{pagedown}'))
+      );
       it('should display the next month', () => {
         expect(getMonthCaption()).toHaveTextContent('July 2022');
       });
@@ -139,8 +151,9 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
       });
     });
     describe('when Shift + Page Up is pressed', () => {
-      beforeEach(async () =>
-        user.type(getFocusedElement(), '{shift>}{pageup}')
+      beforeEach(
+        async () =>
+          await act(() => user.type(getFocusedElement(), '{shift>}{pageup}'))
       );
       it('should display the previous year', () => {
         expect(getMonthCaption()).toHaveTextContent('June 2021');
@@ -150,8 +163,9 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
       });
     });
     describe('when Shift + Page Down is pressed', () => {
-      beforeEach(async () =>
-        user.type(getFocusedElement(), '{shift>}{pagedown}')
+      beforeEach(
+        async () =>
+          await act(() => user.type(getFocusedElement(), '{shift>}{pagedown}'))
       );
       it('should display the next year', () => {
         expect(getMonthCaption()).toHaveTextContent('June 2023');
@@ -161,13 +175,17 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
       });
     });
     describe('when Home is pressed', () => {
-      beforeEach(async () => user.type(getFocusedElement(), '{home}'));
+      beforeEach(async () =>
+        act(() => user.type(getFocusedElement(), '{home}'))
+      );
       it('should focus the start of the week', () => {
         expect(getDayButton(startOfWeekDay)).toHaveFocus();
       });
     });
     describe('when End is pressed', () => {
-      beforeEach(async () => user.type(getFocusedElement(), '{end}'));
+      beforeEach(async () =>
+        act(() => user.type(getFocusedElement(), '{end}'))
+      );
       it('should focus the end of the week', () => {
         expect(getDayButton(endOfWeekDay)).toHaveFocus();
       });
@@ -179,9 +197,11 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
     const nextDay = addDays(day, 1);
     const prevDay = addDays(day, -1);
 
-    beforeEach(() => getDayButton(day).focus());
+    beforeEach(() => act(() => getDayButton(day).focus()));
     describe('when the Arrow Right is pressed', () => {
-      beforeEach(async () => user.type(getFocusedElement(), '{arrowright}'));
+      beforeEach(async () =>
+        act(() => user.type(getFocusedElement(), '{arrowright}'))
+      );
       if (dir === 'rtl') {
         test('should focus the previous day', () => {
           expect(getDayButton(prevDay)).toHaveFocus();
@@ -197,7 +217,9 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
       }
     });
     describe('when the Arrow Left is pressed', () => {
-      beforeEach(async () => user.type(getFocusedElement(), '{arrowleft}'));
+      beforeEach(async () =>
+        act(() => user.type(getFocusedElement(), '{arrowleft}'))
+      );
       if (dir === 'rtl') {
         test('should display the next month', () => {
           expect(getMonthCaption()).toHaveTextContent('July 2022');
@@ -216,7 +238,9 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
       }
     });
     describe('when the Arrow Up is pressed', () => {
-      beforeEach(async () => user.type(getFocusedElement(), '{arrowup}'));
+      beforeEach(async () =>
+        act(() => user.type(getFocusedElement(), '{arrowup}'))
+      );
       test('should display the same month', () => {
         expect(getMonthCaption()).toHaveTextContent('June 2022');
       });
@@ -226,7 +250,9 @@ describe.each(['ltr', 'rtl'])('when text direction is %s', (dir: string) => {
       });
     });
     describe('when the Arrow Down is pressed', () => {
-      beforeEach(async () => user.type(getFocusedElement(), '{arrowdown}'));
+      beforeEach(async () =>
+        act(() => user.type(getFocusedElement(), '{arrowdown}'))
+      );
       test('should display the next month', () => {
         expect(getMonthCaption()).toHaveTextContent('July 2022');
       });
@@ -247,17 +273,17 @@ describe('when week is set to start on a Monday', () => {
     setup({ mode: 'single', weekStartsOn: 1 });
   });
 
-  beforeEach(() => getDayButton(day).focus());
+  beforeEach(() => act(() => getDayButton(day).focus()));
 
   describe('when Home is pressed', () => {
-    beforeEach(async () => user.type(getFocusedElement(), '{home}'));
+    beforeEach(async () => act(() => user.type(getFocusedElement(), '{home}')));
     it('should focus the start of the week being Monday', () => {
       expect(getDayButton(startOfWeekDay)).toHaveFocus();
     });
   });
   describe('when End is pressed', () => {
     beforeEach(async () => {
-      await user.type(getFocusedElement(), '{end}');
+      await act(() => user.type(getFocusedElement(), '{end}'));
     });
     it('should focus the end of the week being Sunday', () => {
       expect(getDayButton(endOfWeekDay)).toHaveFocus();

--- a/website/test-integration/examples/modifiers-custom.test.tsx
+++ b/website/test-integration/examples/modifiers-custom.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { getDayButton, getTableFooter } from 'react-day-picker/test/selectors';
@@ -22,7 +22,7 @@ test.each(bookedDays)('%s should have the booked style', (day) => {
 
 describe('when the booked day is clicked', () => {
   beforeEach(async () => {
-    await user.click(getDayButton(bookedDays[1]));
+    await act(() => user.click(getDayButton(bookedDays[1])));
   });
   test('the footer should be updated', () => {
     expect(getTableFooter()).toHaveTextContent('This day is already booked!');

--- a/website/test-integration/examples/modifiers-today.test.tsx
+++ b/website/test-integration/examples/modifiers-today.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { addDays } from 'date-fns';
 
@@ -29,7 +29,7 @@ describe('when rendering a month that contains today', () => {
 });
 
 describe('when the today date is clicked', () => {
-  beforeEach(async () => user.click(getDayButton(today)));
+  beforeEach(async () => act(() => user.click(getDayButton(today))));
   test('should update the footer', () => {
     expect(getTableFooter()).toHaveTextContent('You clicked the today’s date');
   });
@@ -37,7 +37,7 @@ describe('when the today date is clicked', () => {
 
 describe('when another date is clicked', () => {
   const date = addDays(today, 1);
-  beforeEach(async () => user.click(getDayButton(date)));
+  beforeEach(async () => act(() => user.click(getDayButton(date))));
   test('should update the footer', () => {
     expect(getTableFooter()).toHaveTextContent(
       'Try clicking the today’s date.'

--- a/website/test-integration/examples/multiple-min-max.test.tsx
+++ b/website/test-integration/examples/multiple-min-max.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { addDays } from 'date-fns';
 
@@ -30,7 +30,7 @@ test('should not have AXE violations', async () => {
 });
 
 describe('when a day is clicked', () => {
-  beforeEach(async () => user.click(getDayButton(days[0])));
+  beforeEach(async () => act(() => user.click(getDayButton(days[0]))));
   test('should appear as selected', () => {
     expect(getDayButton(days[0])).toHaveAttribute('aria-selected', 'true');
   });
@@ -41,7 +41,7 @@ describe('when a day is clicked', () => {
     expect(await axe(container)).toHaveNoViolations();
   });
   describe('when a second day is clicked', () => {
-    beforeEach(async () => user.click(getDayButton(days[1])));
+    beforeEach(async () => act(() => user.click(getDayButton(days[1]))));
     test('the first day should appear as selected', () => {
       expect(getDayButton(days[0])).toHaveAttribute('aria-selected', 'true');
     });
@@ -55,7 +55,7 @@ describe('when a day is clicked', () => {
       expect(await axe(container)).toHaveNoViolations();
     });
     describe('when clicked again', () => {
-      beforeEach(async () => user.click(getDayButton(days[1])));
+      beforeEach(async () => act(() => user.click(getDayButton(days[1]))));
       test('the first day should still appear as selected', () => {
         expect(getDayButton(days[0])).toHaveAttribute('aria-selected', 'true');
       });
@@ -74,17 +74,17 @@ describe('when a day is clicked', () => {
 
 describe('when the first 5 days are clicked', () => {
   beforeEach(async () => {
-    const promises = [];
-    days.forEach((day) => promises.push(user.click(getDayButton(day))));
-    await Promise.all(promises);
+    await act(() => user.click(getDayButton(days[0])));
+    await act(() => user.click(getDayButton(days[1])));
+    await act(() => user.click(getDayButton(days[2])));
+    await act(() => user.click(getDayButton(days[3])));
+    await act(() => user.click(getDayButton(days[4])));
   });
   test.each(days)('the %s day should appear as selected', (day) => {
     expect(getDayButton(day)).toHaveAttribute('aria-selected', 'true');
   });
-  describe('when a sixth day is clicked', () => {
+  test('the sixth day should not appear as selected', () => {
     const day6 = addDays(today, 5);
-    test('it should not appear as selected', () => {
-      expect(getDayButton(day6)).not.toHaveAttribute('aria-selected');
-    });
+    expect(getDayButton(day6)).not.toHaveAttribute('aria-selected');
   });
 });

--- a/website/test-integration/examples/multiple-months-paged.test.tsx
+++ b/website/test-integration/examples/multiple-months-paged.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { getPrevButton } from 'react-day-picker/test/selectors';
@@ -35,7 +35,7 @@ describe('when rendering November 2021', () => {
   });
   // Test pagination
   describe('when the previous month button is clicked', () => {
-    beforeEach(async () => user.click(getPrevButton()));
+    beforeEach(async () => act(() => user.click(getPrevButton())));
     test('the first month should be October', () => {
       const grids = screen.getAllByRole('grid');
       expect(grids[0]).toHaveAccessibleName('September 2021');

--- a/website/test-integration/examples/multiple-months.test.tsx
+++ b/website/test-integration/examples/multiple-months.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { getPrevButton } from 'react-day-picker/test/selectors';
@@ -36,7 +36,7 @@ test('the second grid should be December', () => {
 
 // Test pagination
 describe('when the previous month button is clicked', () => {
-  beforeEach(async () => user.click(getPrevButton()));
+  beforeEach(async () => act(() => user.click(getPrevButton())));
   test('the first month should be October', () => {
     const grids = screen.getAllByRole('grid');
     expect(grids[0]).toHaveAccessibleName('October 2021');

--- a/website/test-integration/examples/multiple.test.tsx
+++ b/website/test-integration/examples/multiple.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { getDayButton, getTableFooter } from 'react-day-picker/test/selectors';
@@ -22,7 +22,7 @@ test('should not have AXE violations', async () => {
 
 describe('when a day is clicked', () => {
   const day1 = new Date(2021, 10, 1);
-  beforeEach(async () => user.click(getDayButton(day1)));
+  beforeEach(async () => act(() => user.click(getDayButton(day1))));
   test('should appear as selected', () => {
     expect(getDayButton(day1)).toHaveAttribute('aria-selected', 'true');
   });
@@ -31,7 +31,7 @@ describe('when a day is clicked', () => {
   });
   describe('when a second day is clicked', () => {
     const day2 = new Date(2021, 10, 2);
-    beforeEach(async () => user.click(getDayButton(day2)));
+    beforeEach(async () => act(() => user.click(getDayButton(day2))));
     test('the first day should appear as selected', () => {
       expect(getDayButton(day1)).toHaveAttribute('aria-selected', 'true');
     });

--- a/website/test-integration/examples/range-min-max.test.tsx
+++ b/website/test-integration/examples/range-min-max.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { setDate } from 'date-fns';
 
@@ -22,7 +22,7 @@ test('should not have AXE violations', async () => {
 
 describe('when the first day is clicked', () => {
   const fromDay = setDate(today, 14);
-  beforeEach(async () => user.click(getDayButton(fromDay)));
+  beforeEach(async () => act(() => user.click(getDayButton(fromDay))));
   test('the clicked day should be selected', () => {
     expect(getDayButton(fromDay)).toHaveAttribute('aria-selected', 'true');
   });

--- a/website/test-integration/examples/range-shift-key.test.tsx
+++ b/website/test-integration/examples/range-shift-key.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { getDayButton } from 'react-day-picker/test/selectors';
@@ -23,7 +23,7 @@ test('should not have AXE violations', async () => {
 describe('when displaying November 2021', () => {
   describe('when clicking on the 11th', () => {
     const day1 = new Date(2021, 10, 11);
-    beforeEach(async () => user.click(getDayButton(day1)));
+    beforeEach(async () => act(() => user.click(getDayButton(day1))));
     test('the 11th day should have aria-selected true', () => {
       expect(getDayButton(day1)).toHaveAttribute('aria-selected', 'true');
     });
@@ -32,7 +32,7 @@ describe('when displaying November 2021', () => {
     });
     describe('when clicking on the 13th', () => {
       const day2 = new Date(2021, 10, 13);
-      beforeEach(async () => user.click(getDayButton(day2)));
+      beforeEach(async () => act(() => user.click(getDayButton(day2))));
 
       test('the 11th day should still have aria-selected true', () => {
         expect(getDayButton(day1)).toHaveAttribute('aria-selected', 'true');
@@ -48,7 +48,7 @@ describe('when displaying November 2021', () => {
       const day2 = new Date(2021, 10, 13);
       beforeEach(async () => {
         user.keyboard('{Shift>}');
-        await user.click(getDayButton(day2));
+        await act(() => user.click(getDayButton(day2)));
       });
       test('the 13th day should have aria-selected true', () => {
         expect(getDayButton(day2)).toHaveAttribute('aria-selected', 'true');

--- a/website/test-integration/examples/range.test.tsx
+++ b/website/test-integration/examples/range.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { addDays } from 'date-fns';
 
@@ -38,7 +38,7 @@ test.each(days)('%s should be selected', (day) => {
 
 describe('when a day in the range is clicked', () => {
   const day = days[2];
-  beforeEach(async () => user.click(getDayButton(day)));
+  beforeEach(async () => act(() => user.click(getDayButton(day))));
   test.each([days[0], days[1], day])('%s should be selected', (day) => {
     expect(getDayButton(day)).toHaveAttribute('aria-selected', 'true');
   });
@@ -47,7 +47,7 @@ describe('when a day in the range is clicked', () => {
   });
   describe('when the day is clicked again', () => {
     const day = days[2];
-    beforeEach(async () => user.click(getDayButton(day)));
+    beforeEach(async () => act(() => user.click(getDayButton(day))));
     test('only one day should be selected', () => {
       expect(getAllSelectedDays()).toHaveLength(1);
     });
@@ -57,7 +57,7 @@ describe('when a day in the range is clicked', () => {
 
     describe('when a day in the range is clicked again', () => {
       const day = days[2];
-      beforeEach(async () => user.click(getDayButton(day)));
+      beforeEach(async () => act(() => user.click(getDayButton(day))));
       test('only one day should be selected', () => {
         expect(getAllSelectedDays()).toHaveLength(1);
       });

--- a/website/test-integration/examples/single-required.test.tsx
+++ b/website/test-integration/examples/single-required.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { getDayButton, getTableFooter } from 'react-day-picker/test/selectors';
@@ -22,7 +22,7 @@ test('should not have AXE violations', async () => {
 
 describe('when a day is clicked', () => {
   const day = new Date(2021, 10, 1);
-  beforeEach(async () => user.click(getDayButton(day)));
+  beforeEach(async () => act(() => user.click(getDayButton(day))));
   test('should appear as selected', () => {
     expect(getDayButton(day)).toHaveAttribute('aria-selected', 'true');
   });
@@ -32,7 +32,7 @@ describe('when a day is clicked', () => {
     );
   });
   describe('when the day is clicked again', () => {
-    beforeEach(async () => user.click(getDayButton(day)));
+    beforeEach(async () => act(() => user.click(getDayButton(day))));
     test('should appear as selected', () => {
       expect(getDayButton(day)).toHaveAttribute('aria-selected', 'true');
     });

--- a/website/test-integration/examples/single.test.tsx
+++ b/website/test-integration/examples/single.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { getDayButton, getTableFooter } from 'react-day-picker/test/selectors';
@@ -22,7 +22,7 @@ test('should not have AXE violations', async () => {
 
 describe('when a day is clicked', () => {
   const day = new Date(2021, 10, 1);
-  beforeEach(async () => user.click(getDayButton(day)));
+  beforeEach(async () => act(() => user.click(getDayButton(day))));
   test('should appear as selected', () => {
     expect(getDayButton(day)).toHaveAttribute('aria-selected', 'true');
   });
@@ -32,7 +32,7 @@ describe('when a day is clicked', () => {
     );
   });
   describe('when the day is clicked again', () => {
-    beforeEach(async () => user.click(getDayButton(day)));
+    beforeEach(async () => act(() => user.click(getDayButton(day))));
     test('should appear as not selected', () => {
       expect(getDayButton(day)).not.toHaveAttribute('aria-selected');
     });

--- a/website/test-integration/examples/start.test.tsx
+++ b/website/test-integration/examples/start.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { getDayButton, getTableFooter } from 'react-day-picker/test/selectors';
@@ -21,7 +21,7 @@ test('should not have AXE violations', async () => {
 });
 describe('when a day is clicked', () => {
   const day = new Date(2021, 10, 1);
-  beforeEach(async () => user.click(getDayButton(day)));
+  beforeEach(async () => act(() => user.click(getDayButton(day))));
   test('should appear as selected', () => {
     expect(getDayButton(day)).toHaveAttribute('aria-selected', 'true');
   });

--- a/website/test-integration/examples/testcase-1567.test.tsx
+++ b/website/test-integration/examples/testcase-1567.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import Example from '@examples/testcase-1567';
@@ -9,10 +9,10 @@ const user = userEvent.setup();
 
 beforeEach(async () => {
   render(<Example />);
-  await user.tab();
-  await user.tab();
-  await user.tab();
-  await user.tab();
+  await act(() => user.tab());
+  await act(() => user.tab());
+  await act(() => user.tab());
+  await act(() => user.tab());
 });
 
 test('the button should have focus', () => {

--- a/website/test-integration/examples/useinput.test.tsx
+++ b/website/test-integration/examples/useinput.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { addDays, format } from 'date-fns';
 
@@ -38,14 +38,14 @@ test('the input field should display today', () => {
 });
 
 describe('when yesterday is clicked', () => {
-  beforeEach(async () => user.click(getDayButton(yday)));
+  beforeEach(async () => act(() => user.click(getDayButton(yday))));
   test('the input field should display yesterday', () => {
     expect(getInput()).toHaveValue(format(yday, 'PP'));
   });
   describe('when today is typed in', () => {
     beforeEach(async () => {
-      await user.clear(getInput());
-      await user.type(getInput(), format(today, 'PP'));
+      await act(() => user.clear(getInput()));
+      await act(() => user.type(getInput(), format(today, 'PP')));
     });
     test('should not have AXE violations', async () => {
       expect(await axe(container)).toHaveNoViolations();
@@ -55,7 +55,7 @@ describe('when yesterday is clicked', () => {
     });
   });
   describe('when the input is cleared', () => {
-    beforeEach(async () => user.clear(getInput()));
+    beforeEach(async () => act(() => user.clear(getInput())));
     test('no day should be selected', () => {
       expect(getAllSelectedDays()).toHaveLength(0);
     });

--- a/website/test-integration/examples/weeknumber.test.tsx
+++ b/website/test-integration/examples/weeknumber.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { axe } from '@site/test/axe';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { getTableFooter, getWeekButton } from 'react-day-picker/test/selectors';
@@ -26,7 +26,7 @@ describe('when displaying November 2021', () => {
     expect(getWeekButton(45)).toBeInTheDocument();
   });
   describe('when the week button is clicked', () => {
-    beforeEach(async () => user.click(getWeekButton(45)));
+    beforeEach(async () => act(() => user.click(getWeekButton(45))));
     test('should update the footer', () => {
       expect(getTableFooter()).toHaveTextContent('You clicked the week n. 45.');
     });


### PR DESCRIPTION
The tests are throwing a lot of warning – I think after the changes to the focus provider., which for some reasons may cause extra rendering (see #1473). We will address that issue in another instance. For now, we want just clean the test logs.
