### PR TITLE
fix(a11y): Remove rowgroup role from tbody element

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -51,7 +51,7 @@ export function Table(props: TableProps): JSX.Element {
       aria-labelledby={props['aria-labelledby']}
     >
       {!hideHead && <HeadComponent />}
-      <tbody className={classNames.tbody} style={styles.tbody} role="rowgroup">
+      <tbody className={classNames.tbody} style={styles.tbody}>
         {weeks.map((week) => (
           <RowComponent
             displayMonth={props.displayMonth}

--- a/src/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__snapshots__/Table.test.tsx.snap
@@ -64,7 +64,6 @@ exports[`should render correctly 1`] = `
   </thead>
   <tbody
     class="rdp-tbody"
-    role="rowgroup"
   >
     <tr
       class="rdp-row"
@@ -524,7 +523,6 @@ exports[`when showing the week numbers should render correctly 1`] = `
   </thead>
   <tbody
     class="rdp-tbody"
-    role="rowgroup"
   >
     <tr
       class="rdp-row"
@@ -976,7 +974,6 @@ exports[`when using custom components should render correctly 1`] = `
   </thead>
   <tbody
     class="rdp-tbody"
-    role="rowgroup"
   >
     <tr>
       <td>

--- a/website/test-integration/examples/__snapshots__/range.test.tsx.snap
+++ b/website/test-integration/examples/__snapshots__/range.test.tsx.snap
@@ -130,7 +130,6 @@ exports[`should match the snapshot 1`] = `
           </thead>
           <tbody
             class="rdp-tbody"
-            role="rowgroup"
           >
             <tr
               class="rdp-row"
@@ -770,7 +769,6 @@ exports[`when a day in the range is clicked when the day is clicked again when a
           </thead>
           <tbody
             class="rdp-tbody"
-            role="rowgroup"
           >
             <tr
               class="rdp-row"


### PR DESCRIPTION
### Context

The `role="rowgroup"` attribute added to the `<tbody>` element in `Table.tsx` is redundant and it may cause html validators to fail. (e.g. #1903).

https://github.com/gpbl/react-day-picker/blob/6fc2614dbcb7016ad0362385b44ea016039bc080/src/components/Table/Table.tsx#L54

### Analysis

The role attribute can be removed as it [is the implicit ARIA role](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody) for `tbody`.

### Solution

Remove the role and update the test screenshots.
