### PR TITLE
docs(website): fix wrong link to the react.js project website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React DayPicker
 
-[DayPicker](http://react-day-picker.js.org) is a date picker component for [React](https://reactjs.org). Renders a monthly calendar to select days. DayPicker is customizable, works great with input fields and can be styled to match any design.
+[DayPicker](http://react-day-picker.js.org) is a date picker component for [React](https://react.dev/). Renders a monthly calendar to select days. DayPicker is customizable, works great with input fields and can be styled to match any design.
 
 ➡️ **[react-day-picker.js.org](http://react-day-picker.js.org)** for guides, examples and API reference.
 


### PR DESCRIPTION
## Description

Fix wrong / outdated link to the react.js project website.
```diff
-https://reactjs.dev/
+https://react.dev/
```
## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update