### PR TITLE
Replace deprecated props

### DIFF
--- a/website/docs/upgrading.mdx
+++ b/website/docs/upgrading.mdx
@@ -108,8 +108,8 @@ In case you are using `fromDate` or `toDate`, replace them with the `hidden` and
 
 | Removed prop | Notes                                                                                                        |
 | ------------ | ------------------------------------------------------------------------------------------------------------ |
-| ~`fromDate`~ | Replace it with `fromMonth` and the `hidden` prop and the `before` [Matcher](./api/type-aliases/Matcher.md). |
-| ~`toDate`~   | Replace it with `toMonth` the `hidden` prop and the `after` [Matcher](./api/type-aliases/Matcher.md).        |
+| ~`fromDate`~ | Replace it with `startMonth` and the `hidden` prop and the `before` [Matcher](./api/type-aliases/Matcher.md). |
+| ~`toDate`~   | Replace it with `endMonth` the `hidden` prop and the `after` [Matcher](./api/type-aliases/Matcher.md).        |
 
 #### Example
 


### PR DESCRIPTION
# Pull Request Template

`fromMonth` has been renamed to `startMonth`,
`toMonth` has been renamed to `endMonth`

## What's Changed

Deprecated prop use fixed in upgrade docs

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update