### PR TITLE
fix(docs): remove anchor from the Readme image

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@
 
 ➡️ **[react-day-picker.js.org](http://react-day-picker.js.org)** for guides, examples and API reference.
 
-<a href="http://react-day-picker.js.org">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcSet="https://user-images.githubusercontent.com/120693/188241991-19d0e8a1-230a-48c8-8477-3c90d4e36197.png"/>
-    <source media="(prefers-color-scheme: light)" srcSet="https://user-images.githubusercontent.com/120693/188238076-311ec6d1-503d-4c21-8ffe-d89faa60e40f.png"/>
-    <img alt="Shows a screenshot of the React DayPicker component in a browser’s window." width="900" />
-  </picture>
-</a>
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcSet="https://user-images.githubusercontent.com/120693/188241991-19d0e8a1-230a-48c8-8477-3c90d4e36197.png"/>
+  <source media="(prefers-color-scheme: light)" srcSet="https://user-images.githubusercontent.com/120693/188238076-311ec6d1-503d-4c21-8ffe-d89faa60e40f.png"/>
+  <img alt="Shows a screenshot of the React DayPicker component in a browser’s window." width="900" />
+</picture>
 
 ## Main features
 


### PR DESCRIPTION
### Context

In the current documentation site, the header image looks like a component that seems clickable but opens the same site in the new tab when clicked which leads to a confusing user experience.

### Solution

I have removed the surrounding anchor tag around the picture element. I understand that it made sense to have it in the readme because it was in Github but since the same readme is parsed and used in the landing page I think the other links in the readme should be enough to help a visitor in Github to get to the website.
