### PR TITLE
docs: fix date-fns locale link in localization.mdx

### DIFF
--- a/website/docs/using-daypicker/localization.mdx
+++ b/website/docs/using-daypicker/localization.mdx
@@ -8,7 +8,7 @@ sidebar_position: 5
 
 | Prop Name               | Type                                          | Description                                                        |
 | ----------------------- | --------------------------------------------- | ------------------------------------------------------------------ |
-| `locale`                | [`Locale`](http://date-fns.org/docs/Locale)   | Set the locale. Default is `en-US`.                                |
+| `locale`                | [`Locale`](http://date-fns.org/docs/I18n)   | Set the locale. Default is `en-US`.                                |
 | `weekStartsOn`          | `1` \| `2` \| `3` \| `4` \| `5` \| `6` \| `7` | Display the days falling into the other months.                    |
 | `firstWeekContainsDate` | `1` \| `4`                                    | Configure the first date in the first week of the year.            |
 | `ISOWeek`               | `boolean`                                     | Use [ISO Week Dates](https://en.wikipedia.org/wiki/ISO_week_date). |


### PR DESCRIPTION

## Description

This simply fixes the url to the locale in date-fns. (see screenshots below)


## Type of Change

- [x] Documentation update

## Screenshots (if appropriate)

# Before 
![image](https://github.com/gpbl/react-day-picker/assets/46135573/171b8a8b-1367-406b-b3ff-587838732c37)

# After 
![image](https://github.com/gpbl/react-day-picker/assets/46135573/fb425a03-9725-4186-ae19-d83f98be62e9)
