### PR TITLE
fix: missing variable name

### DIFF
--- a/website/docs/docs/styling.mdx
+++ b/website/docs/docs/styling.mdx
@@ -79,7 +79,7 @@ The following table lists the CSS variables used by DayPicker inside the `.rdp-r
 | `--rdp-nav-height`                        | The height of the navigation bar.                                             |
 | `--rdp-range_middle-background-color`     | The color of the background for days in the middle of a range.                |
 | `--rdp-range_middle-font`                 | The font for days in the middle of a range.                                   |
-| `-- `                                     | The color of the text for days in the middle of a range.                      |
+| `--rdp-range_middle-foreground-color`     | The color of the text for days in the middle of a range.                      |
 | `--rdp-range_start-color`                 | The color of the range text at the start of the range.                        |
 | `--rdp-range_start-background`            | Used for the background of the start of the selected range.                   |
 | `--rdp-range_start-date-background-color` | The background color of the date at the start of the selected range.          |


### PR DESCRIPTION
## What's Changed

Fix `styling.mdx` for a missing variable: `--rdp-range_middle-foreground-color`

## Type of Change

- [x] Documentation update
