### PR TITLE
fix: use correct month to disable Chevron of NextMonthButton

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -56,7 +56,7 @@ export function Nav(
         onClick={props.onNextClick}
       >
         <components.Chevron
-          disabled={previousMonth ? undefined : true}
+          disabled={nextMonth ? undefined : true}
           orientation="right"
           className={classNames[UI.Chevron]}
         />


### PR DESCRIPTION
## What's Changed

Inside the `NextMonthButton` component, the `disabled` prop is now using the correct _next month_ reference for the `Chevron` component.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
