### PR TITLE
feat: add DropdownOption custom component

### DIFF
--- a/packages/react-day-picker/src/components/DropdownOption/DropdownOption.test.tsx
+++ b/packages/react-day-picker/src/components/DropdownOption/DropdownOption.test.tsx
@@ -1,14 +1,8 @@
 import React from 'react';
 
-import { fireEvent, render, screen } from '@testing-library/react';
-import { DayPickerProps } from 'DayPicker';
+import { render } from '@testing-library/react';
 
-import { customRender } from 'test/render';
 import { freezeBeforeAll } from 'test/utils';
-
-import { Dropdown, DropdownProps } from 'components/Dropdown';
-import { defaultClassNames } from 'contexts/DayPicker/defaultClassNames';
-import { CustomComponents } from 'types/DayPickerBase';
 
 import { DropdownOption } from './DropdownOption';
 
@@ -16,13 +10,14 @@ const today = new Date(2021, 8);
 
 freezeBeforeAll(today);
 
-function setup(props: DropdownProps, dayPickerProps?: DayPickerProps) {
-  customRender(<Dropdown {...props} />, dayPickerProps);
-}
-
 test('should match the snapshot', () => {
   const result = render(
-    <DropdownOption date={today} value={7} label="label as prop" />
+    <DropdownOption
+      date={today}
+      value={7}
+      label="label as prop"
+      type={'month'}
+    />
   );
   expect(result.container.firstChild).toMatchInlineSnapshot(`
     <option
@@ -36,7 +31,7 @@ test('should match the snapshot', () => {
 describe('when rendered with children', () => {
   test('should match the snapshot', () => {
     const result = render(
-      <DropdownOption date={today} value={7} label="label">
+      <DropdownOption date={today} value={7} label="label" type={'month'}>
         label as children
       </DropdownOption>
     );

--- a/packages/react-day-picker/src/components/DropdownOption/DropdownOption.test.tsx
+++ b/packages/react-day-picker/src/components/DropdownOption/DropdownOption.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { DayPickerProps } from 'DayPicker';
+
+import { customRender } from 'test/render';
+import { freezeBeforeAll } from 'test/utils';
+
+import { Dropdown, DropdownProps } from 'components/Dropdown';
+import { defaultClassNames } from 'contexts/DayPicker/defaultClassNames';
+import { CustomComponents } from 'types/DayPickerBase';
+
+import { DropdownOption } from './DropdownOption';
+
+const today = new Date(2021, 8);
+
+freezeBeforeAll(today);
+
+function setup(props: DropdownProps, dayPickerProps?: DayPickerProps) {
+  customRender(<Dropdown {...props} />, dayPickerProps);
+}
+
+test('should match the snapshot', () => {
+  const result = render(
+    <DropdownOption date={today} value={7} label="label as prop" />
+  );
+  expect(result.container.firstChild).toMatchInlineSnapshot(`
+    <option
+      value="7"
+    >
+      label as prop
+    </option>
+  `);
+});
+
+describe('when rendered with children', () => {
+  test('should match the snapshot', () => {
+    const result = render(
+      <DropdownOption date={today} value={7} label="label">
+        label as children
+      </DropdownOption>
+    );
+    expect(result.container.firstChild).toMatchInlineSnapshot(`
+      <option
+        value="7"
+      >
+        label as children
+      </option>
+    `);
+  });
+});

--- a/packages/react-day-picker/src/components/DropdownOption/DropdownOption.tsx
+++ b/packages/react-day-picker/src/components/DropdownOption/DropdownOption.tsx
@@ -2,13 +2,18 @@ import React from 'react';
 
 /** The props for the {@link DropdownOption} component. */
 export interface DropdownOptionProps {
+  /** Whether used in the month or year dropdown. */
+  type: 'month' | 'year';
   /** The month or the year represented by this option. */
   date: Date;
   /** The value of the option (e.g. the month or the year). */
   value: string | number;
   /** The label of the option. */
   label?: string | undefined;
-  /** Use `children` instead of `label` to render a React node. */
+  /**
+   * Use `children` instead of `label` to render a React node.
+   * @deprecated Use `label` instead.
+   */
   children?: React.ReactNode | undefined;
 }
 

--- a/packages/react-day-picker/src/components/DropdownOption/DropdownOption.tsx
+++ b/packages/react-day-picker/src/components/DropdownOption/DropdownOption.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+/** The props for the {@link DropdownOption} component. */
+export interface DropdownOptionProps {
+  /** The month or the year represented by this option. */
+  date: Date;
+  /** The value of the option (e.g. the month or the year). */
+  value: string | number;
+  /** The label of the option. */
+  label?: string | undefined;
+  /** Use `children` instead of `label` to render a React node. */
+  children?: React.ReactNode | undefined;
+}
+
+/**
+ * Render the option for the {@link Dropdown} component.
+ */
+export function DropdownOption(props: DropdownOptionProps): JSX.Element {
+  return <option value={props.value}>{props.children || props.label}</option>;
+}

--- a/packages/react-day-picker/src/components/DropdownOption/index.ts
+++ b/packages/react-day-picker/src/components/DropdownOption/index.ts
@@ -1,0 +1,1 @@
+export * from './DropdownOption';

--- a/packages/react-day-picker/src/components/MonthsDropdown/MonthsDropdown.tsx
+++ b/packages/react-day-picker/src/components/MonthsDropdown/MonthsDropdown.tsx
@@ -70,6 +70,7 @@ export function MonthsDropdown(props: MonthsDropdownProps): JSX.Element {
         const label = formatMonthCaption(m, { locale });
         return (
           <OptionComponent
+            type="month"
             key={m.getMonth()}
             value={m.getMonth()}
             label={typeof label === 'string' ? label : undefined}

--- a/packages/react-day-picker/src/components/MonthsDropdown/MonthsDropdown.tsx
+++ b/packages/react-day-picker/src/components/MonthsDropdown/MonthsDropdown.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { isSameYear, setMonth, startOfMonth } from 'date-fns';
 
 import { Dropdown } from 'components/Dropdown';
+import { DropdownOption } from 'components/DropdownOption';
 import { useDayPicker } from 'contexts/DayPicker';
 import { MonthChangeEventHandler } from 'types/EventHandlers';
 
@@ -53,6 +54,7 @@ export function MonthsDropdown(props: MonthsDropdownProps): JSX.Element {
   };
 
   const DropdownComponent = components?.Dropdown ?? Dropdown;
+  const OptionComponent = components?.DropdownOption ?? DropdownOption;
 
   return (
     <DropdownComponent
@@ -64,11 +66,19 @@ export function MonthsDropdown(props: MonthsDropdownProps): JSX.Element {
       value={props.displayMonth.getMonth()}
       caption={formatMonthCaption(props.displayMonth, { locale })}
     >
-      {dropdownMonths.map((m) => (
-        <option key={m.getMonth()} value={m.getMonth()}>
-          {formatMonthCaption(m, { locale })}
-        </option>
-      ))}
+      {dropdownMonths.map((m) => {
+        const label = formatMonthCaption(m, { locale });
+        return (
+          <OptionComponent
+            key={m.getMonth()}
+            value={m.getMonth()}
+            label={typeof label === 'string' ? label : undefined}
+            date={m}
+          >
+            {label}
+          </OptionComponent>
+        );
+      })}
     </DropdownComponent>
   );
 }

--- a/packages/react-day-picker/src/components/YearsDropdown/YearsDropdown.tsx
+++ b/packages/react-day-picker/src/components/YearsDropdown/YearsDropdown.tsx
@@ -68,7 +68,7 @@ export function YearsDropdown(props: YearsDropdownProps): JSX.Element {
       caption={formatYearCaption(displayMonth, { locale })}
     >
       {years.map((year) => {
-        const label = formatYearCaption(m, { locale });
+        const label = formatYearCaption(year, { locale });
         return (
           <OptionComponent
             key={year.getFullYear()}

--- a/packages/react-day-picker/src/components/YearsDropdown/YearsDropdown.tsx
+++ b/packages/react-day-picker/src/components/YearsDropdown/YearsDropdown.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { setYear, startOfMonth, startOfYear } from 'date-fns';
 
 import { Dropdown } from 'components/Dropdown';
+import { DropdownOption } from 'components/DropdownOption';
 import { useDayPicker } from 'contexts/DayPicker';
 import { MonthChangeEventHandler } from 'types/EventHandlers';
 
@@ -54,6 +55,7 @@ export function YearsDropdown(props: YearsDropdownProps): JSX.Element {
   };
 
   const DropdownComponent = components?.Dropdown ?? Dropdown;
+  const OptionComponent = components?.DropdownOption ?? DropdownOption;
 
   return (
     <DropdownComponent
@@ -65,11 +67,19 @@ export function YearsDropdown(props: YearsDropdownProps): JSX.Element {
       value={displayMonth.getFullYear()}
       caption={formatYearCaption(displayMonth, { locale })}
     >
-      {years.map((year) => (
-        <option key={year.getFullYear()} value={year.getFullYear()}>
-          {formatYearCaption(year, { locale })}
-        </option>
-      ))}
+      {years.map((year) => {
+        const label = formatYearCaption(m, { locale });
+        return (
+          <OptionComponent
+            key={year.getFullYear()}
+            value={year.getFullYear()}
+            label={typeof label === 'string' ? label : undefined}
+            date={year}
+          >
+            {label}
+          </OptionComponent>
+        );
+      })}
     </DropdownComponent>
   );
 }

--- a/packages/react-day-picker/src/components/YearsDropdown/YearsDropdown.tsx
+++ b/packages/react-day-picker/src/components/YearsDropdown/YearsDropdown.tsx
@@ -71,6 +71,7 @@ export function YearsDropdown(props: YearsDropdownProps): JSX.Element {
         const label = formatYearCaption(year, { locale });
         return (
           <OptionComponent
+            type="year"
             key={year.getFullYear()}
             value={year.getFullYear()}
             label={typeof label === 'string' ? label : undefined}

--- a/packages/react-day-picker/src/index.ts
+++ b/packages/react-day-picker/src/index.ts
@@ -9,6 +9,7 @@ export * from 'components/CaptionNavigation';
 export * from 'components/Day';
 export * from 'components/DayContent';
 export * from 'components/Dropdown';
+export * from 'components/DropdownOption';
 export * from 'components/Footer';
 export * from 'components/Head';
 export * from 'components/HeadRow';

--- a/packages/react-day-picker/src/types/DayPickerBase.ts
+++ b/packages/react-day-picker/src/types/DayPickerBase.ts
@@ -5,6 +5,7 @@ import { CaptionLabelProps } from 'components/CaptionLabel';
 import { DayProps } from 'components/Day';
 import { DayContentProps } from 'components/DayContent';
 import { DropdownProps } from 'components/Dropdown';
+import { DropdownOptionProps } from 'components/DropdownOption';
 import { FooterProps } from 'components/Footer';
 import { RowProps } from 'components/Row';
 import { WeekNumberProps } from 'components/WeekNumber';
@@ -323,8 +324,10 @@ export interface CustomComponents {
   Day?: (props: DayProps) => JSX.Element | null;
   /** The component for the content of the day element. */
   DayContent?: (props: DayContentProps) => JSX.Element | null;
-  /** The component for the drop-down elements. */
+  /** The component for the drop-down elements used to change the month or the year. As default, a `select` element is used. */
   Dropdown?: (props: DropdownProps) => JSX.Element | null;
+  /** The component for the drop-down options.  */
+  DropdownOption?: (props: DropdownOptionProps) => JSX.Element | null;
   /** The component for the table footer. */
   Footer?: (props: FooterProps) => JSX.Element | null;
   /** The component for the table’s head. */

--- a/packages/react-day-picker/src/types/Formatters.ts
+++ b/packages/react-day-picker/src/types/Formatters.ts
@@ -4,7 +4,7 @@ import React from 'react';
 export type DateFormatter = (
   date: Date,
   options?: { locale?: Locale }
-) => React.ReactNode;
+) => string | React.ReactNode;
 
 /** Represent a map of formatters used to render localized content. */
 export type Formatters = {


### PR DESCRIPTION
### Context

Users of DayPicker may choose to implement a custom select for the months, years dropdowns. Some of these components (such as the [RadixUI select)](https://www.radix-ui.com/docs/primitives/components/select)) don't work with the `<option>` HTML element, rendered by default when using a custom `Dropwdown`.

### Analysis

The year and month dropdowns implements an HTML `option` element:

https://github.com/gpbl/react-day-picker/blob/a6ac2e3d46a8baaa74280b62c9494a6abf3896d6/packages/react-day-picker/src/components/YearsDropdown/YearsDropdown.tsx#L69-L71

https://github.com/gpbl/react-day-picker/blob/a6ac2e3d46a8baaa74280b62c9494a6abf3896d6/packages/react-day-picker/src/components/MonthsDropdown/MonthsDropdown.tsx#L68-L70

### Solution

- I've added a `DropdownOption` custom component replacing the `option` element, if passed with the `components` prop. 
- This uses some more props, such as `date`, `type` and `label` that may be useful when using a custom component.
- To keep backward compatibility, I've changed the `DateFormatter` to return a `string` type as well.

### Example

```tsx
<DayPicker
  components={{
    DropdownOption: (props) => <CustomOption {...props} />
  }}

```