### PR TITLE
[FIX] Add type module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "types": "./dist/cjs/index.d.ts",
   "module": "./dist/esm/index.js",
   "style": "./src/style.css",
+  "type": "module",
   "exports": {
     ".": {
       "require": {


### PR DESCRIPTION
## Description

There is a missing `type: module` in `package.json` making jest be lost when trying to use esm/cjs.

<img width="672" alt="Capture d’écran 2024-06-24 à 16 29 39" src="https://github.com/gpbl/react-day-picker/assets/50388474/65129fbb-01bf-444a-aa44-2f26e71f90f2">

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

Before submitting your pull request, please make sure the following is done:

- [x] I have read the [CONTRIBUTING](./CONTRIBUTING.md) doc
- / I have added tests that prove my fix is effective or that my feature works
- / I have added necessary documentation (if appropriate)
- [x] I have followed the coding guidelines in this project
- [x] I have tested my changes on different browsers and screen sizes

## Linked Issues

No posted issue

## Test Plan

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate)

Include screenshots or GIFs if relevant. This is especially important for UI-related changes.

## Further Comments

If you have any additional comments or questions, please add them here.
