### PR TITLE
fix: typo in css rdp-hidden

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -263,7 +263,7 @@
 
 .rdp-hidden {
   visibility: hidden;
-  color: var(end-range_start-color);
+  color: var(--rdp-range_start-color);
 }
 
 .rdp-range_start {


### PR DESCRIPTION
## What's Changed

Renamed css variable `end-range_start-color` to `--rdp-range_start-color`. This error is preventing project build.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
