### PR TITLE
Export ChevronProps

### DIFF
--- a/src/components/Chevron.tsx
+++ b/src/components/Chevron.tsx
@@ -38,3 +38,5 @@ export function Chevron(props: {
     </svg>
   );
 }
+
+export type ChevronProps = Parameters<typeof Chevron>[0];


### PR DESCRIPTION
## What's Changed

Exporting the type of `Chevron`’s `props` as `ChevronProps`. All other custom components do export their types. It was missing on `Chevron`.

## Type of Change

- [x] Bug fix
