### PR TITLE
feat: allow undefined as initially selected value

### DIFF
--- a/examples/SingleRequired.tsx
+++ b/examples/SingleRequired.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import { DayPicker } from "react-day-picker";
 
 export function SingleRequired() {
-  const [selectedDay, setSelectedDay] = useState<Date>(new Date());
+  const [selectedDay, setSelectedDay] = useState<Date>();
 
   return (
     <DayPicker

--- a/src/DayPicker.test.tsx
+++ b/src/DayPicker.test.tsx
@@ -19,19 +19,19 @@ import { MonthsProps } from "./components/Months";
 const testId = "test";
 const dayPicker = () => screen.getByTestId(testId);
 
-test("should render a date picker component", () => {
+test("render a date picker component", () => {
   render(<DayPicker data-testid={testId} />);
   expect(dayPicker()).toBeInTheDocument();
 });
 
-it("should render the navigation and month grids", () => {
+test("render the navigation and month grids", () => {
   render(<DayPicker data-testid={testId} />);
 
   expect(nav()).toBeInTheDocument();
   expect(grid()).toBeInTheDocument();
 });
 
-it("should apply classnames and style according to props", () => {
+test("apply classnames and style according to props", () => {
   render(
     <DayPicker
       data-testid={testId}
@@ -47,7 +47,7 @@ it("should apply classnames and style according to props", () => {
   expect(dayPicker()).toHaveStyle({ color: "red" });
 });
 
-it("should use custom components", () => {
+test("use custom components", () => {
   render(
     <DayPicker
       data-testid={testId}
@@ -91,7 +91,7 @@ describe("when the grid is focused", () => {
   beforeAll(() => jest.setSystemTime(today));
   afterAll(() => jest.useRealTimers());
 
-  test("should focus the today's date", async () => {
+  test("focus the today's date", async () => {
     render(<DayPicker mode="single" today={today} />);
     await user.tab();
     await user.tab();
@@ -99,7 +99,7 @@ describe("when the grid is focused", () => {
     expect(activeElement()).toBe(dateButton(today));
   });
   describe("when the today’s date is disabled", () => {
-    test("should focus the first day of the month", async () => {
+    test("focus the first day of the month", async () => {
       render(<DayPicker mode="single" disabled={today} />);
       await user.tab();
       await user.tab();
@@ -126,8 +126,27 @@ describe("when a day is mouse entered", () => {
     fireEvent.mouseEnter(dateButton(today));
     fireEvent.mouseLeave(dateButton(today));
   });
-  test("should call the event handler", async () => {
+  test("call the event handler", async () => {
     expect(handleDayMouseEnter).toHaveBeenCalled();
     expect(handleDayMouseLeave).toHaveBeenCalled();
+  });
+});
+
+describe("when a day is clicked", () => {
+  const handleDayClick = jest.fn();
+  const today = startOfDay(new Date());
+  beforeEach(async () => {
+    render(
+      <DayPicker
+        today={today}
+        defaultMonth={today}
+        mode="single"
+        onDayClick={handleDayClick}
+      />
+    );
+    fireEvent.click(dateButton(today));
+  });
+  test("call the event handler", async () => {
+    expect(handleDayClick).toHaveBeenCalled();
   });
 });

--- a/src/DayPicker.test.tsx
+++ b/src/DayPicker.test.tsx
@@ -19,19 +19,19 @@ import { MonthsProps } from "./components/Months";
 const testId = "test";
 const dayPicker = () => screen.getByTestId(testId);
 
-test("render a date picker component", () => {
+test("should render a date picker component", () => {
   render(<DayPicker data-testid={testId} />);
   expect(dayPicker()).toBeInTheDocument();
 });
 
-test("render the navigation and month grids", () => {
+it("should render the navigation and month grids", () => {
   render(<DayPicker data-testid={testId} />);
 
   expect(nav()).toBeInTheDocument();
   expect(grid()).toBeInTheDocument();
 });
 
-test("apply classnames and style according to props", () => {
+it("should apply classnames and style according to props", () => {
   render(
     <DayPicker
       data-testid={testId}
@@ -47,7 +47,7 @@ test("apply classnames and style according to props", () => {
   expect(dayPicker()).toHaveStyle({ color: "red" });
 });
 
-test("use custom components", () => {
+it("should use custom components", () => {
   render(
     <DayPicker
       data-testid={testId}
@@ -91,7 +91,7 @@ describe("when the grid is focused", () => {
   beforeAll(() => jest.setSystemTime(today));
   afterAll(() => jest.useRealTimers());
 
-  test("focus the today's date", async () => {
+  test("should focus the today's date", async () => {
     render(<DayPicker mode="single" today={today} />);
     await user.tab();
     await user.tab();
@@ -99,7 +99,7 @@ describe("when the grid is focused", () => {
     expect(activeElement()).toBe(dateButton(today));
   });
   describe("when the today’s date is disabled", () => {
-    test("focus the first day of the month", async () => {
+    test("should focus the first day of the month", async () => {
       render(<DayPicker mode="single" disabled={today} />);
       await user.tab();
       await user.tab();
@@ -126,27 +126,8 @@ describe("when a day is mouse entered", () => {
     fireEvent.mouseEnter(dateButton(today));
     fireEvent.mouseLeave(dateButton(today));
   });
-  test("call the event handler", async () => {
+  test("should call the event handler", async () => {
     expect(handleDayMouseEnter).toHaveBeenCalled();
     expect(handleDayMouseLeave).toHaveBeenCalled();
-  });
-});
-
-describe("when a day is clicked", () => {
-  const handleDayClick = jest.fn();
-  const today = startOfDay(new Date());
-  beforeEach(async () => {
-    render(
-      <DayPicker
-        today={today}
-        defaultMonth={today}
-        mode="single"
-        onDayClick={handleDayClick}
-      />
-    );
-    fireEvent.click(dateButton(today));
-  });
-  test("call the event handler", async () => {
-    expect(handleDayClick).toHaveBeenCalled();
   });
 });

--- a/src/selection/useMulti.tsx
+++ b/src/selection/useMulti.tsx
@@ -22,14 +22,7 @@ export function useMulti<T extends DayPickerProps>(
     initiallySelected
   );
 
-  const { isSameDay, Date } = dateLib;
-
-  // Update the selected date if the required flag is set.
-  React.useEffect(() => {
-    if (required && selected === undefined) {
-      setSelected([new Date()]);
-    }
-  }, [required, selected, Date, mode]);
+  const { isSameDay } = dateLib;
 
   // Update the selected date if the selected value from props changes.
   React.useEffect(() => {

--- a/src/selection/useRange.tsx
+++ b/src/selection/useRange.tsx
@@ -16,7 +16,6 @@ export function useRange<T extends DayPickerProps>(
   dateLib: DateLib
 ): Selection<T> {
   const {
-    mode,
     disabled,
     excludeDisabled,
     selected: initiallySelected,
@@ -27,13 +26,6 @@ export function useRange<T extends DayPickerProps>(
   const [selected, setSelected] = React.useState<DateRange | undefined>(
     initiallySelected
   );
-
-  // Update the selected date if the required flag is set.
-  React.useEffect(() => {
-    if (required && selected === undefined) {
-      setSelected({ from: undefined, to: undefined });
-    }
-  }, [required, selected, mode]);
 
   // Update the selected date if the `selected` prop changes.
   React.useEffect(() => {

--- a/src/selection/useSingle.tsx
+++ b/src/selection/useSingle.tsx
@@ -23,21 +23,14 @@ export function useSingle<T extends DayPickerProps>(
   const {
     selected: initiallySelected,
     required,
-    onSelect,
-    mode
+    onSelect
   } = props as PropsSingle;
 
   const [selected, setSelected] = React.useState<Date | undefined>(
     initiallySelected
   );
 
-  const { isSameDay, Date, startOfDay } = dateLib;
-  // Update the selected date if the required flag is set.
-  React.useEffect(() => {
-    if (required && selected === undefined) {
-      setSelected(startOfDay(new Date()));
-    }
-  }, [required, selected, Date, startOfDay, mode]);
+  const { isSameDay } = dateLib;
 
   // Update the selected date if the `selected` value changes.
   React.useEffect(() => {

--- a/src/types/props.test.tsx
+++ b/src/types/props.test.tsx
@@ -2,6 +2,8 @@ import React from "react";
 
 import { DayPicker } from "../DayPicker";
 
+import { DateRange } from "./shared";
+
 const Test = () => {
   return (
     <>
@@ -23,14 +25,19 @@ const Test = () => {
         required
         onSelect={(date: Date | undefined) => {}}
       />
-      {/* @ts-expect-error selected should not be undefined. */}
+      {/* Allow undefined as initial selected value */}
       <DayPicker mode="single" required selected={undefined} />
       <DayPicker
         mode="multiple"
-        required={true}
-        // @ts-expect-error Missing `selected`
+        required
         selected={undefined}
         onSelect={(selected: Date[], date: Date, modifiers) => {}}
+      />
+      <DayPicker
+        mode="range"
+        required
+        selected={undefined}
+        onSelect={(selected: DateRange, date: Date, modifiers) => {}}
       />
       <DayPicker
         mode="multiple"

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -470,7 +470,7 @@ export interface PropsSingleRequired {
   mode: "single";
   required: true;
   /** The selected date. */
-  selected: Date;
+  selected: Date | undefined;
   /** Event handler when a day is selected. */
   onSelect?: (
     selected: Date,
@@ -506,7 +506,7 @@ export interface PropsMultiRequired {
   mode: "multiple";
   required: true;
   /** The selected dates. */
-  selected: Date[];
+  selected: Date[] | undefined;
   /** Event handler when days are selected. */
   onSelect?: (
     selected: Date[],
@@ -557,7 +557,7 @@ export interface PropsRangeRequired {
    */
   excludeDisabled?: boolean | undefined;
   /** The selected range. */
-  selected: DateRange;
+  selected: DateRange | undefined;
   /** Event handler when a range is selected. */
   onSelect?: (
     selected: DateRange,

--- a/website/docs/docs/selection-modes.mdx
+++ b/website/docs/docs/selection-modes.mdx
@@ -17,8 +17,8 @@ The `mode` prop determines the selection mode. The `disabled` prop can be used t
 | `mode`     | `"single"` \| `"multiple"` \| `"range"`                                              | Enter a selection mode.                 |
 | `disabled` | [`Matcher`](../api/type-aliases/Matcher.md) \| `Matcher[]`                           | Disabled days that cannot be selected.  |
 | `selected` | `Date` \| `Date[]` \| [`DateRange`](../api/type-aliases/DateRange.md) \| `undefined` | The selected day(s).                    |
-| `required` | `boolean`                                                                            | Make the selection required.            |
-| `onSelect` | `(selected, date, modifiers, e) => void`                                             | Event callback when a date is selected. |
+| `required` | `boolean`                                                                            | When `true`, the selection is required. |
+| `onSelect` | `(selected, triggerDate, modifiers, e) => void`                                      | Event callback when a date is selected. |
 
 ## Single Mode
 
@@ -34,11 +34,11 @@ When the `mode` prop is set to `"single"`, only one day can be selected.
 
 ### Single Mode Props
 
-| Prop Name  | Type                                     | Description                             |
-| ---------- | ---------------------------------------- | --------------------------------------- |
-| `selected` | `Date \| undefined`                      | The selected date.                      |
-| `onSelect` | `(selected, date, modifiers, e) => void` | Event callback when a date is selected. |
-| `required` | `boolean`                                | Make the selection required.            |
+| Prop Name  | Type                                            | Description                             |
+| ---------- | ----------------------------------------------- | --------------------------------------- |
+| `selected` | `Date \| undefined`                             | The selected date.                      |
+| `onSelect` | `(selected, triggerDate, modifiers, e) => void` | Event callback when a date is selected. |
+| `required` | `boolean`                                       | Make the selection required.            |
 
 Use the `selected` and `onSelect` props to control the selected date:
 
@@ -137,7 +137,7 @@ When the `mode` prop is set to `"range"`, DayPicker allows selecting a continuou
 | Prop Name         | Type                                            | Description                             |
 | ----------------- | ----------------------------------------------- | --------------------------------------- |
 | `selected`        | [`DateRange`](../api/type-aliases/DateRange.md) | The selected range.                     |
-| `onSelect`        | `(selected, date, modifiers, e) => void`        | Event callback when a date is selected. |
+| `onSelect`        | `(selected, triggerDate, modifiers, e) => void` | Event callback when a date is selected. |
 | `required`        | `boolean`                                       | Make the selection required.            |
 | `min`             | `number`                                        | The minimum dates that can be selected. |
 | `max`             | `number`                                        | The maximum dates that can be selected. |

--- a/website/docs/docs/selection-modes.mdx
+++ b/website/docs/docs/selection-modes.mdx
@@ -17,8 +17,8 @@ The `mode` prop determines the selection mode. The `disabled` prop can be used t
 | `mode`     | `"single"` \| `"multiple"` \| `"range"`                                              | Enter a selection mode.                 |
 | `disabled` | [`Matcher`](../api/type-aliases/Matcher.md) \| `Matcher[]`                           | Disabled days that cannot be selected.  |
 | `selected` | `Date` \| `Date[]` \| [`DateRange`](../api/type-aliases/DateRange.md) \| `undefined` | The selected day(s).                    |
-| `required` | `boolean`                                                                            | When `true`, the selection is required. |
-| `onSelect` | `(selected, triggerDate, modifiers, e) => void`                                      | Event callback when a date is selected. |
+| `required` | `boolean`                                                                            | Make the selection required.            |
+| `onSelect` | `(selected, date, modifiers, e) => void`                                             | Event callback when a date is selected. |
 
 ## Single Mode
 
@@ -34,11 +34,11 @@ When the `mode` prop is set to `"single"`, only one day can be selected.
 
 ### Single Mode Props
 
-| Prop Name  | Type                                            | Description                             |
-| ---------- | ----------------------------------------------- | --------------------------------------- |
-| `selected` | `Date \| undefined`                             | The selected date.                      |
-| `onSelect` | `(selected, triggerDate, modifiers, e) => void` | Event callback when a date is selected. |
-| `required` | `boolean`                                       | Make the selection required.            |
+| Prop Name  | Type                                     | Description                             |
+| ---------- | ---------------------------------------- | --------------------------------------- |
+| `selected` | `Date \| undefined`                      | The selected date.                      |
+| `onSelect` | `(selected, date, modifiers, e) => void` | Event callback when a date is selected. |
+| `required` | `boolean`                                | Make the selection required.            |
 
 Use the `selected` and `onSelect` props to control the selected date:
 
@@ -76,12 +76,13 @@ By setting the `mode` prop to `"multiple"`, DayPicker allows selecting multiple 
 
 ### Multiple Mode Props
 
-| Prop Name  | Type                                            | Description                             |
-| ---------- | ----------------------------------------------- | --------------------------------------- |
-| `selected` | `Date[] \| undefined`                           | The selected dates.                     |
-| `onSelect` | `(selected, triggerDate, modifiers, e) => void` | Event callback when a date is selected. |
-| `min`      | `number`                                        | The minimum dates that can be selected. |
-| `max`      | `number`                                        | The maximum dates that can be selected. |
+| Prop Name  | Type                                     | Description                             |
+| ---------- | ---------------------------------------- | --------------------------------------- |
+| `selected` | `Date[] \| undefined`                    | The selected dates.                     |
+| `onSelect` | `(selected, date, modifiers, e) => void` | Event callback when a date is selected. |
+| `min`      | `number`                                 | The minimum dates that can be selected. |
+| `max`      | `number`                                 | The maximum dates that can be selected. |
+| `required` | `boolean`                                | Make the selection required.            |
 
 Use the `selected` and `onSelect` props to control the selected date:
 
@@ -109,7 +110,7 @@ Use the `min` and `max` props to limit the number of selectable dates.
 
 ### Required Selection
 
-By setting the `required` prop, DayPicker requires at least one date to be selected.
+By setting the `required` prop, DayPicker won't allow unselect the selected dates.
 
 ```tsx
 <DayPicker mode="multiple" required selected={[new Date()]} />
@@ -136,7 +137,7 @@ When the `mode` prop is set to `"range"`, DayPicker allows selecting a continuou
 | Prop Name         | Type                                            | Description                             |
 | ----------------- | ----------------------------------------------- | --------------------------------------- |
 | `selected`        | [`DateRange`](../api/type-aliases/DateRange.md) | The selected range.                     |
-| `onSelect`        | `(selected, triggerDate, modifiers, e) => void` | Event callback when a date is selected. |
+| `onSelect`        | `(selected, date, modifiers, e) => void`        | Event callback when a date is selected. |
 | `required`        | `boolean`                                       | Make the selection required.            |
 | `min`             | `number`                                        | The minimum dates that can be selected. |
 | `max`             | `number`                                        | The maximum dates that can be selected. |
@@ -158,7 +159,7 @@ Similarly, you can se the `max` prop to set the maximum number of nights.
 
 ### Required Ranges
 
-By setting the `required` prop, a range must be selected. 
+By setting the `required` prop, DayPicker won't allow unselect the selected range.
 
 ```tsx
 <DayPicker mode="range" required />


### PR DESCRIPTION
Allow setting `selected={undefined}` even when required is set. Fixes #2334.

Thanks @gharabaghi for your suggestion!