### PR TITLE
build(types): add missing `Locale` imports

### DIFF
--- a/src/contexts/DayPicker/DayPickerContext.tsx
+++ b/src/contexts/DayPicker/DayPickerContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, ReactNode, useContext } from 'react';
 
+import { Locale } from 'date-fns';
 import { DayPickerProps } from 'DayPicker';
 
 import { CaptionLayout } from 'components/Caption';

--- a/src/contexts/DayPicker/formatters/formatDay.ts
+++ b/src/contexts/DayPicker/formatters/formatDay.ts
@@ -1,5 +1,4 @@
-import type { Locale } from 'date-fns';
-import { format } from 'date-fns';
+import { format, Locale } from 'date-fns';
 
 /**
  * The default formatter for the Day button.

--- a/src/contexts/DayPicker/formatters/formatMonthCaption.ts
+++ b/src/contexts/DayPicker/formatters/formatMonthCaption.ts
@@ -1,5 +1,4 @@
-import type { Locale } from 'date-fns';
-import { format } from 'date-fns';
+import { format, Locale } from 'date-fns';
 
 /**
  * The default formatter for the Month caption.

--- a/src/contexts/DayPicker/formatters/formatWeekdayName.ts
+++ b/src/contexts/DayPicker/formatters/formatWeekdayName.ts
@@ -1,5 +1,4 @@
-import type { Locale } from 'date-fns';
-import { format } from 'date-fns';
+import { format, Locale } from 'date-fns';
 
 /**
  * The default formatter for the name of the weekday.

--- a/src/contexts/DayPicker/formatters/formatYearCaption.ts
+++ b/src/contexts/DayPicker/formatters/formatYearCaption.ts
@@ -1,11 +1,13 @@
-import { format } from 'date-fns';
+import { format, Locale } from 'date-fns';
 
 /**
  * The default formatter for the Year caption.
  */
 export function formatYearCaption(
   year: Date,
-  options?: { locale?: Locale }
+  options?: {
+    locale?: Locale;
+  }
 ): string {
   return format(year, 'yyyy', options);
 }

--- a/src/types/DayPickerBase.ts
+++ b/src/types/DayPickerBase.ts
@@ -1,6 +1,6 @@
-import type { Locale } from 'date-fns';
-
 import { CSSProperties, ReactNode } from 'react';
+
+import { Locale } from 'date-fns';
 
 import { CaptionLayout, CaptionProps } from 'components/Caption';
 import { CaptionLabelProps } from 'components/CaptionLabel';

--- a/src/types/Formatters.ts
+++ b/src/types/Formatters.ts
@@ -1,9 +1,13 @@
 import { ReactNode } from 'react';
 
+import { Locale } from 'date-fns';
+
 /** Represents a function to format a date. */
 export type DateFormatter = (
   date: Date,
-  options?: { locale?: Locale }
+  options?: {
+    locale?: Locale;
+  }
 ) => ReactNode;
 
 /** Represent a map of formatters used to render localized content. */
@@ -25,5 +29,7 @@ export type Formatters = {
 /** Represent a function to format the week number. */
 export type WeekNumberFormatter = (
   weekNumber: number,
-  options?: { locale?: Locale }
+  options?: {
+    locale?: Locale;
+  }
 ) => ReactNode;

--- a/src/types/Labels.ts
+++ b/src/types/Labels.ts
@@ -1,4 +1,4 @@
-import type { Locale } from 'date-fns';
+import { Locale } from 'date-fns';
 
 import { ActiveModifiers } from 'types/Modifiers';
 
@@ -18,20 +18,31 @@ export type Labels = {
 export type DayLabel = (
   day: Date,
   activeModifiers: ActiveModifiers,
-  options?: { locale?: Locale }
+  options?: {
+    locale?: Locale;
+  }
 ) => string;
 
 /** Return the ARIA label for the "next month" / "prev month" buttons in the navigation.*/
 export type NavButtonLabel = (
   month?: Date,
-  options?: { locale?: Locale }
+  options?: {
+    locale?: Locale;
+  }
 ) => string;
 
 /** Return the ARIA label for the Head component.*/
-export type WeekdayLabel = (day: Date, options?: { locale?: Locale }) => string;
+export type WeekdayLabel = (
+  day: Date,
+  options?: {
+    locale?: Locale;
+  }
+) => string;
 
 /** Return the ARIA label of the week number.*/
 export type WeekNumberLabel = (
   n: number,
-  options?: { locale?: Locale }
+  options?: {
+    locale?: Locale;
+  }
 ) => string;


### PR DESCRIPTION
## Bug description

Build is failing locally because `Locale` types have not been imported. 

## Solution

Added imports from date-fns `Locale` where missing.