### PR TITLE
fix: pass month and years dropdown classes to the related components

### DIFF
--- a/src/DayPicker.tsx
+++ b/src/DayPicker.tsx
@@ -367,6 +367,7 @@ export function DayPicker(props: DayPickerProps) {
                       {captionLayout === "dropdown" ||
                       captionLayout === "dropdown-months" ? (
                         <components.Dropdown
+                          className={classNames[UI.MonthsDropdown]}
                           aria-label={labelMonthDropdown()}
                           classNames={classNames}
                           components={components}
@@ -384,6 +385,7 @@ export function DayPicker(props: DayPickerProps) {
                       {captionLayout === "dropdown" ||
                       captionLayout === "dropdown-years" ? (
                         <components.Dropdown
+                          className={classNames[UI.YearsDropdown]}
                           aria-label={labelYearDropdown(labelOptions)}
                           classNames={classNames}
                           components={components}


### PR DESCRIPTION
Fixes: #2393

## What's Changed

This pull request passes the `MonthsDropdown` and `YearsDropdown` classes to the related components. With these classes, users will be able to differentiate between these two dropdowns.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
