### PR TITLE
Fix broken link: "Upgrading from v7 to v8"

### DIFF
--- a/website/docs/upgrading.mdx
+++ b/website/docs/upgrading.mdx
@@ -9,7 +9,7 @@ This release includes important updates related to accessibility, styles, intern
 <details>
   <summary>**Upgrading from v7**</summary>
 
-If you are upgrading from v7, this guide is still valid for you. Read first the [migration guide from v7 to v8](#upgrade-from-v7-to-v8) and then follow the steps below.
+If you are upgrading from v7, this guide is still valid for you. Read first the [migration guide from v7 to v8](/v8/upgrading#upgrade-to-v8) and then follow the steps below.
 
 </details>
 


### PR DESCRIPTION
## What's Changed

Fix broken link: "Upgrading from v7 to v8". The link was missing the `/v8` prefix. Adding it points correctly to the v8 version of the website.

## Type of Change

- [x] Documentation update