### PR TITLE
docs: remove shadow-dom from examples

### DIFF
--- a/website/examples/date-picker-dialog.tsx
+++ b/website/examples/date-picker-dialog.tsx
@@ -53,22 +53,19 @@ export default function DatePickerDialog() {
     <div>
       <div ref={popperRef}>
         <input
+          size={12}
           type="text"
           placeholder={format(new Date(), 'y-MM-dd')}
           value={inputValue}
           onChange={handleInputChange}
-          className="input-reset pa2 ma2 bg-white black ba"
         />
         <button
           ref={buttonRef}
           type="button"
-          className="pa2 bg-white button-reset ba"
           aria-label="Pick a date"
           onClick={handleButtonClick}
         >
-          <span role="img" aria-label="calendar icon">
-            📅
-          </span>
+          Pick a date
         </button>
       </div>
       {isPopperOpen && (

--- a/website/examples/input-range.tsx
+++ b/website/examples/input-range.tsx
@@ -67,7 +67,6 @@ export default function App() {
             placeholder="From Date"
             value={fromValue}
             onChange={handleFromChange}
-            className="input-reset pa2 ma bg-white black ba"
           />
           {' – '}
           <input
@@ -75,7 +74,6 @@ export default function App() {
             placeholder="To Date"
             value={toValue}
             onChange={handleToChange}
-            className="input-reset pa2 bg-white black ba"
           />
         </form>
       }

--- a/website/examples/useinput.tsx
+++ b/website/examples/useinput.tsx
@@ -14,10 +14,7 @@ export default function App() {
   const footer = (
     <form>
       <label>
-        <input
-          {...inputProps}
-          className="input-reset pa2 ma2 bg-white black ba"
-        />
+        <input {...inputProps} />
       </label>
     </form>
   );

--- a/website/package.json
+++ b/website/package.json
@@ -27,8 +27,7 @@
     "react": "^18.2.0",
     "react-day-picker": "workspace:^",
     "react-dom": "^18.2.0",
-    "react-popper": "^2.3.0",
-    "react-shadow": "^20.0.0"
+    "react-popper": "^2.3.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^2.4.0",

--- a/website/src/components/RenderExample.module.css
+++ b/website/src/components/RenderExample.module.css
@@ -1,0 +1,12 @@
+.example {
+  padding: 1em;
+}
+.example input {
+  font-size: 1em;
+  padding: 0.4em 0.6em;
+}
+
+.example button {
+  font-size: 1em;
+  padding: 0.4em 0.6em;
+}

--- a/website/src/components/RenderExample.module.css
+++ b/website/src/components/RenderExample.module.css
@@ -10,3 +10,6 @@
   font-size: 1em;
   padding: 0.4em 0.6em;
 }
+.example input + button {
+  margin-left: 0.5em;
+}

--- a/website/src/components/RenderExample.tsx
+++ b/website/src/components/RenderExample.tsx
@@ -1,51 +1,10 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 import React from 'react';
-
-import BrowserOnly from '@docusaurus/BrowserOnly';
-import { useColorMode } from '@docusaurus/theme-common';
-import root from 'react-shadow';
 
 export function RenderExample(props: {
   name: string;
   rootStyle?: React.CSSProperties;
 }) {
-  const isDarkTheme = useColorMode().colorMode === 'dark';
-  return (
-    <BrowserOnly>
-      {() => {
-        try {
-          require(`@site/examples/${props.name}`).default;
-        } catch (e) {
-          return <pre>{e.message}</pre>;
-        }
-        const Component = require(`@site/examples/${props.name}`).default;
-
-        const style: string =
-          require(`!raw-loader!./shadow-dom-styles.css`).default;
-        const styleDark: string =
-          require(`!raw-loader!./shadow-dom-styles-dark.css`).default;
-        const libStyle: string =
-          require(`!raw-loader!react-day-picker/dist/style.css`).default;
-        const libStyleModule =
-          require(`react-day-picker/dist/style.module.css`).default;
-
-        let libStyleModuleRaw: string =
-          require(`!raw-loader!react-day-picker/dist/style.module.css`).default;
-        Object.entries(libStyleModule).map(([key, value]) => {
-          const regExp = new RegExp(`\\.${key}([,: .])+`, 'g');
-          libStyleModuleRaw = libStyleModuleRaw.replace(regExp, `.${value}$1`);
-        });
-
-        return (
-          <root.div style={props.rootStyle}>
-            <style type="text/css">{libStyle}</style>
-            <style type="text/css">{libStyleModuleRaw}</style>
-            <style type="text/css">{style}</style>
-            <style type="text/css">{isDarkTheme && styleDark}</style>
-            <Component />
-          </root.div>
-        );
-      }}
-    </BrowserOnly>
-  );
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const Component = require(`@site/examples/${props.name}`).default;
+  return <Component />;
 }

--- a/website/src/components/RenderExample.tsx
+++ b/website/src/components/RenderExample.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 
+import styles from './RenderExample.module.css';
+
 export function RenderExample(props: {
   name: string;
   rootStyle?: React.CSSProperties;
 }) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const Component = require(`@site/examples/${props.name}`).default;
-  return <Component />;
+  return (
+    <div className={styles.example}>
+      <Component />
+    </div>
+  );
 }

--- a/website/src/components/shadow-dom-styles-dark.css
+++ b/website/src/components/shadow-dom-styles-dark.css
@@ -1,6 +1,0 @@
-.rdp {
-  --rdp-background-color: var(--rdp-background-color-dark);
-  --rdp-accent-color-light: var(--rdp-accent-color-dark);
-  --rdp-accent-color-lighter: var(--rdp-accent-color-darker);
-  --rdp-accent-color-lightest: var(--rdp-accent-color-darkest);
-}

--- a/website/src/components/shadow-dom-styles.css
+++ b/website/src/components/shadow-dom-styles.css
@@ -1,8 +1,0 @@
-.shadowRoot {
-  background-color: white;
-  overflow: auto;
-}
-
-html[data-theme='dark'] .shadowRoot {
-  color: white;
-}

--- a/website/src/custom.css
+++ b/website/src/custom.css
@@ -211,3 +211,56 @@ html[data-theme='dark'] .dialog-sheet {
 }
 
 /* #endregion */
+
+/* Remove CSS pollution from docusaurus. See https://github.com/facebook/docusaurus/issues/6032 */
+.rdp {
+  box-sizing: revert;
+}
+.rdp-table {
+  border-collapse: revert;
+  display: revert;
+  margin-bottom: revert;
+  overflow: revert;
+}
+
+.rdp-table tr:nth-child(2n) {
+  background-color: revert;
+}
+
+.rdp-head {
+  background-color: revert;
+}
+.rdp-head_row {
+  border-bottom: revert;
+  background-color: revert;
+  border-top: revert;
+}
+
+.rdp-head_cell {
+  font: revert;
+  color: revert;
+  background-color: revert;
+  border: revert;
+}
+
+.rdp-table tr,
+.rdp-row {
+  background-color: revert;
+  border-top: revert;
+}
+
+.rdp-table td {
+  border: revert;
+  padding: revert;
+  color: revert;
+}
+
+.rdp p {
+  margin: revert;
+}
+
+.rdp-cell {
+  color: revert;
+  border: revert;
+  background-color: revert;
+}

--- a/website/src/theme/CodeBlock/sandpack-app/dark.css
+++ b/website/src/theme/CodeBlock/sandpack-app/dark.css
@@ -1,4 +1,5 @@
 body {
+  margin: 1em;
   font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Ubuntu, Cantarell,
     'Noto Sans', sans-serif, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
@@ -10,6 +11,18 @@ body {
   -webkit-touch-callout: none;
   background-color: #191c1f;
   color: #f5f6f7;
+}
+
+input {
+  font-size: 1em;
+  padding: 0.4em 0.6em;
+}
+button {
+  font-size: 1em;
+  padding: 0.4em 0.6em;
+}
+input + button {
+  margin-left: 0.5em;
 }
 
 .rdp {

--- a/website/src/theme/CodeBlock/sandpack-app/light.css
+++ b/website/src/theme/CodeBlock/sandpack-app/light.css
@@ -1,4 +1,5 @@
 body {
+  margin: 1em;
   font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Ubuntu, Cantarell,
     'Noto Sans', sans-serif, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
@@ -16,4 +17,16 @@ body {
   border-radius: 4px;
   box-shadow: 0px 1px 10px rgba(0, 0, 0, 0.04), 0px 4px 5px rgba(0, 0, 0, 0.06),
     0px 2px 4px -1px rgba(0, 0, 0, 0.09);
+}
+input {
+  font-size: 1em;
+  padding: 0.4em 0.6em;
+}
+button {
+  font-size: 1em;
+  padding: 0.4em 0.6em;
+}
+
+input + button {
+  margin-left: 0.5em;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5288,13 +5288,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/js-cookie@npm:^2.2.6":
-  version: 2.2.7
-  resolution: "@types/js-cookie@npm:2.2.7"
-  checksum: 851f47e94ca1fc43661d8f51614d67a613e7810c91b876d0a3b311ce72f7df800107fd02a08cb6948184e12c120b4f058edca2f50424d8798bdcffd6627281e3
-  languageName: node
-  linkType: hard
-
 "@types/jsdom@npm:^20.0.0":
   version: 20.0.0
   resolution: "@types/jsdom@npm:20.0.0"
@@ -6153,13 +6146,6 @@ __metadata:
     "@webassemblyjs/ast": 1.11.5
     "@xtuc/long": 4.2.2
   checksum: c2995224c56b403be7fce7afbb3ad6b2ceadce07a47b28bce745eabb0435fa363c0180bca907d28703ece02422d0de219e689253b55de288c79b8f92416c1d71
-  languageName: node
-  linkType: hard
-
-"@xobotyi/scrollbar-width@npm:^1.9.5":
-  version: 1.9.5
-  resolution: "@xobotyi/scrollbar-width@npm:1.9.5"
-  checksum: e880c8696bd6c7eedaad4e89cc7bcfcd502c22dc6c061288ffa7f5a4fe5dab4aa2358bdd68e7357bf0334dc8b56724ed9bee05e010b60d83a3bb0d855f3d886f
   languageName: node
   linkType: hard
 
@@ -7814,15 +7800,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"copy-to-clipboard@npm:^3.3.1":
-  version: 3.3.3
-  resolution: "copy-to-clipboard@npm:3.3.3"
-  dependencies:
-    toggle-selection: ^1.0.6
-  checksum: e0a325e39b7615108e6c1c8ac110ae7b829cdc4ee3278b1df6a0e4228c490442cc86444cd643e2da344fbc424b3aab8909e2fec82f8bc75e7e5b190b7c24eecf
-  languageName: node
-  linkType: hard
-
 "copy-webpack-plugin@npm:^11.0.0":
   version: 11.0.0
   resolution: "copy-webpack-plugin@npm:11.0.0"
@@ -7971,16 +7948,6 @@ __metadata:
   peerDependencies:
     postcss: ^8.0.9
   checksum: ff0d9989ee21ec4c42430b9bb86c43f973ed5024d68f30edc1e3fb07a22828ce3c3e5b922019f2ccbff606722e43c407c5c76e3cddac523ac4afcb31e4b2601c
-  languageName: node
-  linkType: hard
-
-"css-in-js-utils@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "css-in-js-utils@npm:2.0.1"
-  dependencies:
-    hyphenate-style-name: ^1.0.2
-    isobject: ^3.0.1
-  checksum: c9964c4708216954c468b69bbee2d971fd759ada4f40637b8ca4d3f79caba4818d0532a4f190ac560227c08742ad063ffec7a30afddc4d96b66a18c3a008f0d8
   languageName: node
   linkType: hard
 
@@ -8310,13 +8277,6 @@ __metadata:
   version: 3.0.10
   resolution: "csstype@npm:3.0.10"
   checksum: 20a8fa324f2b33ddf94aa7507d1b6ab3daa6f3cc308888dc50126585d7952f2471de69b2dbe0635d1fdc31223fef8e070842691877e725caf456e2378685a631
-  languageName: node
-  linkType: hard
-
-"csstype@npm:^3.0.6":
-  version: 3.1.0
-  resolution: "csstype@npm:3.1.0"
-  checksum: 644e986cefab86525f0b674a06889cfdbb1f117e5b7d1ce0fc55b0423ecc58807a1ea42ecc75c4f18999d14fc42d1d255f84662a45003a52bb5840e977eb2ffd
   languageName: node
   linkType: hard
 
@@ -8985,15 +8945,6 @@ __metadata:
   dependencies:
     is-arrayish: ^0.2.1
   checksum: c1c2b8b65f9c91b0f9d75f0debaa7ec5b35c266c2cac5de412c1a6de86d4cbae04ae44e510378cb14d032d0645a36925d0186f8bb7367bcc629db256b743a001
-  languageName: node
-  linkType: hard
-
-"error-stack-parser@npm:^2.0.6":
-  version: 2.1.4
-  resolution: "error-stack-parser@npm:2.1.4"
-  dependencies:
-    stackframe: ^1.3.4
-  checksum: 3b916d2d14c6682f287c8bfa28e14672f47eafe832701080e420e7cdbaebb2c50293868256a95706ac2330fe078cf5664713158b49bc30d7a5f2ac229ded0e18
   languageName: node
   linkType: hard
 
@@ -9749,26 +9700,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-shallow-equal@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "fast-shallow-equal@npm:1.0.0"
-  checksum: ae89318ce43c0c46410d9511ac31520d59cfe675bad3d0b1cb5f900b2d635943d788b8370437178e91ae0d0412decc394229c03e69925ade929a8c02da241610
-  languageName: node
-  linkType: hard
-
 "fast-url-parser@npm:1.1.3":
   version: 1.1.3
   resolution: "fast-url-parser@npm:1.1.3"
   dependencies:
     punycode: ^1.3.2
   checksum: 5043d0c4a8d775ff58504d56c096563c11b113e4cb8a2668c6f824a1cd4fb3812e2fdf76537eb24a7ce4ae7def6bd9747da630c617cf2a4b6ce0c42514e4f21c
-  languageName: node
-  linkType: hard
-
-"fastest-stable-stringify@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "fastest-stable-stringify@npm:2.0.2"
-  checksum: 5e2cb166c7bb6f16ac25a1e4be17f6b8d2923234c80739e12c9d21dea376b3128b2c63f90aa2aae7746cfec4dcf188d1d4eb6a964bb484ca133f17c8e9acfacc
   languageName: node
   linkType: hard
 
@@ -11045,20 +10982,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"humps@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "humps@npm:2.0.1"
-  checksum: 7d5a674cfca2f34c04562f6fd0d129b4c43a5caf85fcc1c9eacf5d0729554c9375db362c4232519b37369c94dd2560d85f96ad4091a8fbf4af4e625ab5214a30
-  languageName: node
-  linkType: hard
-
-"hyphenate-style-name@npm:^1.0.2":
-  version: 1.0.4
-  resolution: "hyphenate-style-name@npm:1.0.4"
-  checksum: 4f5bf4b055089754924babebaa23c17845937bcca6aee95d5d015f8fa1e6814279002bd6a9e541e3fac2cd02519fc76305396727066c57c8e21a7e73e7a12137
-  languageName: node
-  linkType: hard
-
 "iconv-lite@npm:0.4.24":
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
@@ -11258,15 +11181,6 @@ __metadata:
   version: 0.1.1
   resolution: "inline-style-parser@npm:0.1.1"
   checksum: 5d545056a3e1f2bf864c928a886a0e1656a3517127d36917b973de581bd54adc91b4bf1febcb0da054f204b4934763f1a4e09308b4d55002327cf1d48ac5d966
-  languageName: node
-  linkType: hard
-
-"inline-style-prefixer@npm:^6.0.0":
-  version: 6.0.1
-  resolution: "inline-style-prefixer@npm:6.0.1"
-  dependencies:
-    css-in-js-utils: ^2.0.0
-  checksum: 0bfa6fa89faa21e425c71425910c37c7b35a16ea753586c408fcc9246c84937c1b8184e6ce792139cda5de5cce8e1bc9eb0ba9f30968bdc97e7a06ece21c0737
   languageName: node
   linkType: hard
 
@@ -12521,13 +12435,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "js-cookie@npm:2.2.1"
-  checksum: 9b1fb980a1c5e624fd4b28ea4867bb30c71e04c4484bb3a42766344c533faa684de9498e443425479ec68609e96e27b60614bfe354877c449c631529b6d932f2
-  languageName: node
-  linkType: hard
-
 "js-sdsl@npm:^4.1.4":
   version: 4.1.5
   resolution: "js-sdsl@npm:4.1.5"
@@ -13505,25 +13412,6 @@ __metadata:
   version: 2.1.9
   resolution: "mylas@npm:2.1.9"
   checksum: 5339f9009bc931c7f5a22991e4965839c503a29d4b2e2159af23119d09724188ac704e3bb0d53bb8a161e106c3d19d8bcd78bae727b287cbe07bd269254f4eb9
-  languageName: node
-  linkType: hard
-
-"nano-css@npm:^5.3.1":
-  version: 5.3.5
-  resolution: "nano-css@npm:5.3.5"
-  dependencies:
-    css-tree: ^1.1.2
-    csstype: ^3.0.6
-    fastest-stable-stringify: ^2.0.2
-    inline-style-prefixer: ^6.0.0
-    rtl-css-js: ^1.14.0
-    sourcemap-codec: ^1.4.8
-    stacktrace-js: ^2.0.2
-    stylis: ^4.0.6
-  peerDependencies:
-    react: "*"
-    react-dom: "*"
-  checksum: 8d4e59a2a29477221af47320d850a7dcee1ac51774fb5a0dce6ee59b22174c7149f75108235de85559581fbb2b93aa222a2b32ea53c93ba3f5d322c4d098c355
   languageName: node
   linkType: hard
 
@@ -15601,20 +15489,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-shadow@npm:^20.0.0":
-  version: 20.0.0
-  resolution: "react-shadow@npm:20.0.0"
-  dependencies:
-    humps: ^2.0.1
-    react-use: ^17.0.0
-  peerDependencies:
-    prop-types: ^15.0.0
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: 4cccb89c83f8fe2e38ca2c45f0575ba60b34d936647e9b8484e0d16b6d257ba62e6ada777588d8e73167f97c817da2c8e93290659235c534a0422359d7da156b
-  languageName: node
-  linkType: hard
-
 "react-textarea-autosize@npm:^8.3.2":
   version: 8.3.3
   resolution: "react-textarea-autosize@npm:8.3.3"
@@ -15625,41 +15499,6 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
   checksum: da3d0192825df3d9f27eef33e7eddf928359a7e3e2b01ae7f7f672ecf4e5c1f7a34f27bdde9ccc24e2e9fbe1d1b9dd2a39c7d47323c9bdf63e7b9bd05c325a71
-  languageName: node
-  linkType: hard
-
-"react-universal-interface@npm:^0.6.2":
-  version: 0.6.2
-  resolution: "react-universal-interface@npm:0.6.2"
-  peerDependencies:
-    react: "*"
-    tslib: "*"
-  checksum: 070a7e9e3cdd8b0ec91a2ac9ac0a8df6bcb3fd183d2775bf0f439b9870fc1faf5b4fa9fe9741abd5187f0a35be645cb4004e1c9ebda9ada7e5d0a624f94910cb
-  languageName: node
-  linkType: hard
-
-"react-use@npm:^17.0.0":
-  version: 17.4.0
-  resolution: "react-use@npm:17.4.0"
-  dependencies:
-    "@types/js-cookie": ^2.2.6
-    "@xobotyi/scrollbar-width": ^1.9.5
-    copy-to-clipboard: ^3.3.1
-    fast-deep-equal: ^3.1.3
-    fast-shallow-equal: ^1.0.0
-    js-cookie: ^2.2.1
-    nano-css: ^5.3.1
-    react-universal-interface: ^0.6.2
-    resize-observer-polyfill: ^1.5.1
-    screenfull: ^5.1.0
-    set-harmonic-interval: ^1.0.1
-    throttle-debounce: ^3.0.1
-    ts-easing: ^0.2.0
-    tslib: ^2.1.0
-  peerDependencies:
-    react: ^16.8.0  || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0  || ^17.0.0 || ^18.0.0
-  checksum: 0889da919b49a186de375ec15d2778b954ae981c523acd17dd496e4a4da7b6190efe7993491e1b85fdd6de3e745d08a4eaba4caa35408d570b5f1de550f35d11
   languageName: node
   linkType: hard
 
@@ -15980,13 +15819,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resize-observer-polyfill@npm:^1.5.1":
-  version: 1.5.1
-  resolution: "resize-observer-polyfill@npm:1.5.1"
-  checksum: 57e7f79489867b00ba43c9c051524a5c8f162a61d5547e99333549afc23e15c44fd43f2f318ea0261ea98c0eb3158cca261e6f48d66e1ed1cd1f340a43977094
-  languageName: node
-  linkType: hard
-
 "resolve-cwd@npm:^3.0.0":
   version: 3.0.0
   resolution: "resolve-cwd@npm:3.0.0"
@@ -16217,15 +16049,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rtl-css-js@npm:^1.14.0":
-  version: 1.16.0
-  resolution: "rtl-css-js@npm:1.16.0"
-  dependencies:
-    "@babel/runtime": ^7.1.2
-  checksum: 51756329f691cacd3e1b48f0f9d04a69338a90013f2d2942ca1ae3b069c952f70055f5fd76c66921e9a5cb956276252376a847c3294bd0ee54be9ceb32ea868c
-  languageName: node
-  linkType: hard
-
 "rtl-detect@npm:^1.0.4":
   version: 1.0.4
   resolution: "rtl-detect@npm:1.0.4"
@@ -16382,13 +16205,6 @@ __metadata:
     ajv-formats: ^2.1.1
     ajv-keywords: ^5.0.0
   checksum: c843e92fdd1a5c145dbb6ffdae33e501867f9703afac67bdf35a685e49f85b1dcc10ea250033175a64bd9d31f0555bc6785b8359da0c90bcea30cf6dfbb55a8f
-  languageName: node
-  linkType: hard
-
-"screenfull@npm:^5.1.0":
-  version: 5.2.0
-  resolution: "screenfull@npm:5.2.0"
-  checksum: 21eae33b780eb4679ea0ea2d14734b11168cf35049c45a2bf24ddeb39c67a788e7a8fb46d8b61ca6d8367fd67ce9dd4fc8bfe476489249c7189c2a79cf83f51a
   languageName: node
   linkType: hard
 
@@ -16571,13 +16387,6 @@ __metadata:
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
   checksum: 6e65a05f7cf7ebdf8b7c75b101e18c0b7e3dff4940d480efed8aad3a36a4005140b660fa1d804cb8bce911cac290441dc728084a30504d3516ac2ff7ad607b02
-  languageName: node
-  linkType: hard
-
-"set-harmonic-interval@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "set-harmonic-interval@npm:1.0.1"
-  checksum: c122b831c2e0b1fb812e5e9d065094b9d174bd0576f9a779ab7a7d8881c8f6dd7d5fcab9a2553da15eea670eb598f9dd4d5162b626d45cc9c529706aa1444a84
   languageName: node
   linkType: hard
 
@@ -16830,13 +16639,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:0.5.6":
-  version: 0.5.6
-  resolution: "source-map@npm:0.5.6"
-  checksum: 390b3f5165c9631a74fb6fb55ba61e62a7f9b7d4026ae0e2bfc2899c241d71c1bccb8731c496dc7f7cb79a5f523406eb03d8c5bebe8448ee3fc38168e2d209c8
-  languageName: node
-  linkType: hard
-
 "source-map@npm:^0.5.0":
   version: 0.5.7
   resolution: "source-map@npm:0.5.7"
@@ -16855,13 +16657,6 @@ __metadata:
   version: 0.7.3
   resolution: "source-map@npm:0.7.3"
   checksum: cd24efb3b8fa69b64bf28e3c1b1a500de77e84260c5b7f2b873f88284df17974157cc88d386ee9b6d081f08fdd8242f3fc05c953685a6ad81aad94c7393dedea
-  languageName: node
-  linkType: hard
-
-"sourcemap-codec@npm:^1.4.8":
-  version: 1.4.8
-  resolution: "sourcemap-codec@npm:1.4.8"
-  checksum: b57981c05611afef31605732b598ccf65124a9fcb03b833532659ac4d29ac0f7bfacbc0d6c5a28a03e84c7510e7e556d758d0bb57786e214660016fb94279316
   languageName: node
   linkType: hard
 
@@ -16922,49 +16717,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stack-generator@npm:^2.0.5":
-  version: 2.0.10
-  resolution: "stack-generator@npm:2.0.10"
-  dependencies:
-    stackframe: ^1.3.4
-  checksum: 4fc3978a934424218a0aa9f398034e1f78153d5ff4f4ff9c62478c672debb47dd58de05b09fc3900530cbb526d72c93a6e6c9353bacc698e3b1c00ca3dda0c47
-  languageName: node
-  linkType: hard
-
 "stack-utils@npm:^2.0.3":
   version: 2.0.5
   resolution: "stack-utils@npm:2.0.5"
   dependencies:
     escape-string-regexp: ^2.0.0
   checksum: 76b69da0f5b48a34a0f93c98ee2a96544d2c4ca2557f7eef5ddb961d3bdc33870b46f498a84a7c4f4ffb781df639840e7ebf6639164ed4da5e1aeb659615b9c7
-  languageName: node
-  linkType: hard
-
-"stackframe@npm:^1.3.4":
-  version: 1.3.4
-  resolution: "stackframe@npm:1.3.4"
-  checksum: bae1596873595c4610993fa84f86a3387d67586401c1816ea048c0196800c0646c4d2da98c2ee80557fd9eff05877efe33b91ba6cd052658ed96ddc85d19067d
-  languageName: node
-  linkType: hard
-
-"stacktrace-gps@npm:^3.0.4":
-  version: 3.1.2
-  resolution: "stacktrace-gps@npm:3.1.2"
-  dependencies:
-    source-map: 0.5.6
-    stackframe: ^1.3.4
-  checksum: 85daa232d138239b6ae0f4bcdd87d15d302a045d93625db17614030945b5314e204b5fbcf9bee5b6f4f9e6af5fca05f65c27fe910894b861ef6853b99470aa1c
-  languageName: node
-  linkType: hard
-
-"stacktrace-js@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "stacktrace-js@npm:2.0.2"
-  dependencies:
-    error-stack-parser: ^2.0.6
-    stack-generator: ^2.0.5
-    stacktrace-gps: ^3.0.4
-  checksum: 081e786d56188ac04ac6604c09cd863b3ca2b4300ec061366cf68c3e4ad9edaa34fb40deea03cc23a05f442aa341e9171f47313f19bd588f9bec6c505a396286
   languageName: node
   linkType: hard
 
@@ -17241,13 +16999,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylis@npm:^4.0.6":
-  version: 4.1.1
-  resolution: "stylis@npm:4.1.1"
-  checksum: e9b0a086996a94c44d45933287731313f6ecdbf9334410231d882d31a1890fb36e34a7b163487e2d7f992c2044e4cb37179810fc6f758f359a431343c2374ed2
-  languageName: node
-  linkType: hard
-
 "supports-color@npm:^5.3.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
@@ -17488,13 +17239,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"throttle-debounce@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "throttle-debounce@npm:3.0.1"
-  checksum: e34ef638e8df3a9154249101b68afcbf2652a139c803415ef8a2f6a8bc577bcd4d79e4bb914ad3cd206523ac78b9fb7e80885bfa049f64fbb1927f99d98b5736
-  languageName: node
-  linkType: hard
-
 "thunky@npm:^1.0.2":
   version: 1.1.0
   resolution: "thunky@npm:1.1.0"
@@ -17553,13 +17297,6 @@ __metadata:
   dependencies:
     is-number: ^7.0.0
   checksum: f76fa01b3d5be85db6a2a143e24df9f60dd047d151062d0ba3df62953f2f697b16fe5dad9b0ac6191c7efc7b1d9dcaa4b768174b7b29da89d4428e64bc0a20ed
-  languageName: node
-  linkType: hard
-
-"toggle-selection@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "toggle-selection@npm:1.0.6"
-  checksum: a90dc80ed1e7b18db8f4e16e86a5574f87632dc729cfc07d9ea3ced50021ad42bb4e08f22c0913e0b98e3837b0b717e0a51613c65f30418e21eb99da6556a74c
   languageName: node
   linkType: hard
 
@@ -17623,13 +17360,6 @@ __metadata:
   version: 1.0.5
   resolution: "trough@npm:1.0.5"
   checksum: d6c8564903ed00e5258bab92134b020724dbbe83148dc72e4bf6306c03ed8843efa1bcc773fa62410dd89161ecb067432dd5916501793508a9506cacbc408e25
-  languageName: node
-  linkType: hard
-
-"ts-easing@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "ts-easing@npm:0.2.0"
-  checksum: e67ee862acca3b2e2718e736f31999adcef862d0df76d76a0e138588728d8a87dfec9978556044640bd0e90203590ad88ac2fe8746d0e9959b8d399132315150
   languageName: node
   linkType: hard
 
@@ -18714,7 +18444,6 @@ __metadata:
     react-day-picker: "workspace:^"
     react-dom: ^18.2.0
     react-popper: ^2.3.0
-    react-shadow: ^20.0.0
     source-map-loader: ^4.0.1
     ts-jest: ^29.1.0
     typedoc: ^0.24.7


### PR DESCRIPTION
An attempt to fix https://github.com/facebook/docusaurus/issues/6032 by "reverting" the CSS properties set by Docusaurus, and remove the shadow DOM workaround.