### PR TITLE
build: Fix Preact support by externalizing JSX runtime

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -44,7 +44,7 @@ const mainConfig = {
       }
     }
   ],
-  external: ['react', 'date-fns', 'date-fns/locale'],
+  external: ['react', 'react/jsx-runtime', 'date-fns', 'date-fns/locale'],
   plugins: [
     nodeResolve(),
     commonjs(),


### PR DESCRIPTION
## Description

When [the new jsx transform was introduced](https://github.com/gpbl/react-day-picker/commit/f3327c92ee2142ec4ced28a257ba3c84386f8127), a copy of the JSX runtime started getting included in the `index.esm.js` bundle. Including this copy meant that we could no longer swap out that module when building our own downstream Preact project. In effect, it broke Preact support.

To fix this, I've updated the `rollup` config to treat `react/jsx-runtime` as an external dependency. By externalizing the JSX runtime in this project, it 1) reduces the library bundle size by 32% and 2) allows downstream projects to use whatever JSX runtime they want.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Could possibly be considered a breaking change, but I don't know the landscape of dependent projects well enough to know if that's true.

## Checklist
Before submitting your pull request, please make sure the following is done:
- [x] I have read the [CONTRIBUTING](./CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have followed the coding guidelines in this project
- [ ] I have tested my changes on different browsers and screen sizes

## Linked Issues
If this PR addresses any existing issues, please link them here. Example: `Fixes #123`

## Test Plan
You can test that it removes the runtime by searching for the `jsxDEV` function in `dist/index.esm.js` before and after the change. You can also see that the file size changed from `144KB` to `97KB`.

I can also create a branch in my downstream project for testing upon request.
