### PR TITLE
docs: matcher api reference page uses incorrect object syntax

### DIFF
--- a/src/types/Matchers.ts
+++ b/src/types/Matchers.ts
@@ -16,12 +16,12 @@
  * const dateMatcher: Matcher = new Date();
  *
  * // will match the days in the array
- * const arrayMatcher: Matcher = [new Date(2019, 1, 2);, new Date(2019, 1, 4)];
+ * const arrayMatcher: Matcher = [new Date(2019, 1, 2), new Date(2019, 1, 4)];
  *
  * // will match days after the 2nd of February 2019
- * const afterMatcher: DateAfter = { after: new Date(2019, 1, 2); };
+ * const afterMatcher: DateAfter = { after: new Date(2019, 1, 2) };
  *  // will match days before the 2nd of February 2019 }
- * const beforeMatcher: DateBefore = { before: new Date(2019, 1, 2); };
+ * const beforeMatcher: DateBefore = { before: new Date(2019, 1, 2) };
  *
  * // will match Sundays
  * const dayOfWeekMatcher: DayOfWeek = {
@@ -30,13 +30,13 @@
  *
  * // will match the included days, except the two dates
  * const intervalMatcher: DateInterval = {
- *    after: new Date(2019, 1, 2);,
+ *    after: new Date(2019, 1, 2),
  *    before: new Date(2019, 1, 5)
  * };
  *
  * // will match the included days, including the two dates
  * const rangeMatcher: DateRange = {
- *    from: new Date(2019, 1, 2);,
+ *    from: new Date(2019, 1, 2),
  *    to: new Date(2019, 1, 5)
  * };
  *


### PR DESCRIPTION
### Context

Closes #1976 
I would like to improve the website docs as per the contributing guide's website proofreading line. 

### Analysis

It's important that the documentation is consistent and correct, which is why I would like to add these small fixes to the typos

### Solution

Removed the incorrect `;` from the following lines:  
`const arrayMatcher: Matcher = [new Date(2019, 1, 2);, new Date(2019, 1, 4)];`
`const afterMatcher: DateAfter = { after: new Date(2019, 1, 2); };`
`const beforeMatcher: DateBefore = { before: new Date(2019, 1, 2); };`
`const rangeMatcher: DateRange = {
   from: new Date(2019, 1, 2);,
   to: new Date(2019, 1, 5)
};`
on the [Type alias: Matcher](https://react-day-picker.js.org/api/types/Matcher) API reference documentation

 