### PR TITLE
docs: adjust example wording: "the today's date"

### DIFF
--- a/website/examples/modifiers-today.tsx
+++ b/website/examples/modifiers-today.tsx
@@ -3,12 +3,12 @@ import React, { useState } from 'react';
 import { DayClickEventHandler, DayPicker } from 'react-day-picker';
 
 export default function App() {
-  const initialFooter = <p>Try clicking the today’s date.</p>;
+  const initialFooter = <p>Try clicking today’s date.</p>;
   const [footer, setFooter] = useState(initialFooter);
 
   const handleDayClick: DayClickEventHandler = (day, modifiers) => {
     if (modifiers.today) {
-      setFooter(<p>You clicked the today’s date.</p>);
+      setFooter(<p>You clicked today’s date.</p>);
     } else {
       setFooter(initialFooter);
     }

--- a/website/test-integration/examples/modifiers-today.test.tsx
+++ b/website/test-integration/examples/modifiers-today.test.tsx
@@ -30,7 +30,7 @@ describe('when rendering a month that contains today', () => {
 describe('when the today date is clicked', () => {
   beforeEach(async () => act(() => user.click(getDayButton(today))));
   test('should update the footer', () => {
-    expect(getTableFooter()).toHaveTextContent('You clicked the today’s date');
+    expect(getTableFooter()).toHaveTextContent('You clicked today’s date');
   });
 });
 
@@ -38,8 +38,6 @@ describe('when another date is clicked', () => {
   const date = addDays(today, 1);
   beforeEach(async () => act(() => user.click(getDayButton(date))));
   test('should update the footer', () => {
-    expect(getTableFooter()).toHaveTextContent(
-      'Try clicking the today’s date.'
-    );
+    expect(getTableFooter()).toHaveTextContent('Try clicking today’s date.');
   });
 });


### PR DESCRIPTION
### Context
<img width="334" alt="image" src="https://github.com/gpbl/react-day-picker/assets/99420996/5a949292-8b10-4a44-b16a-22d9f3153b04">

### Analysis

None

### Solution

"the today's date" is a bit awkward, so update it to just say "today's date".
