### PR TITLE
Fixing incompatible usage of PropsWithChildren so that typing works with React 17

### DIFF
--- a/src/components/Months/Months.tsx
+++ b/src/components/Months/Months.tsx
@@ -1,9 +1,9 @@
-import { PropsWithChildren } from 'react';
+import { ReactNode } from 'react';
 
 import { useDayPicker } from 'contexts/DayPicker';
 
 /** The props for the {@link Months} component. */
-export type MonthsProps = PropsWithChildren;
+export type MonthsProps = { children: ReactNode };
 
 /**
  * Render the wrapper for the mont grids.

--- a/src/contexts/Focus/FocusContext.tsx
+++ b/src/contexts/Focus/FocusContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, PropsWithChildren, useContext, useState } from 'react';
+import { createContext, ReactNode, useContext, useState } from 'react';
 
 import { isSameDay } from 'date-fns';
 
@@ -54,7 +54,7 @@ export const FocusContext = createContext<FocusContextValue | undefined>(
   undefined
 );
 
-export type FocusProviderProps = PropsWithChildren;
+export type FocusProviderProps = { children: ReactNode };
 
 /** The provider for the {@link FocusContext}. */
 export function FocusProvider(props: FocusProviderProps): JSX.Element {

--- a/src/contexts/Modifiers/ModifiersContext.tsx
+++ b/src/contexts/Modifiers/ModifiersContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, PropsWithChildren, useContext } from 'react';
+import { createContext, useContext, ReactNode } from 'react';
 
 import { useDayPicker } from 'contexts/DayPicker';
 import { useSelectMultiple } from 'contexts/SelectMultiple';
@@ -11,7 +11,7 @@ import { getInternalModifiers } from './utils/getInternalModifiers';
 /** The Modifiers context store the modifiers used in DayPicker. To access the value of this context, use {@link useModifiers}. */
 export const ModifiersContext = createContext<Modifiers | undefined>(undefined);
 
-export type ModifiersProviderProps = PropsWithChildren;
+export type ModifiersProviderProps = { children: ReactNode };
 
 /** Provide the value for the {@link ModifiersContext}. */
 export function ModifiersProvider(props: ModifiersProviderProps): JSX.Element {

--- a/src/contexts/SelectRange/SelectRangeContext.tsx
+++ b/src/contexts/SelectRange/SelectRangeContext.tsx
@@ -44,9 +44,9 @@ export const SelectRangeContext = createContext<
   SelectRangeContextValue | undefined
 >(undefined);
 
-type SelectRangeProviderProps = {
+type SelectRangeProviderProps = PropsWithChildren<{
   initialProps: DayPickerBase;
-} & PropsWithChildren;
+}>;
 
 /** Provides the values for the {@link SelectRangeProvider}. */
 export function SelectRangeProvider(
@@ -76,9 +76,9 @@ export function SelectRangeProvider(
   );
 }
 
-type SelectRangeProviderInternalProps = {
+type SelectRangeProviderInternalProps = PropsWithChildren<{
   initialProps: DayPickerRangeProps;
-} & PropsWithChildren;
+}>;
 
 export function SelectRangeProviderInternal({
   initialProps,


### PR DESCRIPTION
### Context

The newest version of react-day-picker is not compatible with @types/react 17.

### Analysis


In the last version of the library some props were declare with PropsWithChildren. This interface originally in @types/react 17 is:

```
    type PropsWithChildren<P> = P & { children?: ReactNode | undefined };
```

but in @types/react version 18 it has changed to

```
    type PropsWithChildren<P = unknown> = P & { children?: ReactNode | undefined };
```

Please note the new default of unknown. This mean new typing relies on @types/react@18 doesn't have to provide the typing when using PropsWithChildren, however it is a must with @types/react@17. The usage of PropsWithChildren in react-day-picker without the argument for the generic type make it incompatible with projects using React 17.

### Solution

When using PropsWithChildren, always include argument for the generic typing so that it's also compatible with React 17 codebase. 
In this PR I also change some places where the prop is declare as equal to PropsWithChildren (e.g. MonthsProps) to explicitly type as { children: ReactNode }. This ensure that children is required, and there is no need to rely on PropsWithChildren since there is no additional prop.
