### PR TITLE
chore: add dates as an option to formatWeekNumber

### DIFF
--- a/src/components/WeekNumber/WeekNumber.tsx
+++ b/src/components/WeekNumber/WeekNumber.tsx
@@ -39,7 +39,7 @@ export function WeekNumber(props: WeekNumberProps): JSX.Element {
     );
   }
 
-  const label = labelWeekNumber(Number(weekNumber), { locale });
+  const label = labelWeekNumber(Number(weekNumber), { locale, dates });
 
   const handleClick: React.MouseEventHandler = function (e) {
     onWeekNumberClick(weekNumber, dates, e);

--- a/src/components/WeekNumber/WeekNumber.tsx
+++ b/src/components/WeekNumber/WeekNumber.tsx
@@ -29,7 +29,7 @@ export function WeekNumber(props: WeekNumberProps): JSX.Element {
     formatters: { formatWeekNumber }
   } = useDayPicker();
 
-  const content = formatWeekNumber(Number(weekNumber), { locale });
+  const content = formatWeekNumber(Number(weekNumber), { locale, dates });
 
   if (!onWeekNumberClick) {
     return (

--- a/src/types/Formatters.ts
+++ b/src/types/Formatters.ts
@@ -25,5 +25,5 @@ export type Formatters = {
 /** Represent a function to format the week number. */
 export type WeekNumberFormatter = (
   weekNumber: number,
-  options?: { locale?: Locale }
+  options?: { locale?: Locale; dates: Date[] }
 ) => React.ReactNode;

--- a/src/types/Formatters.ts
+++ b/src/types/Formatters.ts
@@ -25,5 +25,5 @@ export type Formatters = {
 /** Represent a function to format the week number. */
 export type WeekNumberFormatter = (
   weekNumber: number,
-  options?: { locale?: Locale; dates: Date[] }
+  options?: { locale?: Locale; dates?: Date[] }
 ) => React.ReactNode;

--- a/src/types/Labels.ts
+++ b/src/types/Labels.ts
@@ -33,5 +33,5 @@ export type WeekdayLabel = (day: Date, options?: { locale?: Locale }) => string;
 /** Return the ARIA label of the week number.*/
 export type WeekNumberLabel = (
   n: number,
-  options?: { locale?: Locale }
+  options?: { locale?: Locale; dates?: Date[] }
 ) => string;


### PR DESCRIPTION
### Context

Proposing this because I want to be able to recalculate the week number based on the date

### Analysis

When using `formatWeekNumber`, I only have access to the `locale` and would like to be able to format the week based on the date as well

### Solution

I have added `dates` to the object passed to `formatWeekNumber`
