### PR TITLE
fix(types): Add support for props that exist on downstream providers whose props are derived from prop spreading

### DIFF
--- a/src/contexts/RootProvider.tsx
+++ b/src/contexts/RootProvider.tsx
@@ -8,11 +8,21 @@ import { NavigationProvider } from './Navigation';
 import { SelectMultipleProvider } from './SelectMultiple';
 import { SelectRangeProvider } from './SelectRange';
 import { SelectSingleProvider } from './SelectSingle';
+import { DayPickerDefaultProps } from 'types/DayPickerDefault';
+import { DayPickerSingleProps } from 'types/DayPickerSingle';
+import { DayPickerMultipleProps } from 'types/DayPickerMultiple';
+import { DayPickerRangeProps } from 'types/DayPickerRange';
+
+type RootContextProps =
+  | Partial<DayPickerDefaultProps>
+  | Partial<DayPickerSingleProps>
+  | Partial<DayPickerMultipleProps>
+  | Partial<DayPickerRangeProps>;
 
 /** The props of {@link RootProvider}. */
-export interface RootContext {
+export type RootContext = RootContextProps & {
   children?: ReactNode;
-}
+};
 
 /** Provide the value for all the context providers. */
 export function RootProvider(props: RootContext): JSX.Element {


### PR DESCRIPTION
## Description
Fix for #2072

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
Before submitting your pull request, please make sure the following is done:
- [x] I have read the [CONTRIBUTING](./CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have followed the coding guidelines in this project
- [ ] I have tested my changes on different browsers and screen sizes

## Linked Issues
Fixes #2072

## Test Plan
I have a project that relies on this repo and I'm currently casting `RootProvider` as `any` to avoid this.  If this does not resolve the issue I am dedicated to a fix because I like to avoid `any` at ALL costs

## Further Comments
Candidly, I don't know if this will _definitely_ fix the issue, but it silenced any warning / errors on my local machine in VS Code
