### PR TITLE
fix(types): `firstWeekContainsDate` to be only Monday or Thursday

### DIFF
--- a/src/components/Table/utils/daysToMonthWeeks.ts
+++ b/src/components/Table/utils/daysToMonthWeeks.ts
@@ -20,7 +20,7 @@ export function daysToMonthWeeks(
     ISOWeek?: boolean;
     locale?: Locale;
     weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-    firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7;
+    firstWeekContainsDate?: 1 | 4;
   }
 ): MonthWeek[] {
   const toWeek = options?.ISOWeek

--- a/src/components/Table/utils/getMonthWeeks.test.ts
+++ b/src/components/Table/utils/getMonthWeeks.test.ts
@@ -65,12 +65,12 @@ describe('when using the "enGB" locale', () => {
       expect(weekNumbers[weekNumbers.length - 1]).toEqual(5);
     });
   });
-  describe('when setting a 3 as first day of year', () => {
+  describe('when setting thursday as first day of year', () => {
     const date = new Date(2022, 0);
-    const weeks = getMonthWeeks(date, { locale, firstWeekContainsDate: 3 });
-    test('the number of week should have number 53', () => {
+    const weeks = getMonthWeeks(date, { locale, firstWeekContainsDate: 4 });
+    test('the number of week should have number 52', () => {
       const weekNumbers = weeks.map((week) => week.weekNumber);
-      expect(weekNumbers[0]).toEqual(53);
+      expect(weekNumbers[0]).toEqual(52);
     });
   });
 });

--- a/src/components/Table/utils/getMonthWeeks.ts
+++ b/src/components/Table/utils/getMonthWeeks.ts
@@ -26,7 +26,7 @@ export function getMonthWeeks(
     locale: Locale;
     useFixedWeeks?: boolean;
     weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
-    firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7;
+    firstWeekContainsDate?: 1 | 4;
     ISOWeek?: boolean;
   }
 ): MonthWeek[] {

--- a/src/types/DayPickerBase.ts
+++ b/src/types/DayPickerBase.ts
@@ -210,7 +210,7 @@ export interface DayPickerBase {
    *
    * See also {@link ISOWeek}.
    */
-  firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7;
+  firstWeekContainsDate?: 1 | 4;
   /**
    * Use ISO week dates instead of the locale setting. See also
    * https://en.wikipedia.org/wiki/ISO_week_date.


### PR DESCRIPTION
This change is required for compatibility with date-fns v3.