### PR TITLE
fix: typo in css rdp-hidden module css

### DIFF
--- a/src/style.module.css
+++ b/src/style.module.css
@@ -262,7 +262,7 @@
 
 .hidden {
   visibility: hidden;
-  color: var(end-range_start-color);
+  color: var(--rdp-range_start-color);
 }
 
 .range_start {


### PR DESCRIPTION

## What's Changed

Follow up to #2298. I use CSS modules, so my CSS preprocessor (PostCSS) refuses to build in this situation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

