### PR TITLE
feat: add formatClassNames function to format CSS class names

### DIFF
--- a/src/contexts/DayPicker/DayPickerContext.tsx
+++ b/src/contexts/DayPicker/DayPickerContext.tsx
@@ -36,10 +36,15 @@ export interface DayPickerContextValue extends DayPickerBase {
 
   captionLayout: CaptionLayout;
   classNames: Required<ClassNames>;
+  formatClassNames: (classNames: Required<ClassNames>) => Required<ClassNames>;
+
   formatters: Formatters;
   labels: Labels;
   locale: Locale;
   modifiersClassNames: ModifiersClassNames;
+  formatModifiersClassNames: (
+    classNames: ModifiersClassNames
+  ) => ModifiersClassNames;
   modifiers: DayModifiers;
   numberOfMonths: number;
   styles: Styles;
@@ -94,10 +99,12 @@ export function DayPickerProvider(props: DayPickerProviderProps): JSX.Element {
     ...defaultContextValues,
     ...initialProps,
     captionLayout,
-    classNames: {
+    classNames: (
+      initialProps.formatClassNames || defaultContextValues.formatClassNames
+    )({
       ...defaultContextValues.classNames,
       ...initialProps.classNames
-    },
+    }),
     components: {
       ...initialProps.components
     },
@@ -115,10 +122,13 @@ export function DayPickerProvider(props: DayPickerProviderProps): JSX.Element {
       ...defaultContextValues.modifiers,
       ...initialProps.modifiers
     },
-    modifiersClassNames: {
+    modifiersClassNames: (
+      initialProps.formatModifiersClassNames ||
+      defaultContextValues.formatModifiersClassNames
+    )({
       ...defaultContextValues.modifiersClassNames,
       ...initialProps.modifiersClassNames
-    },
+    }),
     onSelect,
     styles: {
       ...defaultContextValues.styles,

--- a/src/contexts/DayPicker/defaultContextValues.ts
+++ b/src/contexts/DayPicker/defaultContextValues.ts
@@ -6,14 +6,18 @@ import { DayPickerContextValue } from 'contexts/DayPicker';
 import { defaultClassNames } from './defaultClassNames';
 import * as formatters from './formatters';
 import * as labels from './labels';
+import { ClassNames } from 'types/Styles';
+import { ModifiersClassNames } from 'types/Modifiers';
 
 export type DefaultContextProps =
   | 'captionLayout'
   | 'classNames'
+  | 'formatClassNames'
   | 'formatters'
   | 'locale'
   | 'labels'
   | 'modifiersClassNames'
+  | 'formatModifiersClassNames'
   | 'modifiers'
   | 'numberOfMonths'
   | 'styles'
@@ -37,14 +41,19 @@ export function getDefaultContextValues(): DefaultContextValues {
   const numberOfMonths = 1;
   const styles = {};
   const today = new Date();
+  const formatClassNames = (classNames: Required<ClassNames>) => classNames;
+  const formatModifiersClassNames = (classNames: ModifiersClassNames) =>
+    classNames;
 
   return {
     captionLayout,
     classNames,
+    formatClassNames,
     formatters,
     labels,
     locale,
     modifiersClassNames,
+    formatModifiersClassNames,
     modifiers,
     numberOfMonths,
     styles,

--- a/src/types/DayPickerBase.ts
+++ b/src/types/DayPickerBase.ts
@@ -57,10 +57,30 @@ export interface DayPickerBase {
    */
   classNames?: ClassNames;
   /**
+   * Format class names of the HTML elements.
+   *
+   * Use this prop when you need to format class names - for example when using twMerge with TailwindCss
+   *
+   * @param classnames ClassNames
+   * @returns ClassNames
+   */
+  formatClassNames?: (classnames: Required<ClassNames>) => Required<ClassNames>;
+
+  /**
    * Change the class name for the day matching the {@link modifiers}.
    */
   modifiersClassNames?: ModifiersClassNames;
-
+  /**
+   * Format class names of the day matching the {@link modifiers}.
+   *
+   * Use this prop when you need to format class names - for example when using twMerge with TailwindCss
+   *
+   * @param classnames ModifiersClassNames
+   * @returns ModifiersClassNames
+   */
+  formatModifiersClassNames?: (
+    classnames: ModifiersClassNames
+  ) => ModifiersClassNames;
   /**
    * Style to apply to the container element.
    */


### PR DESCRIPTION
### Context
DayPicker accepts class names for styling, but class names composition doesn't work well with TailwindCSS.

### Analysis
Class names are concatenated as is. No options to modify composed selected day, range start day, etc. 

### Solution
DayPicker accepts `formatClassNames/formatModifiersClassNames` functions to format corresponding class names. Defaults are identity functions.
