### PR TITLE
Add flag to disable selecting days range with disabled days in between.

### DIFF
--- a/src/contexts/Modifiers/utils/createDisabledNonConsecutiveDates.test.ts
+++ b/src/contexts/Modifiers/utils/createDisabledNonConsecutiveDates.test.ts
@@ -1,0 +1,51 @@
+import { createDisabledNonConsecutiveDates } from './createDisabledNonConsecutiveDates';
+import { addDays } from 'date-fns';
+import { isDateAfterType, isDateBeforeType } from '../../../types/Matchers';
+
+describe('when today is before disabled dates', () => {
+  const disabledNonConsecutiveDates = createDisabledNonConsecutiveDates(
+    [
+      { from: addDays(new Date(), 3), to: addDays(new Date(), 8) },
+      { from: addDays(new Date(), 12), to: addDays(new Date(), 17) }
+    ],
+    new Date()
+  );
+
+  test('should only create one disabled matcher', () => {
+    expect(disabledNonConsecutiveDates).toHaveLength(1);
+  });
+
+  test('should create "after" matcher from the earliest "to"', () => {
+    expect(
+      disabledNonConsecutiveDates
+        .filter(isDateAfterType)
+        .some(
+          (date) => addDays(new Date(), 8).getDate() === date.after.getDate()
+        )
+    ).toBeTruthy();
+  });
+});
+
+describe('when today after disabled dates', () => {
+  const disabledNonConsecutiveDates = createDisabledNonConsecutiveDates(
+    [
+      { from: addDays(new Date(), -8), to: addDays(new Date(), -3) },
+      { from: addDays(new Date(), -17), to: addDays(new Date(), -12) }
+    ],
+    new Date()
+  );
+
+  test('should only create one disabled matcher', () => {
+    expect(disabledNonConsecutiveDates).toHaveLength(1);
+  });
+
+  test('should create "before" matcher from the latest "from"', () => {
+    expect(
+      disabledNonConsecutiveDates
+        .filter(isDateBeforeType)
+        .some(
+          (date) => addDays(new Date(), -8).getDate() === date.before.getDate()
+        )
+    ).toBeTruthy();
+  });
+});

--- a/src/contexts/Modifiers/utils/createDisabledNonConsecutiveDates.ts
+++ b/src/contexts/Modifiers/utils/createDisabledNonConsecutiveDates.ts
@@ -1,0 +1,31 @@
+import { DateAfter, DateBefore, isDateRange, Matcher } from 'types/Matchers';
+import { isAfter, isBefore } from 'date-fns';
+
+/** Return a list of {@link DateBefore} and {@link DateAfter} from the disabled modifiers. */
+export function createDisabledNonConsecutiveDates(
+  disabled: Matcher[],
+  from: Date
+): (DateBefore | DateAfter)[] {
+  const disabledNonConsecutiveDates: (DateBefore | DateAfter)[] = [];
+
+  let earliest: Date | undefined;
+  let latest: Date | undefined;
+
+  disabled.filter(isDateRange).forEach((range) => {
+    // We only need to add the latest 'from' date in the range.
+    // As when we disable it with DateBefore object, others will be included.
+    if (range.from && range.from < from) {
+      (!latest || isAfter(range.from, latest)) && (latest = range.from);
+    }
+    // We only need to add the earliest 'to' date in the range.
+    // As when we disable it with DateAfter object, others will be included.
+    if (range.to && range.to > from) {
+      (!earliest || isBefore(range.to, earliest)) && (earliest = range.to);
+    }
+  });
+
+  latest && disabledNonConsecutiveDates.push({ before: latest });
+  earliest && disabledNonConsecutiveDates.push({ after: earliest });
+
+  return disabledNonConsecutiveDates;
+}

--- a/src/contexts/Modifiers/utils/getInternalModifiers.test.ts
+++ b/src/contexts/Modifiers/utils/getInternalModifiers.test.ts
@@ -6,6 +6,7 @@ import { SelectRangeContextValue } from 'contexts/SelectRange';
 import { InternalModifier, InternalModifiers } from 'types/Modifiers';
 
 import { getInternalModifiers } from './getInternalModifiers';
+import * as createDisabledNonConsecutiveDatesModule from './createDisabledNonConsecutiveDates';
 
 const defaultDayPickerContext: DayPickerContextValue =
   getDefaultContextValues();
@@ -143,5 +144,74 @@ describe('when in range select mode', () => {
     expect(internalModifiers[RangeMiddle]).toStrictEqual(
       selectRangeContext.modifiers[RangeMiddle]
     );
+  });
+});
+
+describe('when disabledNonConsecutiveDates is set to true', () => {
+  const disabled = {
+    from: addDays(new Date(), 5),
+    to: addDays(new Date(), 10)
+  };
+  const rangeStart = new Date();
+  const rangeMiddle = [addDays(rangeStart, 1), addDays(rangeStart, 2)];
+  const rangeEnd = [addDays(rangeStart, 3)];
+  const selectRangeContext: SelectRangeContextValue = {
+    ...defaultSelectRangeContext,
+    modifiers: {
+      [Disabled]: [disabled],
+      [RangeStart]: [rangeStart],
+      [RangeEnd]: rangeEnd,
+      [RangeMiddle]: rangeMiddle
+    }
+  };
+
+  describe('when mode is range', () => {
+    const dayPickerContext: DayPickerContextValue = {
+      ...defaultDayPickerContext,
+      mode: 'range',
+      disableNonConsecutiveDates: true
+    };
+
+    test('should call createDisabledNonConsecutiveDates', () => {
+      const spy = jest.spyOn(
+        createDisabledNonConsecutiveDatesModule,
+        'createDisabledNonConsecutiveDates'
+      );
+
+      spy.mockReturnValue([]);
+
+      getInternalModifiers(
+        dayPickerContext,
+        defaultSelectMultipleContext,
+        selectRangeContext
+      );
+      expect(spy).toHaveBeenCalled();
+      spy.mockClear();
+    });
+  });
+
+  describe('when mode is not range', () => {
+    const dayPickerContext: DayPickerContextValue = {
+      ...defaultDayPickerContext,
+      mode: 'single',
+      disableNonConsecutiveDates: true
+    };
+
+    test('should not call createDisabledNonConsecutiveDates', () => {
+      const spy = jest.spyOn(
+        createDisabledNonConsecutiveDatesModule,
+        'createDisabledNonConsecutiveDates'
+      );
+
+      spy.mockReturnValue([]);
+
+      getInternalModifiers(
+        dayPickerContext,
+        defaultSelectMultipleContext,
+        selectRangeContext
+      );
+      expect(spy).toHaveBeenCalledTimes(0);
+      spy.mockClear();
+    });
   });
 });

--- a/src/contexts/Modifiers/utils/getInternalModifiers.ts
+++ b/src/contexts/Modifiers/utils/getInternalModifiers.ts
@@ -6,6 +6,7 @@ import { isDayPickerRange } from 'types/DayPickerRange';
 import { InternalModifier, InternalModifiers } from 'types/Modifiers';
 
 import { matcherToArray } from './matcherToArray';
+import { createDisabledNonConsecutiveDates } from './createDisabledNonConsecutiveDates';
 
 const {
   Selected,
@@ -53,6 +54,18 @@ export function getInternalModifiers(
     internalModifiers[RangeStart] = selectRange.modifiers[RangeStart];
     internalModifiers[RangeMiddle] = selectRange.modifiers[RangeMiddle];
     internalModifiers[RangeEnd] = selectRange.modifiers[RangeEnd];
+
+    if (
+      dayPicker.disableNonConsecutiveDates &&
+      internalModifiers[RangeStart].length > 0
+    ) {
+      internalModifiers[Disabled] = internalModifiers[Disabled].concat(
+        createDisabledNonConsecutiveDates(
+          internalModifiers[Disabled],
+          internalModifiers[RangeStart][0] as Date
+        )
+      );
+    }
   }
   return internalModifiers;
 }

--- a/src/types/DayPickerBase.ts
+++ b/src/types/DayPickerBase.ts
@@ -287,6 +287,12 @@ export interface DayPickerBase {
    */
   formatters?: Partial<Formatters>;
 
+  /**
+   * Disables other dates that cannot be consecutively selected within a range
+   * of non-disabled dates.
+   */
+  disableNonConsecutiveDates?: boolean;
+
   onDayClick?: DayClickEventHandler;
   onDayFocus?: DayFocusEventHandler;
   onDayBlur?: DayFocusEventHandler;

--- a/website/docs/basics/selecting-days.md
+++ b/website/docs/basics/selecting-days.md
@@ -56,6 +56,14 @@ Use the `min` and `max` props to limit the amount of days in the range.
 range-min-max
 ```
 
+### Disable days outside the selectable non-disabled days from the start date
+
+Use the `disableNonConsecutiveDates` prop to disable dates outside the range.
+
+```include-example
+non-consecutive-dates
+```
+
 ## Custom Selections
 
 If the built-in selection modes are not enough for your app’s requirements, you can control the selection behavior using `onDayClick`.

--- a/website/examples/non-consecutive-dates.tsx
+++ b/website/examples/non-consecutive-dates.tsx
@@ -1,0 +1,26 @@
+import React, { useState } from 'react';
+
+import { DayPicker, DateRange } from 'react-day-picker';
+import { addDays } from 'date-fns';
+
+export default function App() {
+  const [range, setRange] = useState<DateRange | undefined>(undefined);
+
+  const today = new Date();
+
+  const disabledDays = [
+    { from: addDays(today, -5), to: addDays(today, -3) },
+    { from: addDays(today, 3), to: addDays(today, 5) },
+    { from: addDays(today, 9), to: addDays(today, 12) }
+  ];
+
+  return (
+    <DayPicker
+      mode="range"
+      disabled={disabledDays}
+      selected={range}
+      disableNonConsecutiveDates={true}
+      onSelect={setRange}
+    />
+  );
+}


### PR DESCRIPTION
### Context

Added flag to disable selecting range of dates with disabled dates in between.

### Solution

During `getInternalModifers` execution, if the `disableNonConsecutiveDates` is set true, this will create an array of `DateBefore` and `DateAfter` to be added to `disabled`. 

```typescript
export function createDisabledNonConsecutiveDates(
  disabled: Matcher[],
  from: Date
): (DateBefore | DateAfter)[] {
  const disabledNonConsecutiveDates: (DateBefore | DateAfter)[] = [];

  let earliest: Date | undefined;
  let latest: Date | undefined;

  disabled.filter(isDateRange).forEach((range) => {
    // We only need to add the latest 'from' date in the range.
    // As when we disable it with DateBefore object, others will be included.
    if (range.from && range.from < from) {
      (!latest || isAfter(range.from, latest)) && (latest = range.from);
    }
    // We only need to add the earliest 'to' date in the range.
    // As when we disable it with DateAfter object, others will be included.
    if (range.to && range.to > from) {
      (!earliest || isBefore(range.to, earliest)) && (earliest = range.to);
    }
  });

  latest && disabledNonConsecutiveDates.push({ before: latest });
  earliest && disabledNonConsecutiveDates.push({ after: earliest });

  return disabledNonConsecutiveDates;
}
```