### PR TITLE
feat: Introduced custom components "Months"

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.5.1",
     "@types/jest": "^29.5.5",
-    "@types/node": "^18.17.19",
+    "@types/node": "^20.6.5",
     "@types/react": "^18.2.22",
     "@types/react-dom": "^18.2.7",
     "@types/testing-library__jest-dom": "^5.14.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^29.5.5
         version: 29.5.5
       '@types/node':
-        specifier: ^18.17.19
-        version: 18.17.19
+        specifier: ^20.6.5
+        version: 20.6.5
       '@types/react':
         specifier: ^18.2.22
         version: 18.2.22
@@ -85,7 +85,7 @@ importers:
         version: 5.11.1(eslint@8.50.0)(typescript@4.9.5)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@18.17.19)(ts-node@10.9.1)
+        version: 29.7.0(@types/node@20.6.5)(ts-node@10.9.1)
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -133,7 +133,7 @@ importers:
         version: 29.1.1(@babel/core@7.23.0)(@jest/types@29.6.3)(jest@29.7.0)(typescript@4.9.5)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.17.19)(typescript@4.9.5)
+        version: 10.9.1(@types/node@20.6.5)(typescript@4.9.5)
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.8
@@ -223,8 +223,8 @@ importers:
         specifier: ^3.5.6
         version: 3.5.6
       '@types/node':
-        specifier: ^18.17.19
-        version: 18.17.19
+        specifier: ^20.6.5
+        version: 20.6.5
       '@types/react':
         specifier: ^18.2.22
         version: 18.2.22
@@ -251,7 +251,7 @@ importers:
         version: 3.0.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@18.17.19)(ts-node@10.9.1)
+        version: 29.7.0(@types/node@20.6.5)(ts-node@10.9.1)
       jest-axe:
         specifier: ^8.0.0
         version: 8.0.0
@@ -4046,7 +4046,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -4067,14 +4067,14 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.8.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.17.19)(ts-node@10.9.1)
+      jest-config: 29.7.0(@types/node@20.6.5)(ts-node@10.9.1)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -4102,7 +4102,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       jest-mock: 29.7.0
     dev: true
 
@@ -4136,7 +4136,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -4169,7 +4169,7 @@ packages:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.19
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -5002,23 +5002,23 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
 
   /@types/bonjour@3.5.10:
     resolution: {integrity: sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==}
     dependencies:
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
 
   /@types/connect-history-api-fallback@1.3.5:
     resolution: {integrity: sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==}
     dependencies:
       '@types/express-serve-static-core': 4.17.28
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
 
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
 
   /@types/eslint-scope@3.7.3:
     resolution: {integrity: sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==}
@@ -5038,7 +5038,7 @@ packages:
   /@types/express-serve-static-core@4.17.28:
     resolution: {integrity: sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==}
     dependencies:
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
 
@@ -5053,20 +5053,20 @@ packages:
   /@types/fs-extra@8.1.2:
     resolution: {integrity: sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==}
     dependencies:
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
     dev: true
 
   /@types/glob@7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
     dev: true
 
   /@types/graceful-fs@4.1.7:
     resolution: {integrity: sha512-MhzcwU8aUygZroVwL2jeYk6JisJrPl/oov/gsgGCue9mkgl9wjGbzReYQClxiUgFDnib9FuHqTndccKeZKxTRw==}
     dependencies:
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
     dev: true
 
   /@types/hast@2.3.6:
@@ -5083,7 +5083,7 @@ packages:
   /@types/http-proxy@1.17.8:
     resolution: {integrity: sha512-5kPLG5BKpWYkw/LVOGWpiq3nEVqxiN32rTgI53Sk12/xHFQ2rG3ehI9IO+O3W2QoKeyB92dJkoka8SUm6BX1pA==}
     dependencies:
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
 
   /@types/istanbul-lib-coverage@2.0.4:
     resolution: {integrity: sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==}
@@ -5118,7 +5118,7 @@ packages:
   /@types/jsdom@20.0.0:
     resolution: {integrity: sha512-YfAchFs0yM1QPDrLm2VHe+WHGtqms3NXnXAMolrgrVP6fgBHHXy1ozAbo/dFtPNtZC/m66bPiCTWYmqp1F14gA==}
     dependencies:
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       '@types/tough-cookie': 4.0.2
       parse5: 7.1.1
     dev: true
@@ -5136,7 +5136,7 @@ packages:
   /@types/keyv@3.1.3:
     resolution: {integrity: sha512-FXCJgyyN3ivVgRoml4h94G/p3kY+u/B86La+QptcqJaWtBWtmc6TtkNfS40n9bIvyLteHh7zXOtgbobORKPbDg==}
     dependencies:
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
 
   /@types/mdast@3.0.12:
     resolution: {integrity: sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==}
@@ -5156,6 +5156,10 @@ packages:
 
   /@types/node@18.17.19:
     resolution: {integrity: sha512-+pMhShR3Or5GR0/sp4Da7FnhVmTalWm81M6MkEldbwjETSaPalw138Z4KdpQaistvqQxLB7Cy4xwYdxpbSOs9Q==}
+    dev: true
+
+  /@types/node@20.6.5:
+    resolution: {integrity: sha512-2qGq5LAOTh9izcc0+F+dToFigBWiK1phKPt7rNhOqJSr35y8rlIBjDwGtFSgAI6MGIhjwOVNSQZVdJsZJ2uR1w==}
 
   /@types/parse-json@4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
@@ -5218,7 +5222,7 @@ packages:
   /@types/responselike@1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
 
   /@types/retry@0.12.1:
     resolution: {integrity: sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==}
@@ -5226,7 +5230,7 @@ packages:
   /@types/sax@1.2.4:
     resolution: {integrity: sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==}
     dependencies:
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
     dev: false
 
   /@types/scheduler@0.16.2:
@@ -5245,12 +5249,12 @@ packages:
     resolution: {integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
 
   /@types/sockjs@0.3.33:
     resolution: {integrity: sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==}
     dependencies:
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
 
   /@types/stack-utils@2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
@@ -5278,7 +5282,7 @@ packages:
   /@types/ws@8.5.3:
     resolution: {integrity: sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==}
     dependencies:
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
 
   /@types/yargs-parser@20.2.1:
     resolution: {integrity: sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==}
@@ -6704,7 +6708,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       dot-prop: 5.3.0
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.11
       make-dir: 3.1.0
       unique-string: 2.0.0
       write-file-atomic: 3.0.3
@@ -6816,7 +6820,7 @@ packages:
       path-type: 4.0.0
       yaml: 1.10.2
 
-  /create-jest@29.7.0(@types/node@18.17.19)(ts-node@10.9.1):
+  /create-jest@29.7.0(@types/node@20.6.5)(ts-node@10.9.1):
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -6825,7 +6829,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.17.19)(ts-node@10.9.1)
+      jest-config: 29.7.0(@types/node@20.6.5)(ts-node@10.9.1)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -7804,7 +7808,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.50.0)(typescript@4.9.5)
       '@typescript-eslint/utils': 5.61.0(eslint@8.50.0)(typescript@4.9.5)
       eslint: 8.50.0
-      jest: 29.7.0(@types/node@18.17.19)(ts-node@10.9.1)
+      jest: 29.7.0(@types/node@20.6.5)(ts-node@10.9.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -7974,7 +7978,7 @@ packages:
     resolution: {integrity: sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==}
     engines: {node: '>= 0.8'}
     dependencies:
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       require-like: 0.1.2
 
   /eventemitter3@4.0.7:
@@ -9492,7 +9496,7 @@ packages:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.1
@@ -9513,7 +9517,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@29.7.0(@types/node@18.17.19)(ts-node@10.9.1):
+  /jest-cli@29.7.0(@types/node@20.6.5)(ts-node@10.9.1):
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -9527,10 +9531,10 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.17.19)(ts-node@10.9.1)
+      create-jest: 29.7.0(@types/node@20.6.5)(ts-node@10.9.1)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@18.17.19)(ts-node@10.9.1)
+      jest-config: 29.7.0(@types/node@20.6.5)(ts-node@10.9.1)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -9541,7 +9545,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@29.7.0(@types/node@18.17.19)(ts-node@10.9.1):
+  /jest-config@29.7.0(@types/node@20.6.5)(ts-node@10.9.1):
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -9556,7 +9560,7 @@ packages:
       '@babel/core': 7.22.20
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       babel-jest: 29.7.0(@babel/core@7.22.20)
       chalk: 4.1.2
       ci-info: 3.8.0
@@ -9576,7 +9580,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@types/node@18.17.19)(typescript@4.9.5)
+      ts-node: 10.9.1(@types/node@20.6.5)(typescript@4.9.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -9650,7 +9654,7 @@ packages:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       jest-mock: 29.7.0
       jest-util: 29.7.0
     dev: true
@@ -9666,7 +9670,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.7
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -9752,7 +9756,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       jest-util: 29.7.0
     dev: true
 
@@ -9807,7 +9811,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -9838,7 +9842,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       chalk: 4.1.2
       cjs-module-lexer: 1.2.3
       collect-v8-coverage: 1.0.2
@@ -9890,7 +9894,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       chalk: 4.1.2
       ci-info: 3.3.0
       graceful-fs: 4.2.9
@@ -9902,7 +9906,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       chalk: 4.1.2
       ci-info: 3.3.0
       graceful-fs: 4.2.9
@@ -9914,7 +9918,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -9939,7 +9943,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -9951,7 +9955,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -9959,13 +9963,13 @@ packages:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
 
-  /jest@29.7.0(@types/node@18.17.19)(ts-node@10.9.1):
+  /jest@29.7.0(@types/node@20.6.5)(ts-node@10.9.1):
     resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -9978,7 +9982,7 @@ packages:
       '@jest/core': 29.7.0(ts-node@10.9.1)
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@18.17.19)(ts-node@10.9.1)
+      jest-cli: 29.7.0(@types/node@20.6.5)(ts-node@10.9.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -10104,7 +10108,7 @@ packages:
   /jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.11
     dev: true
 
   /jsonfile@6.1.0:
@@ -10112,7 +10116,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.11
 
   /keyv@3.1.0:
     resolution: {integrity: sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==}
@@ -11055,7 +11059,7 @@ packages:
     dependencies:
       lilconfig: 2.0.6
       postcss: 8.4.30
-      ts-node: 10.9.1(@types/node@18.17.19)(typescript@4.9.5)
+      ts-node: 10.9.1(@types/node@20.6.5)(typescript@4.9.5)
       yaml: 1.10.2
     dev: true
 
@@ -12957,7 +12961,7 @@ packages:
       '@jest/types': 29.6.3
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@18.17.19)(ts-node@10.9.1)
+      jest: 29.7.0(@types/node@20.6.5)(ts-node@10.9.1)
       jest-util: 29.5.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -12967,7 +12971,7 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-node@10.9.1(@types/node@18.17.19)(typescript@4.9.5):
+  /ts-node@10.9.1(@types/node@20.6.5)(typescript@4.9.5):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -12986,7 +12990,7 @@ packages:
       '@tsconfig/node12': 1.0.9
       '@tsconfig/node14': 1.0.1
       '@tsconfig/node16': 1.0.2
-      '@types/node': 18.17.19
+      '@types/node': 20.6.5
       acorn: 8.8.1
       acorn-walk: 8.2.0
       arg: 4.1.3

--- a/src/components/Months/Months.test.tsx
+++ b/src/components/Months/Months.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { customRender } from 'test/render';
 
 import { Months } from './Months';

--- a/src/components/Months/Months.test.tsx
+++ b/src/components/Months/Months.test.tsx
@@ -1,113 +1,29 @@
 import React from 'react';
 
-import { screen } from '@testing-library/react';
-import { DayPickerProps } from 'DayPicker';
-
 import { customRender } from 'test/render';
 
-import { defaultClassNames } from 'contexts/DayPicker/defaultClassNames';
-import { Months, MonthsProps } from './Months';
+import { Months } from './Months';
 
-let root: HTMLDivElement;
+let root: HTMLElement;
 
-const testStyles: Record<string, Record<string, unknown>> = {
-  months: { color: 'red' }
-};
-
-const testClassNames: Record<string, string> = {
-  months: 'months_container'
-};
-
-function TestChildren() {
-  return (
-    <>
-      <div role="grid">1</div>
-      <div role="grid">2</div>
-    </>
-  );
-}
-
-function TestEmptyChildren() {
-  return null;
-}
-function setup(
-  { children, ...props }: MonthsProps,
-  dayPickerProps?: DayPickerProps
-) {
-  const view = customRender(
-    <Months {...props}>{children}</Months>,
-    dayPickerProps
-  );
-  root = view.container.firstChild as HTMLDivElement;
-}
-describe('when rendered with children', () => {
-  beforeEach(() => {
-    setup({
-      children: <TestChildren />
-    });
-  });
-  test('months container should have children grids', () => {
-    expect(screen.getAllByRole('grid')).toHaveLength(2);
-  });
+test('should use the default class name', () => {
+  const view = customRender(<Months>foo</Months>, {});
+  root = view.container.firstChild as HTMLElement;
+  expect(root).toHaveClass('rdp-months');
 });
 
-describe('when rendered with empty children', () => {
-  beforeEach(() => {
-    setup({
-      children: <TestEmptyChildren />
-    });
+test('should use a custom class name', () => {
+  const view = customRender(<Months>foo</Months>, {
+    classNames: { months: 'foo' }
   });
-  test('months container should not have children grids', () => {
-    expect(screen.queryAllByRole('grid')).toHaveLength(0);
-  });
+  root = view.container.firstChild as HTMLElement;
+  expect(root).toHaveClass('foo');
 });
 
-describe('when custom className and styles provided', () => {
-  beforeEach(() => {
-    setup(
-      {
-        children: <TestChildren />
-      },
-      {
-        styles: testStyles,
-        classNames: testClassNames
-      }
-    );
+test('should use a custom style', () => {
+  const view = customRender(<Months>foo</Months>, {
+    styles: { months: { color: 'red' } }
   });
-  test('months container should have custom class', () => {
-    expect(root).toHaveClass(testClassNames.months);
-  });
-
-  test('months container should not have default class', () => {
-    expect(root).not.toHaveClass(defaultClassNames.months);
-  });
-
-  test('months container should have custom styles', () => {
-    expect(root).toHaveStyle(testStyles.months);
-  });
-});
-
-describe('when no custom className and styles provided', () => {
-  beforeEach(() => {
-    setup(
-      {
-        children: <TestChildren />
-      },
-      {
-        styles: {},
-        classNames: {}
-      }
-    );
-  });
-  test('months container should not have custom class', () => {
-    expect(root).not.toHaveClass(testClassNames.months);
-  });
-
-  test('months container should have default class', () => {
-    expect(root).toHaveClass(defaultClassNames.months);
-  });
-
-  test('months container should not have custom styles', () => {
-    expect(root).not.toHaveStyle(testStyles.months);
-  });
+  root = view.container.firstChild as HTMLElement;
+  expect(root).toHaveStyle({ color: 'red' });
 });

--- a/src/components/Months/Months.tsx
+++ b/src/components/Months/Months.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 
 import { useDayPicker } from 'contexts/DayPicker';
 

--- a/src/components/Months/Months.tsx
+++ b/src/components/Months/Months.tsx
@@ -1,19 +1,19 @@
-import React, { ReactNode } from 'react';
+import React, { PropsWithChildren } from 'react';
+
 import { useDayPicker } from 'contexts/DayPicker';
 
-export interface MonthsProps {
-  children: ReactNode;
-}
+/** The props for the {@link Months} component. */
+export type MonthsProps = PropsWithChildren;
 
-export function Months({ children }: MonthsProps): JSX.Element {
-  const dayPicker = useDayPicker();
+/**
+ * Render the wrapper for the mont grids.
+ */
+export function Months(props: MonthsProps): JSX.Element {
+  const { classNames, styles } = useDayPicker();
 
   return (
-    <div
-      className={dayPicker.classNames.months}
-      style={dayPicker.styles.months}
-    >
-      {children}
+    <div className={classNames.months} style={styles.months}>
+      {props.children}
     </div>
   );
 }

--- a/src/components/Root/Root.test.tsx
+++ b/src/components/Root/Root.test.tsx
@@ -67,7 +67,7 @@ describe('when using a custom "Months" component', () => {
     );
   }
   beforeEach(() => {
-    setup({ numberOfMonths: 3, components: { Months: CustomMonths } });
+    render({ numberOfMonths: 3, components: { Months: CustomMonths } });
   });
   test('should render the custom component', () => {
     expect(screen.getByTestId('foo')).toBeInTheDocument();

--- a/src/components/Root/Root.test.tsx
+++ b/src/components/Root/Root.test.tsx
@@ -8,6 +8,7 @@ import { customRender } from 'test/render';
 import { getDayButton, queryMonthGrids } from 'test/selectors';
 import { freezeBeforeAll } from 'test/utils';
 
+import { MonthsProps } from 'components/Months';
 import { defaultClassNames } from 'contexts/DayPicker/defaultClassNames';
 import { ClassNames } from 'types/Styles';
 
@@ -56,25 +57,23 @@ describe('when using the "classNames" prop', () => {
   });
 });
 
-describe('when using custom component "months" prop', () => {
-  const TEST_MONTHS_COPY =
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
-  function TestMonths({ children }: PropsWithChildren) {
+describe('when using a custom "Months" component', () => {
+  function CustomMonths(props: MonthsProps) {
     return (
       <div>
-        <div>{TEST_MONTHS_COPY}</div>
-        {children}
+        <div data-testid="foo" />
+        {props.children}
       </div>
     );
   }
   beforeEach(() => {
-    setup({ numberOfMonths: 3, components: { Months: TestMonths } });
+    setup({ numberOfMonths: 3, components: { Months: CustomMonths } });
   });
-  test('should display the specified number of month grids', () => {
+  test('should render the custom component', () => {
+    expect(screen.getByTestId('foo')).toBeInTheDocument();
+  });
+  test('should still display the specified number of months', () => {
     expect(queryMonthGrids()).toHaveLength(3);
-  });
-  test('should have copy from custom "Months" component', () => {
-    expect(screen.getByText(TEST_MONTHS_COPY)).toBeInTheDocument();
   });
 });
 

--- a/src/components/Root/Root.test.tsx
+++ b/src/components/Root/Root.test.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import React from 'react';
 
 import { RenderResult, screen } from '@testing-library/react';
 import { addDays } from 'date-fns';

--- a/src/types/DayPickerBase.ts
+++ b/src/types/DayPickerBase.ts
@@ -347,7 +347,7 @@ export interface CustomComponents {
   IconRight?: (props: StyledComponent) => JSX.Element | null;
   /** The arrow left icon (used for the Navigation buttons). */
   IconLeft?: (props: StyledComponent) => JSX.Element | null;
-  /** The months wrapper */
+  /** The component wrapping the month grids. */
   Months?: (props: MonthsProps) => JSX.Element | null;
   /** The component for the table rows. */
   Row?: (props: RowProps) => JSX.Element | null;

--- a/website/package.json
+++ b/website/package.json
@@ -41,7 +41,7 @@
     "@tsconfig/docusaurus": "^1.0.7",
     "@types/jest": "^29.5.5",
     "@types/jest-axe": "^3.5.6",
-    "@types/node": "^18.17.19",
+    "@types/node": "^20.6.5",
     "@types/react": "^18.2.22",
     "@types/react-dom": "^18.2.7",
     "@types/react-helmet": "^6.1.6",


### PR DESCRIPTION
### Context

As developer I might want to wrap `<DayPicker />` and use [children API](https://react.dev/reference/react/Children) to map over months. For instance I would want to extend pagination to behave like carousel - this seems good use case for using `Children.map`. 
To achieve it we need to be able to host collection of  `<Month />` elements. That's why replacing hardcoded months container by public customisable `<Months />` open additional possibility how library can be consumed. 

### Analysis

```
const AnyComponent = ({children}) => {
  return <p>Count: {Children.count(children)}</p>
}
---
<AnyComponent>
  <DayPicker numberOfMonths={4} />
</AnyComponent/>

--- output
<p>Count: 1</p>

--- with custom Months
const CustomMonths = ({children}) => (<Months><AnyComponent>{children}</AnyComponent></Months>)

<DayPicker numberOfMonths={4} components={Months: CustomMonths}>

--- output
  <p>Count: 4</p>
```

Current implementation will always return only one children because in **Root** component **DIV** element is wrapper on top of months. 


### Solution

With custom `<Months />` component we can have direct access to array children or to do any other customisation. It means library is more flexible without exposing core functionality.
We already can find dedicated `classes and styles` for `months` to allow customisation, that's makes me think that custom component `<Months />` also make sense.

Other approach I've tried was to compose `DayPicker` form existing components like:

```
const DayPicker = () => {
  <Providers>
    <Root>
       <CustomMonths>{months.map(() => <Month />)}</CustomMonths>
    </Root>
  </Providers>
}
``` 
but it is also impossible because `<Month />` is private (I believe for good reasons). 
