### PR TITLE
Only announce month when the month changes

### DIFF
--- a/packages/react-day-picker/src/components/CaptionLabel/CaptionLabel.tsx
+++ b/packages/react-day-picker/src/components/CaptionLabel/CaptionLabel.tsx
@@ -16,13 +16,14 @@ export function CaptionLabel(props: CaptionLabelProps): JSX.Element {
     locale,
     classNames,
     styles,
-    formatters: { formatCaption }
+    formatters: { formatCaption },
+    shouldAnnounceMonthChange
   } = useDayPicker();
   return (
     <div
       className={classNames.caption_label}
       style={styles.caption_label}
-      aria-live="polite"
+      aria-live={shouldAnnounceMonthChange ? 'polite' : undefined}
       role="presentation"
       id={props.id}
     >


### PR DESCRIPTION
__NOTE: Implemented this quick and dirty to gather feedback. Tests and types will be addressed separately.__

### Context/Analysis

aria-live as it is implemented currently causes usability issues for this component.

You cannot render it on a page without it interfering what the screen reader user will hear. `aria-live` forces the screen reader to be high-jacked by the content on this element regardless of the content order. This is a bad user experience. Instead, the sreen-reader should wait until the screen reader cursor reached the datepicker to announce this content. Additionally, announce it when the user interacts with the next and previous butons.

This causes accessibility issues for a number of use-cases where we defer the mounting of the datepicker.

1. Datepicker is in a modal
2. Datepicker is in a dropdown as part of a combobox
3. Virtualization -- when unmounting components that are out of the view to reduce DOM overhead.
.

### Solution

Only apply the `aria-live` property for a second after the month has changed.
