### PR TITLE
fix(types): replace deprecated React.SFC type

### DIFF
--- a/types/Props.d.ts
+++ b/types/Props.d.ts
@@ -44,7 +44,7 @@ export interface DayPickerProps {
   captionElement?:
     | React.ReactElement<Partial<CaptionElementProps>>
     | React.ComponentClass<CaptionElementProps>
-    | React.SFC<CaptionElementProps>;
+    | React.FunctionComponent<CaptionElementProps>;
   className?: string;
   classNames?: ClassNames;
   containerProps?: React.DetailedHTMLProps<
@@ -69,7 +69,7 @@ export interface DayPickerProps {
   navbarElement?:
     | React.ReactElement<Partial<NavbarElementProps>>
     | React.ComponentClass<NavbarElementProps>
-    | React.SFC<NavbarElementProps>;
+    | React.FunctionComponent<NavbarElementProps>;
   numberOfMonths?: number;
   onBlur?: (e: React.FocusEvent<HTMLDivElement>) => void;
   onCaptionClick?: (month: Date, e: React.MouseEvent<HTMLDivElement>) => void;
@@ -142,7 +142,7 @@ export interface DayPickerProps {
   weekdayElement?:
     | React.ReactElement<Partial<WeekdayElementProps>>
     | React.ComponentClass<WeekdayElementProps>
-    | React.SFC<WeekdayElementProps>;
+    | React.FunctionComponent<WeekdayElementProps>;
   weekdaysLong?: string[];
   weekdaysShort?: string[];
   tabIndex?: number;


### PR DESCRIPTION
## Description
Replaces [deprecated](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/30364) `React.SFC` type with `React.FunctionComponent`.

It's required to passing `@types/react` 18 linter check:

```
node_modules/react-day-picker/types/Props.d.ts:47:13 - error TS2694: Namespace 'React' has no exported member 'SFC'.

47     | React.SFC<CaptionElementProps>;
```

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
Before submitting your pull request, please make sure the following is done:
- [x] I have read the [CONTRIBUTING](./CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have followed the coding guidelines in this project
- [ ] I have tested my changes on different browsers and screen sizes

## Linked Issues
If this PR addresses any existing issues, please link them here. Example: `Fixes #123`

## Test Plan
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate)
Include screenshots or GIFs if relevant. This is especially important for UI-related changes.

## Further Comments
If you have any additional comments or questions, please add them here.
