### PR TITLE
fix(tests): use of `dateLib` to work when mocking dates

### DIFF
--- a/examples/SingleMockDate.test.tsx
+++ b/examples/SingleMockDate.test.tsx
@@ -1,0 +1,39 @@
+/* This test uses mockdate to ensure date mocking works as it should. */
+import React from "react";
+
+import { render } from "@testing-library/react";
+import MockDate from "mockdate";
+
+import { dateButton, gridcell } from "@/test/elements";
+import { user } from "@/test/user";
+
+import { Single } from "./Single";
+
+const today = new Date(2021, 10, 25);
+
+beforeAll(() => MockDate.set(today));
+afterAll(() => MockDate.reset());
+
+beforeEach(() => {
+  render(<Single />);
+});
+
+describe("when a day is clicked", () => {
+  const day = new Date(2021, 10, 1);
+  beforeEach(async () => {
+    await user.click(dateButton(day));
+  });
+  test("should appear as selected", () => {
+    expect(gridcell(day, true)).toHaveAttribute("aria-selected", "true");
+    expect(dateButton(day)).toHaveFocus();
+    expect(gridcell(day, true)).toHaveClass("rdp-selected");
+  });
+  describe("when the day is clicked again", () => {
+    beforeEach(async () => {
+      await user.click(dateButton(day));
+    });
+    test("should not appear as selected", () => {
+      expect(gridcell(day, true)).not.toHaveAttribute("aria-selected");
+    });
+  });
+});

--- a/src/classes/CalendarDay.ts
+++ b/src/classes/CalendarDay.ts
@@ -1,5 +1,5 @@
+import type { DateLib } from "../lib/index.js";
 import { dateLib as defaultDateLib } from "../lib/index.js";
-import type { DateLib } from "../types/index.js";
 
 /**
  * Represent the day displayed in the calendar.

--- a/src/formatters/formatCaption.ts
+++ b/src/formatters/formatCaption.ts
@@ -1,5 +1,8 @@
-import { FormatOptions, dateLib as defaultDateLib } from "../lib/index.js";
-import type { DateLib } from "../types/index.js";
+import {
+  FormatOptions,
+  dateLib as defaultDateLib,
+  type DateLib
+} from "../lib/index.js";
 
 /**
  * Format the caption of the month.

--- a/src/formatters/formatDay.ts
+++ b/src/formatters/formatDay.ts
@@ -1,6 +1,5 @@
-import type { FormatOptions } from "../lib/dateLib.js";
+import type { FormatOptions, DateLib } from "../lib/dateLib.js";
 import { dateLib as defaultDateLib } from "../lib/index.js";
-import type { DateLib } from "../types/index.js";
 
 /**
  * Format the day date shown in the day cell.

--- a/src/formatters/formatWeekdayName.ts
+++ b/src/formatters/formatWeekdayName.ts
@@ -1,6 +1,5 @@
-import type { FormatOptions } from "../lib/dateLib.js";
+import type { FormatOptions, DateLib } from "../lib/dateLib.js";
 import { dateLib as defaultDateLib } from "../lib/index.js";
-import type { DateLib } from "../types/index.js";
 
 /**
  * Format the weekday name to be displayed in the weekdays header.

--- a/src/helpers/getDateLib.ts
+++ b/src/helpers/getDateLib.ts
@@ -1,5 +1,5 @@
-import { dateLib } from "../lib/dateLib.js";
-import type { DateLib, DayPickerProps } from "../types/index.js";
+import { dateLib, type DateLib } from "../lib/dateLib.js";
+import type { DayPickerProps } from "../types/index.js";
 
 export function getDateLib(customLib: DayPickerProps["dateLib"]): DateLib {
   return {

--- a/src/helpers/getDates.ts
+++ b/src/helpers/getDates.ts
@@ -26,8 +26,7 @@ export function getDates(
     differenceInCalendarDays,
     differenceInCalendarMonths,
     isAfter,
-    endOfMonth,
-    Date
+    endOfMonth
   } = dateLib;
 
   const startWeekFirstDate = ISOWeek
@@ -61,7 +60,7 @@ export function getDates(
   if (fixedWeeks && dates.length < extraDates) {
     for (let i = 0; i < 7; i++) {
       const date = addDays(dates[dates.length - 1], 1);
-      dates.push(new Date(date));
+      dates.push(date);
     }
   }
   return dates;

--- a/src/helpers/getDisplayMonths.ts
+++ b/src/helpers/getDisplayMonths.ts
@@ -1,4 +1,5 @@
-import type { DateLib, DayPickerProps } from "../types/index.js";
+import type { DateLib } from "../lib/index.js";
+import type { DayPickerProps } from "../types/index.js";
 
 export function getDisplayMonths(
   firstDisplayedMonth: Date,

--- a/src/helpers/getFocusableDate.ts
+++ b/src/helpers/getFocusableDate.ts
@@ -1,5 +1,5 @@
+import type { DateLib } from "../lib/index.js";
 import type {
-  DateLib,
   DayPickerProps,
   MoveFocusBy,
   MoveFocusDir

--- a/src/helpers/getInitialMonth.ts
+++ b/src/helpers/getInitialMonth.ts
@@ -21,7 +21,11 @@ export function getInitialMonth(
   const {
     month,
     defaultMonth,
-    today = props.timeZone ? TZDate.tz(props.timeZone) : new dateLib.Date(),
+    today = props.timeZone
+      ? TZDate.tz(props.timeZone)
+      : dateLib.Date
+        ? new dateLib.Date()
+        : new Date(),
     numberOfMonths = 1,
     endMonth,
     startMonth

--- a/src/helpers/getMonthOptions.ts
+++ b/src/helpers/getMonthOptions.ts
@@ -1,6 +1,6 @@
 import { DropdownOption } from "../components/Dropdown.js";
-import type { Locale } from "../lib/dateLib.js";
-import type { DateLib, Formatters } from "../types/index.js";
+import type { Locale, DateLib } from "../lib/dateLib.js";
+import type { Formatters } from "../types/index.js";
 
 /** Return the months to show in the dropdown. */
 export function getMonthOptions(
@@ -14,7 +14,7 @@ export function getMonthOptions(
   if (!navStart) return undefined;
   if (!navEnd) return undefined;
 
-  const { addMonths, startOfMonth, isBefore, Date } = dateLib;
+  const { addMonths, startOfMonth, isBefore } = dateLib;
   const year = displayMonth.getFullYear();
 
   const months: number[] = [];
@@ -28,9 +28,12 @@ export function getMonthOptions(
   });
   const options = sortedMonths.map((value) => {
     const label = formatters.formatMonthDropdown(value, locale);
+    const month = dateLib.Date
+      ? new dateLib.Date(year, value)
+      : new Date(year, value);
     const disabled =
-      (navStart && new Date(year, value) < startOfMonth(navStart)) ||
-      (navEnd && new Date(year, value) > startOfMonth(navEnd)) ||
+      (navStart && month < startOfMonth(navStart)) ||
+      (navEnd && month > startOfMonth(navEnd)) ||
       false;
     return { value, label, disabled };
   });

--- a/src/helpers/getMonths.ts
+++ b/src/helpers/getMonths.ts
@@ -1,5 +1,6 @@
 import { CalendarWeek, CalendarDay, CalendarMonth } from "../classes/index.js";
-import type { DateLib, DayPickerProps } from "../types/index.js";
+import type { DateLib } from "../lib/index.js";
+import type { DayPickerProps } from "../types/index.js";
 
 /** Return the months to display in the calendar. */
 export function getMonths(

--- a/src/helpers/getNavMonth.ts
+++ b/src/helpers/getNavMonth.ts
@@ -1,6 +1,7 @@
 import { TZDate } from "@date-fns/tz";
 
-import type { DateLib, DayPickerProps } from "../types/index.js";
+import type { DateLib } from "../lib/index.js";
+import type { DayPickerProps } from "../types/index.js";
 
 /** Return the start and end months for the calendar navigation. */
 export function getNavMonths(
@@ -11,6 +12,7 @@ export function getNavMonths(
     | "startMonth"
     | "today"
     | "timeZone"
+    | "dateLib"
     // Deprecated:
     | "fromMonth"
     | "fromYear"
@@ -27,8 +29,7 @@ export function getNavMonths(
     startOfMonth,
     endOfMonth,
     addYears,
-    endOfYear,
-    Date
+    endOfYear
   } = dateLib;
 
   // Handle deprecated code
@@ -54,7 +55,11 @@ export function getNavMonths(
   } else if (!startMonth && hasDropdowns) {
     const today =
       props.today ??
-      (props.timeZone ? TZDate.tz(props.timeZone) : new dateLib.Date());
+      (props.timeZone
+        ? TZDate.tz(props.timeZone)
+        : dateLib.Date
+          ? new dateLib.Date()
+          : new Date());
     startMonth = startOfYear(addYears(today, -100));
   }
   if (endMonth) {
@@ -64,7 +69,11 @@ export function getNavMonths(
   } else if (!endMonth && hasDropdowns) {
     const today =
       props.today ??
-      (props.timeZone ? TZDate.tz(props.timeZone) : new dateLib.Date());
+      (props.timeZone
+        ? TZDate.tz(props.timeZone)
+        : dateLib.Date
+          ? new dateLib.Date()
+          : new Date());
     endMonth = endOfYear(today);
   }
   return [

--- a/src/helpers/getNextFocus.tsx
+++ b/src/helpers/getNextFocus.tsx
@@ -1,6 +1,6 @@
 import { CalendarDay } from "../classes/index.js";
+import type { DateLib } from "../lib/index.js";
 import type {
-  DateLib,
   DayPickerProps,
   MoveFocusBy,
   MoveFocusDir

--- a/src/helpers/getNextMonth.ts
+++ b/src/helpers/getNextMonth.ts
@@ -1,4 +1,5 @@
-import type { DateLib, DayPickerProps } from "../types/index.js";
+import type { DateLib } from "../lib/index.js";
+import type { DayPickerProps } from "../types/index.js";
 
 /**
  * Return the next month the user can navigate to according to the given

--- a/src/helpers/getPreviousMonth.ts
+++ b/src/helpers/getPreviousMonth.ts
@@ -1,4 +1,5 @@
-import type { DateLib, DayPickerProps } from "../types/index.js";
+import type { DateLib } from "../lib/index.js";
+import type { DayPickerProps } from "../types/index.js";
 
 /**
  * Return the next previous the user can navigate to, according to the given

--- a/src/helpers/getWeekdays.ts
+++ b/src/helpers/getWeekdays.ts
@@ -1,8 +1,7 @@
 import { TZDate } from "@date-fns/tz";
 
-import type { Locale } from "../lib/dateLib.js";
+import type { Locale, DateLib } from "../lib/dateLib.js";
 import { dateLib as defaultDateLib } from "../lib/index.js";
-import type { DateLib } from "../types/index.js";
 
 /**
  * Generate a series of 7 days, starting from the week, to use for formatting
@@ -18,7 +17,11 @@ export function getWeekdays(
   /** @ignore */
   dateLib: DateLib = defaultDateLib
 ): Date[] {
-  const date = timeZone ? TZDate.tz(timeZone) : new dateLib.Date();
+  const date = timeZone
+    ? TZDate.tz(timeZone)
+    : dateLib.Date
+      ? new dateLib.Date()
+      : new Date();
   const start = ISOWeek
     ? dateLib.startOfISOWeek(date)
     : dateLib.startOfWeek(date, { locale, weekStartsOn });

--- a/src/helpers/getYearOptions.ts
+++ b/src/helpers/getYearOptions.ts
@@ -1,5 +1,6 @@
 import { DropdownOption } from "../components/Dropdown.js";
-import type { DateLib, Formatters } from "../types/index.js";
+import type { DateLib } from "../lib/dateLib.js";
+import type { Formatters } from "../types/index.js";
 
 /** Return the years to show in the dropdown. */
 export function getYearOptions(
@@ -17,8 +18,7 @@ export function getYearOptions(
     endOfYear,
     addYears,
     isBefore,
-    isSameYear,
-    Date
+    isSameYear
   } = dateLib;
   const month = displayMonth.getMonth();
   const firstNavYear = startOfYear(calendarStart);
@@ -32,11 +32,12 @@ export function getYearOptions(
   }
 
   return years.map((value) => {
+    const year = dateLib.Date
+      ? new dateLib.Date(value, month)
+      : new Date(value, month);
     const disabled =
-      (calendarStart && new Date(value, month) < startOfMonth(calendarStart)) ||
-      (month &&
-        calendarEnd &&
-        new Date(value, month) > startOfMonth(calendarEnd)) ||
+      (calendarStart && year < startOfMonth(calendarStart)) ||
+      (month && calendarEnd && year > startOfMonth(calendarEnd)) ||
       false;
     const label = formatters.formatYearDropdown(value);
     return {

--- a/src/labels/labelGrid.ts
+++ b/src/labels/labelGrid.ts
@@ -1,6 +1,5 @@
-import type { LabelOptions } from "../lib/dateLib.js";
+import type { LabelOptions, DateLib } from "../lib/dateLib.js";
 import { dateLib as defaultDateLib } from "../lib/index.js";
-import { DateLib } from "../types/index.js";
 
 /**
  * Return an ARIA label for the month grid, that will be announced when entering

--- a/src/labels/labelWeekday.ts
+++ b/src/labels/labelWeekday.ts
@@ -1,6 +1,5 @@
-import type { LabelOptions } from "../lib/dateLib.js";
+import type { LabelOptions, DateLib } from "../lib/dateLib.js";
 import { dateLib as defaultDateLib } from "../lib/index.js";
-import type { DateLib } from "../types/index.js";
 
 /**
  * The ARIA label for the Weekday column header.

--- a/src/lib/dateLib.ts
+++ b/src/lib/dateLib.ts
@@ -42,35 +42,98 @@ export type Locale = DateFnsLocale;
 
 export type { Month as DateFnsMonth } from "date-fns";
 
+/**
+ * The date library used by DayPicker. It's a subset of the date-fns functions
+ * plus an optional Date constructor.
+ *
+ * Override the default date library with the `dateLib` prop.
+ */
 export type DateLib = {
+  /** The constructor of the date object. */
   Date?: DateConstructor | undefined;
+
+  /** Adds the specified number of days to the given date. */
   addDays: typeof addDays;
+
+  /** Adds the specified number of months to the given date. */
   addMonths: typeof addMonths;
+
+  /** Adds the specified number of weeks to the given date. */
   addWeeks: typeof addWeeks;
+
+  /** Adds the specified number of years to the given date. */
   addYears: typeof addYears;
+
+  /** Returns the number of calendar days between the given dates. */
   differenceInCalendarDays: typeof differenceInCalendarDays;
+
+  /** Returns the number of calendar months between the given dates. */
   differenceInCalendarMonths: typeof differenceInCalendarMonths;
+
+  /** Returns the end of an ISO week for the given date. */
   endOfISOWeek: typeof endOfISOWeek;
+
+  /** Returns the end of the month for the given date. */
   endOfMonth: typeof endOfMonth;
+
+  /** Returns the end of the week for the given date. */
   endOfWeek: typeof endOfWeek;
+
+  /** Returns the end of the year for the given date. */
   endOfYear: typeof endOfYear;
+
+  /** Formats the given date using the specified format string. */
   format: typeof format;
+
+  /** Returns the ISO week number for the given date. */
   getISOWeek: typeof getISOWeek;
+
+  /** Returns the week number for the given date. */
   getWeek: typeof getWeek;
+
+  /** Checks if the first date is after the second date. */
   isAfter: typeof isAfter;
+
+  /** Checks if the first date is before the second date. */
   isBefore: typeof isBefore;
+
+  /** Checks if the given value is a date. */
   isDate: typeof isDate;
+
+  /** Checks if the given dates are the same day. */
   isSameDay: typeof isSameDay;
+
+  /** Checks if the given dates are in the same month. */
   isSameMonth: typeof isSameMonth;
+
+  /** Checks if the given dates are in the same year. */
   isSameYear: typeof isSameYear;
+
+  /** Returns the maximum of the given dates. */
   max: typeof max;
+
+  /** Returns the minimum of the given dates. */
   min: typeof min;
+
+  /** Sets the month for the given date. */
   setMonth: typeof setMonth;
+
+  /** Sets the year for the given date. */
   setYear: typeof setYear;
+
+  /** Returns the start of the day for the given date. */
   startOfDay: typeof startOfDay;
+
+  /** Returns the start of an ISO week for the given date. */
   startOfISOWeek: typeof startOfISOWeek;
+
+  /** Returns the start of the month for the given date. */
   startOfMonth: typeof startOfMonth;
+
+  /** Returns the start of the week for the given date. */
   startOfWeek: typeof startOfWeek;
+
+  /** Returns the start of the year for the given date. */
   startOfYear: typeof startOfYear;
 };
 
@@ -81,8 +144,6 @@ export type DateLib = {
  * @internal
  */
 export const dateLib = {
-  /** The constructor of the date object. */
-  Date: undefined,
   addDays,
   addMonths,
   addWeeks,

--- a/src/lib/dateLib.ts
+++ b/src/lib/dateLib.ts
@@ -1,4 +1,3 @@
-import { GenericDateConstructor } from "date-fns";
 import type {
   FormatOptions as DateFnsFormatOptions,
   Locale as DateFnsLocale
@@ -43,6 +42,38 @@ export type Locale = DateFnsLocale;
 
 export type { Month as DateFnsMonth } from "date-fns";
 
+export type DateLib = {
+  Date?: DateConstructor | undefined;
+  addDays: typeof addDays;
+  addMonths: typeof addMonths;
+  addWeeks: typeof addWeeks;
+  addYears: typeof addYears;
+  differenceInCalendarDays: typeof differenceInCalendarDays;
+  differenceInCalendarMonths: typeof differenceInCalendarMonths;
+  endOfISOWeek: typeof endOfISOWeek;
+  endOfMonth: typeof endOfMonth;
+  endOfWeek: typeof endOfWeek;
+  endOfYear: typeof endOfYear;
+  format: typeof format;
+  getISOWeek: typeof getISOWeek;
+  getWeek: typeof getWeek;
+  isAfter: typeof isAfter;
+  isBefore: typeof isBefore;
+  isDate: typeof isDate;
+  isSameDay: typeof isSameDay;
+  isSameMonth: typeof isSameMonth;
+  isSameYear: typeof isSameYear;
+  max: typeof max;
+  min: typeof min;
+  setMonth: typeof setMonth;
+  setYear: typeof setYear;
+  startOfDay: typeof startOfDay;
+  startOfISOWeek: typeof startOfISOWeek;
+  startOfMonth: typeof startOfMonth;
+  startOfWeek: typeof startOfWeek;
+  startOfYear: typeof startOfYear;
+};
+
 /**
  * The default date library to use with the date picker.
  *
@@ -51,7 +82,7 @@ export type { Month as DateFnsMonth } from "date-fns";
  */
 export const dateLib = {
   /** The constructor of the date object. */
-  Date: Date as GenericDateConstructor<Date>,
+  Date: undefined,
   addDays,
   addMonths,
   addWeeks,

--- a/src/selection/useMulti.tsx
+++ b/src/selection/useMulti.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 
 import { useControlledValue } from "../helpers/useControlledValue.js";
+import type { DateLib } from "../lib/dateLib.js";
 import type {
-  DateLib,
   DayPickerProps,
   Modifiers,
   PropsMulti,

--- a/src/selection/useRange.tsx
+++ b/src/selection/useRange.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 
 import { useControlledValue } from "../helpers/useControlledValue.js";
+import type { DateLib } from "../lib/index.js";
 import type {
-  DateLib,
   DayPickerProps,
   Modifiers,
   PropsRange,

--- a/src/selection/useSingle.tsx
+++ b/src/selection/useSingle.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 
 import { useControlledValue } from "../helpers/useControlledValue.js";
+import type { DateLib } from "../lib/index.js";
 import type {
-  DateLib,
   DayPickerProps,
   Modifiers,
   PropsSingle,

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -1,7 +1,7 @@
 import React from "react";
 
 import type { DeprecatedUI } from "../UI.js";
-import type { Locale } from "../lib/dateLib.js";
+import type { Locale, DateLib } from "../lib/dateLib.js";
 
 import type {
   ClassNames,
@@ -16,8 +16,7 @@ import type {
   DayEventHandler,
   Modifiers,
   DateRange,
-  Mode,
-  DateLib
+  Mode
 } from "./shared.js";
 
 /**

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -26,7 +26,6 @@ import {
   labelWeekNumberHeader,
   labelYearDropdown
 } from "../labels/index.js";
-import { dateLib } from "../lib/index.js";
 
 /**
  * Selection modes supported by DayPicker.
@@ -103,9 +102,6 @@ export type CustomComponents = {
   /** Render the dropdown with the years. */
   YearsDropdown: typeof components.YearsDropdown;
 };
-
-/** @private */
-export type DateLib = typeof dateLib;
 
 /** Represent a map of formatters used to render localized content. */
 export type Formatters = {

--- a/src/useCalendar.ts
+++ b/src/useCalendar.ts
@@ -15,8 +15,8 @@ import { getNextMonth } from "./helpers/getNextMonth.js";
 import { getPreviousMonth } from "./helpers/getPreviousMonth.js";
 import { getWeeks } from "./helpers/getWeeks.js";
 import { useControlledValue } from "./helpers/useControlledValue.js";
+import type { DateLib } from "./lib/index.js";
 import type { DayPickerProps } from "./types/props.js";
-import type { DateLib } from "./types/shared.js";
 
 /**
  * Return the calendar object to work with the calendar in custom components.

--- a/src/useFocus.ts
+++ b/src/useFocus.ts
@@ -3,10 +3,10 @@ import { useState } from "react";
 import type { CalendarDay } from "./classes/index.js";
 import { calculateFocusTarget } from "./helpers/calculateFocusTarget.js";
 import { getNextFocus } from "./helpers/getNextFocus.js";
+import type { DateLib } from "./lib/index.js";
 import type {
   MoveFocusBy,
   MoveFocusDir,
-  DateLib,
   DayPickerProps,
   Modifiers
 } from "./types/index.js";

--- a/src/useGetModifiers.tsx
+++ b/src/useGetModifiers.tsx
@@ -2,7 +2,8 @@ import { TZDate } from "@date-fns/tz";
 
 import { DayFlag, SelectionState } from "./UI.js";
 import { CalendarDay } from "./classes/index.js";
-import type { DateLib, DayPickerProps, Modifiers } from "./types/index.js";
+import type { DateLib } from "./lib/index.js";
+import type { DayPickerProps, Modifiers } from "./types/index.js";
 import { dateMatchModifiers } from "./utils/dateMatchModifiers.js";
 
 /**
@@ -51,7 +52,12 @@ export function useGetModifiers(
 
     const isToday = isSameDay(
       date,
-      today ?? (props.timeZone ? TZDate.tz(props.timeZone) : new dateLib.Date())
+      today ??
+        (props.timeZone
+          ? TZDate.tz(props.timeZone)
+          : dateLib.Date
+            ? new dateLib.Date()
+            : new Date())
     );
 
     if (isOutside) internalModifiersMap.outside.push(day);

--- a/src/useSelection.ts
+++ b/src/useSelection.ts
@@ -1,7 +1,8 @@
+import { type DateLib } from "./lib/index.js";
 import { useMulti } from "./selection/useMulti.js";
 import { useRange } from "./selection/useRange.js";
 import { useSingle } from "./selection/useSingle.js";
-import type { DateLib, DayPickerProps } from "./types/index.js";
+import type { DayPickerProps } from "./types/index.js";
 import { Selection } from "./types/selection.js";
 
 export function useSelection<T extends DayPickerProps>(

--- a/src/utils/addToRange.ts
+++ b/src/utils/addToRange.ts
@@ -1,5 +1,5 @@
-import { dateLib as defaultDateLib } from "../lib/index.js";
-import type { DateRange, DateLib } from "../types/index.js";
+import { dateLib as defaultDateLib, type DateLib } from "../lib/index.js";
+import type { DateRange } from "../types/index.js";
 
 /**
  * Add a day to an existing range.

--- a/src/utils/dateMatchModifiers.ts
+++ b/src/utils/dateMatchModifiers.ts
@@ -1,5 +1,5 @@
-import { dateLib as defaultDateLib } from "../lib/dateLib.js";
-import type { DateLib, Matcher } from "../types/index.js";
+import { dateLib as defaultDateLib, type DateLib } from "../lib/dateLib.js";
+import type { Matcher } from "../types/index.js";
 
 import { rangeIncludesDate } from "./rangeIncludesDate.js";
 import {

--- a/src/utils/rangeIncludesDate.ts
+++ b/src/utils/rangeIncludesDate.ts
@@ -1,5 +1,5 @@
-import { dateLib as defaultDateLib } from "../lib/index.js";
-import type { DateRange, DateLib } from "../types/index.js";
+import { dateLib as defaultDateLib, type DateLib } from "../lib/index.js";
+import type { DateRange } from "../types/index.js";
 
 /**
  * Determines whether a given date is inside a specified date range.

--- a/src/utils/typeguards.ts
+++ b/src/utils/typeguards.ts
@@ -1,8 +1,8 @@
+import type { DateLib } from "../lib/index.js";
 import type {
   DateAfter,
   DateBefore,
   DateInterval,
-  DateLib,
   DateRange,
   DayOfWeek
 } from "../types/index.js";


### PR DESCRIPTION
Fix #2477.