### PR TITLE
fix(types): cannot find module types/Matchers

### DIFF
--- a/src/types/EventHandlers.ts
+++ b/src/types/EventHandlers.ts
@@ -6,7 +6,7 @@ import {
   TouchEvent
 } from 'react';
 
-import { DateRange } from 'types/Matchers';
+import { DateRange } from './Matchers';
 
 import { ActiveModifiers } from './Modifiers';
 


### PR DESCRIPTION
…ponding type declarations.

### Context

when using this within a nextjs app the error Type error: Cannot find module 'types/Matchers' or its corresponding type declarations.

### Analysis

Something is causing a conflict with the tsconfig path matching

### Solution

Include the Matchers similar to Modifiers to prevent reliance on types/
