### PR TITLE
docs: fix typo

### DIFF
--- a/src/types/Matchers.ts
+++ b/src/types/Matchers.ts
@@ -72,7 +72,7 @@ export type DateInterval = { before: Date; after: Date };
 /** A matcher to match a range of dates. The range can be open. Differently from {@link DateInterval}, the dates here are included. */
 export type DateRange = { from: Date | undefined; to?: Date | undefined };
 
-/** A matcher to match a date being one of the specified days of the week (`0-7`, where `0` is Sunday). */
+/** A matcher to match a date being one of the specified days of the week (`0-6`, where `0` is Sunday). */
 export type DayOfWeek = { dayOfWeek: number[] };
 
 /** Returns true if `matcher` is of type {@link DateInterval}. */


### PR DESCRIPTION
### Context

There are only 7 days in a week, so either the actual range is 0-6 or Sunday is both day 0 and 7

### Analysis

Trying this out, I don't believe days higher than 6 do anything. Updating the comment to reflect the valid range.

### Solution

Update the comment
