### PR TITLE
Explicitly provide resolved locale for all functions which need it

### DIFF
--- a/src/DayPicker.tsx
+++ b/src/DayPicker.tsx
@@ -103,7 +103,7 @@ export function DayPicker(props: DayPickerProps) {
     formatYearDropdown
   } = formatters;
 
-  const calendar = useCalendar(props, dateLib);
+  const calendar = useCalendar(props, dateLib, locale);
 
   const {
     days,
@@ -128,7 +128,8 @@ export function DayPicker(props: DayPickerProps) {
     calendar,
     getModifiers,
     isSelected ?? (() => false),
-    dateLib
+    dateLib,
+    locale
   );
 
   const {

--- a/src/helpers/getDates.test.ts
+++ b/src/helpers/getDates.test.ts
@@ -1,5 +1,4 @@
-import { dateLib } from "../lib";
-
+import { dateLib, defaultLocale as locale } from "..";
 import { getDates } from "./getDates";
 
 describe("when the first month and the last month are the same", () => {
@@ -13,7 +12,8 @@ describe("when the first month and the last month are the same", () => {
           {
             fixedWeeks: false
           },
-          dateLib
+          dateLib,
+          locale
         );
         expect(dates).toHaveLength(42);
         expect(dates[0]).toEqual(new Date(2023, 10, 26));
@@ -28,7 +28,8 @@ describe("when the first month and the last month are the same", () => {
           {
             fixedWeeks: true
           },
-          dateLib
+          dateLib,
+          locale
         );
         expect(dates).toHaveLength(42);
         expect(dates[0]).toEqual(new Date(2023, 10, 26));
@@ -46,7 +47,8 @@ describe("when the first month and the last month are the same", () => {
           {
             fixedWeeks: false
           },
-          dateLib
+          dateLib,
+          locale
         );
         expect(dates).toHaveLength(35);
         expect(dates[0]).toEqual(new Date(2023, 3, 30));
@@ -61,7 +63,8 @@ describe("when the first month and the last month are the same", () => {
           {
             fixedWeeks: true
           },
-          dateLib
+          dateLib,
+          locale
         );
         expect(dates).toHaveLength(42);
         expect(dates[0]).toEqual(new Date(2023, 3, 30));
@@ -78,7 +81,8 @@ describe("when the first month and the last month are the same", () => {
         {
           weekStartsOn: 1
         },
-        dateLib
+        dateLib,
+        locale
       );
       expect(dates[0]).toBeMonday();
       expect(dates[0]).toEqual(new Date(2023, 4, 1));
@@ -90,7 +94,13 @@ describe("when the first month and the last month are the same", () => {
     const maxDate = new Date(2023, 4, 15);
 
     it("the last day should be the max date", () => {
-      const dates = getDates([month], maxDate, { weekStartsOn: 1 }, dateLib);
+      const dates = getDates(
+        [month],
+        maxDate,
+        { weekStartsOn: 1 },
+        dateLib,
+        locale
+      );
       expect(dates).toHaveLength(15);
       expect(dates[dates.length - 1]).toEqual(maxDate);
     });
@@ -98,7 +108,13 @@ describe("when the first month and the last month are the same", () => {
   describe("when using ISO weeks", () => {
     const month = new Date(2023, 4, 1);
     it("the first day should be Monday", () => {
-      const dates = getDates([month], undefined, { ISOWeek: true }, dateLib);
+      const dates = getDates(
+        [month],
+        undefined,
+        { ISOWeek: true },
+        dateLib,
+        locale
+      );
       expect(dates[0]).toBeMonday();
       expect(dates[0]).toEqual(new Date(2023, 4, 1));
       expect(dates[dates.length - 1]).toEqual(new Date(2023, 5, 4));
@@ -117,7 +133,8 @@ describe("when the first month and the last month are different", () => {
         {
           fixedWeeks: false
         },
-        dateLib
+        dateLib,
+        locale
       );
       expect(dates).toHaveLength(252);
       expect(dates[0]).toEqual(new Date(2023, 3, 30));
@@ -136,7 +153,8 @@ describe("when the first month and the last month are different", () => {
         {
           weekStartsOn: 1
         },
-        dateLib
+        dateLib,
+        locale
       );
       expect(dates).toHaveLength(46);
       expect(dates[dates.length - 1]).toEqual(maxDate);
@@ -145,7 +163,13 @@ describe("when the first month and the last month are different", () => {
   describe("when using ISO weeks", () => {
     const month = new Date(2023, 4, 1);
     it("the first day should be Monday", () => {
-      const dates = getDates([month], undefined, { ISOWeek: true }, dateLib);
+      const dates = getDates(
+        [month],
+        undefined,
+        { ISOWeek: true },
+        dateLib,
+        locale
+      );
       expect(dates[0]).toBeMonday();
       expect(dates[0]).toEqual(new Date(2023, 4, 1));
       expect(dates[dates.length - 1]).toEqual(new Date(2023, 5, 4));

--- a/src/helpers/getDates.ts
+++ b/src/helpers/getDates.ts
@@ -1,4 +1,4 @@
-import { DateLib, DayPickerProps } from "../index.js";
+import type { DateLib, DayPickerProps, Locale } from "../index.js";
 
 /** The number of days in a month when having 6 weeks. */
 const NrOfDaysWithFixedWeeks = 42;
@@ -9,14 +9,15 @@ export function getDates(
   maxDate: Date | undefined,
   props: Pick<
     DayPickerProps,
-    "ISOWeek" | "fixedWeeks" | "locale" | "weekStartsOn" | "timeZone"
+    "ISOWeek" | "fixedWeeks" | "weekStartsOn" | "timeZone"
   >,
-  dateLib: DateLib
+  dateLib: DateLib,
+  locale: Locale
 ): Date[] {
   const firstMonth = displayMonths[0];
   const lastMonth = displayMonths[displayMonths.length - 1];
 
-  const { ISOWeek, fixedWeeks, locale, weekStartsOn } = props ?? {};
+  const { ISOWeek, fixedWeeks, weekStartsOn } = props ?? {};
   const {
     startOfWeek,
     endOfWeek,

--- a/src/helpers/getFocusableDate.ts
+++ b/src/helpers/getFocusableDate.ts
@@ -1,4 +1,4 @@
-import type { DateLib } from "../lib/index.js";
+import type { DateLib, Locale } from "../lib/index.js";
 import type {
   DayPickerProps,
   MoveFocusBy,
@@ -12,10 +12,11 @@ export function getFocusableDate(
   refDate: Date,
   navStart: Date | undefined,
   navEnd: Date | undefined,
-  props: Pick<DayPickerProps, "locale" | "ISOWeek" | "weekStartsOn">,
-  dateLib: DateLib
+  props: Pick<DayPickerProps, "ISOWeek" | "weekStartsOn">,
+  dateLib: DateLib,
+  locale: Locale
 ): Date {
-  const { weekStartsOn, locale, ISOWeek } = props;
+  const { weekStartsOn, ISOWeek } = props;
   const {
     addDays,
     addMonths,

--- a/src/helpers/getMonths.test.ts
+++ b/src/helpers/getMonths.test.ts
@@ -1,8 +1,8 @@
 import { DayPickerProps } from "react-day-picker";
 
 import { CalendarMonth } from "../classes";
-import { dateLib } from "../lib";
 
+import { dateLib, defaultLocale as locale } from "..";
 import { getMonths } from "./getMonths";
 
 const mockDates = [
@@ -19,14 +19,12 @@ const mockProps: Pick<
   DayPickerProps,
   | "fixedWeeks"
   | "ISOWeek"
-  | "locale"
   | "weekStartsOn"
   | "reverseMonths"
   | "firstWeekContainsDate"
 > = {
   fixedWeeks: false,
   ISOWeek: false,
-  locale: undefined,
   weekStartsOn: 0, // Sunday
   reverseMonths: false,
   firstWeekContainsDate: 1
@@ -35,7 +33,13 @@ const mockProps: Pick<
 it("should return the correct months without ISO weeks and reverse months", () => {
   const displayMonths = [new Date(2023, 5, 1)]; // June 2023
 
-  const result = getMonths(displayMonths, mockDates, mockProps, dateLib);
+  const result = getMonths(
+    displayMonths,
+    mockDates,
+    mockProps,
+    dateLib,
+    locale
+  );
 
   expect(result).toHaveLength(1);
   expect(result[0]).toBeInstanceOf(CalendarMonth);
@@ -47,7 +51,7 @@ it("should handle ISO weeks", () => {
 
   const isoProps = { ...mockProps, ISOWeek: true };
 
-  const result = getMonths(displayMonths, mockDates, isoProps, dateLib);
+  const result = getMonths(displayMonths, mockDates, isoProps, dateLib, locale);
 
   expect(result).toHaveLength(1);
   expect(result[0]).toBeInstanceOf(CalendarMonth);
@@ -62,7 +66,13 @@ it("should handle reverse months", () => {
 
   const reverseProps = { ...mockProps, reverseMonths: true };
 
-  const result = getMonths(displayMonths, mockDates, reverseProps, dateLib);
+  const result = getMonths(
+    displayMonths,
+    mockDates,
+    reverseProps,
+    dateLib,
+    locale
+  );
 
   expect(result).toHaveLength(2);
   expect(result[0].date).toEqual(new Date(2023, 5, 1)); // June 2023
@@ -74,7 +84,13 @@ it("should handle fixed weeks", () => {
 
   const fixedWeeksProps = { ...mockProps, fixedWeeks: true };
 
-  const result = getMonths(displayMonths, mockDates, fixedWeeksProps, dateLib);
+  const result = getMonths(
+    displayMonths,
+    mockDates,
+    fixedWeeksProps,
+    dateLib,
+    locale
+  );
 
   expect(result).toHaveLength(1);
   expect(result[0]).toBeInstanceOf(CalendarMonth);
@@ -84,7 +100,7 @@ it("should handle fixed weeks", () => {
 it("should handle months with no dates", () => {
   const displayMonths = [new Date(2023, 5, 1)]; // June 2023
 
-  const result = getMonths(displayMonths, [], mockProps, dateLib);
+  const result = getMonths(displayMonths, [], mockProps, dateLib, locale);
 
   expect(result).toHaveLength(1);
   expect(result[0]).toBeInstanceOf(CalendarMonth);

--- a/src/helpers/getMonths.ts
+++ b/src/helpers/getMonths.ts
@@ -1,5 +1,5 @@
 import { CalendarWeek, CalendarDay, CalendarMonth } from "../classes/index.js";
-import type { DateLib } from "../lib/index.js";
+import type { DateLib, Locale } from "../lib/index.js";
 import type { DayPickerProps } from "../types/index.js";
 
 /** Return the months to display in the calendar. */
@@ -13,13 +13,13 @@ export function getMonths(
     DayPickerProps,
     | "fixedWeeks"
     | "ISOWeek"
-    | "locale"
     | "weekStartsOn"
     | "reverseMonths"
     | "firstWeekContainsDate"
     | "timeZone"
   >,
-  dateLib: DateLib
+  dateLib: DateLib,
+  locale: Locale
 ): CalendarMonth[] {
   const {
     startOfWeek,
@@ -36,14 +36,14 @@ export function getMonths(
       const firstDateOfFirstWeek = props.ISOWeek
         ? startOfISOWeek(month)
         : startOfWeek(month, {
-            locale: props.locale,
+            locale,
             weekStartsOn: props.weekStartsOn
           });
 
       const lastDateOfLastWeek = props.ISOWeek
         ? endOfISOWeek(endOfMonth(month))
         : endOfWeek(endOfMonth(month), {
-            locale: props.locale,
+            locale,
             weekStartsOn: props.weekStartsOn
           });
 
@@ -66,7 +66,7 @@ export function getMonths(
           const weekNumber = props.ISOWeek
             ? getISOWeek(date)
             : getWeek(date, {
-                locale: props.locale,
+                locale,
                 weekStartsOn: props.weekStartsOn,
                 firstWeekContainsDate: props.firstWeekContainsDate
               });

--- a/src/helpers/getNavMonth.ts
+++ b/src/helpers/getNavMonth.ts
@@ -12,7 +12,6 @@ export function getNavMonths(
     | "startMonth"
     | "today"
     | "timeZone"
-    | "dateLib"
     // Deprecated:
     | "fromMonth"
     | "fromYear"

--- a/src/helpers/getNextFocus.test.tsx
+++ b/src/helpers/getNextFocus.test.tsx
@@ -1,16 +1,15 @@
 import { CalendarDay } from "../classes";
-import { dateLib } from "../lib";
 import type { DayPickerProps, MoveFocusBy, MoveFocusDir } from "../types";
 
+import { dateLib, defaultLocale as locale } from "..";
 import { getNextFocus } from "./getNextFocus";
 
 const props: Pick<
   DayPickerProps,
-  "disabled" | "hidden" | "startMonth" | "endMonth" | "dateLib"
+  "disabled" | "hidden" | "startMonth" | "endMonth"
 > = {
   disabled: [],
-  hidden: [],
-  dateLib
+  hidden: []
 };
 
 it("should return `undefined` if `attempt` exceeds 365", () => {
@@ -29,6 +28,7 @@ it("should return `undefined` if `attempt` exceeds 365", () => {
     undefined,
     props,
     dateLib,
+    locale,
     366
   );
   expect(result).toBeUndefined();
@@ -48,7 +48,8 @@ it("should return the focus date if it is not disabled or hidden", () => {
     undefined,
     undefined,
     props,
-    dateLib
+    dateLib,
+    locale
   );
   expect(result?.date).toEqual(expectedDate);
 });
@@ -71,7 +72,8 @@ it("should return the next focus date if it is disabled", () => {
       ...props,
       disabled: [disabledDate]
     },
-    dateLib
+    dateLib,
+    locale
   );
   expect(result?.date).toEqual(expectedDate);
 });
@@ -94,7 +96,8 @@ it("should return the next focus date if it is hidden", () => {
       ...props,
       hidden: [hiddenDate]
     },
-    dateLib
+    dateLib,
+    locale
   );
   expect(result?.date).toEqual(expectedDate);
 });

--- a/src/helpers/getNextFocus.tsx
+++ b/src/helpers/getNextFocus.tsx
@@ -1,5 +1,5 @@
 import { CalendarDay } from "../classes/index.js";
-import type { DateLib } from "../lib/index.js";
+import type { DateLib, Locale } from "../lib/index.js";
 import type {
   DayPickerProps,
   MoveFocusBy,
@@ -21,12 +21,12 @@ export function getNextFocus(
     | "disabled"
     | "hidden"
     | "modifiers"
-    | "locale"
     | "ISOWeek"
     | "weekStartsOn"
     | "timeZone"
   >,
   dateLib: DateLib,
+  locale: Locale,
   attempt: number = 0
 ): CalendarDay | undefined {
   if (attempt > 365) {
@@ -41,7 +41,8 @@ export function getNextFocus(
     calendarStartMonth,
     calendarEndMonth,
     props,
-    dateLib
+    dateLib,
+    locale
   );
 
   const isDisabled = Boolean(
@@ -68,6 +69,7 @@ export function getNextFocus(
     calendarEndMonth,
     props,
     dateLib,
+    locale,
     attempt + 1
   );
 }

--- a/src/helpers/getPossibleFocusDate.test.ts
+++ b/src/helpers/getPossibleFocusDate.test.ts
@@ -13,12 +13,11 @@ import {
 
 import type { DayPickerProps, MoveFocusBy, MoveFocusDir } from "../types";
 
-import { dateLib } from "..";
+import { dateLib, defaultLocale as locale } from "..";
 import { getFocusableDate } from "./getFocusableDate";
 
 const focusedDate = new Date(2023, 0, 1); // Jan 1, 2023
-const options: Pick<DayPickerProps, "locale" | "ISOWeek" | "weekStartsOn"> = {
-  locale: undefined,
+const options: Pick<DayPickerProps, "ISOWeek" | "weekStartsOn"> = {
   ISOWeek: false,
   weekStartsOn: 0 // Sunday
 };
@@ -51,7 +50,8 @@ testCases.forEach(({ moveBy, moveDir, expectedFn }) => {
       calendarStartMonth,
       calendarEndMonth,
       options,
-      dateLib
+      dateLib,
+      locale
     );
     expect(result).toEqual(expectedDate);
   });
@@ -84,7 +84,8 @@ weekTestCases.forEach(({ moveBy, moveDir, expectedFn }) => {
       calendarStartMonth,
       calendarEndMonth,
       options,
-      dateLib
+      dateLib,
+      locale
     );
 
     expect(result).toEqual(expectedDate);
@@ -110,7 +111,8 @@ ISOWeekTestCases.forEach(({ moveBy, moveDir, expectedFn }) => {
       calendarStartMonth,
       calendarEndMonth,
       { ...options, ISOWeek: true },
-      dateLib
+      dateLib,
+      locale
     );
     expect(result).toEqual(expectedDate);
   });
@@ -124,7 +126,8 @@ test("should not move before startMonth", () => {
     calendarStartMonth,
     calendarEndMonth,
     options,
-    dateLib
+    dateLib,
+    locale
   );
   expect(result).toEqual(calendarStartMonth);
 });
@@ -137,7 +140,8 @@ test("should not move after endMonth", () => {
     calendarStartMonth,
     calendarEndMonth,
     options,
-    dateLib
+    dateLib,
+    locale
   );
   expect(result).toEqual(calendarEndMonth);
 });

--- a/src/useCalendar.ts
+++ b/src/useCalendar.ts
@@ -15,7 +15,7 @@ import { getNextMonth } from "./helpers/getNextMonth.js";
 import { getPreviousMonth } from "./helpers/getPreviousMonth.js";
 import { getWeeks } from "./helpers/getWeeks.js";
 import { useControlledValue } from "./helpers/useControlledValue.js";
-import type { DateLib } from "./lib/index.js";
+import type { DateLib, Locale } from "./lib/index.js";
 import type { DayPickerProps } from "./types/props.js";
 
 /**
@@ -88,7 +88,8 @@ export function useCalendar(
     | "toMonth"
     | "toYear"
   >,
-  dateLib: DateLib
+  dateLib: DateLib,
+  locale: Locale
 ): Calendar {
   const [navStart, navEnd] = getNavMonths(props, dateLib);
 
@@ -113,11 +114,12 @@ export function useCalendar(
     displayMonths,
     props.endMonth ? endOfMonth(props.endMonth) : undefined,
     props,
-    dateLib
+    dateLib,
+    locale
   );
 
   /** The Months displayed in the calendar. */
-  const months = getMonths(displayMonths, dates, props, dateLib);
+  const months = getMonths(displayMonths, dates, props, dateLib, locale);
 
   /** The Weeks displayed in the calendar. */
   const weeks = getWeeks(months);

--- a/src/useFocus.ts
+++ b/src/useFocus.ts
@@ -3,7 +3,7 @@ import { useState } from "react";
 import type { CalendarDay } from "./classes/index.js";
 import { calculateFocusTarget } from "./helpers/calculateFocusTarget.js";
 import { getNextFocus } from "./helpers/getNextFocus.js";
-import type { DateLib } from "./lib/index.js";
+import type { DateLib, Locale } from "./lib/index.js";
 import type {
   MoveFocusBy,
   MoveFocusDir,
@@ -35,7 +35,8 @@ export function useFocus<T extends DayPickerProps>(
   calendar: Calendar,
   getModifiers: (day: CalendarDay) => Modifiers,
   isSelected: (date: Date) => boolean,
-  dateLib: DateLib
+  dateLib: DateLib,
+  locale: Locale
 ): UseFocus {
   const { autoFocus } = props;
   const [lastFocused, setLastFocused] = useState<CalendarDay | undefined>();
@@ -64,7 +65,8 @@ export function useFocus<T extends DayPickerProps>(
       calendar.navStart,
       calendar.navEnd,
       props,
-      dateLib
+      dateLib,
+      locale
     );
     if (!nextFocus) return;
 


### PR DESCRIPTION
## What's Changed

`locale` is optionally user defined as a prop to DayPicker and should fallback to en-US (the default for DayPicker) when none is supplied by the user. There were several places where this default was not respected, and instead `props.locale` was used (which can be undefined).

This PR addresses the above problem by explicitly requiring `locale` as a non-optional argument everywhere it's used, similar to how `dateLib` is passed around.

This resolves #2509 (related discussion #2511) in where if the client application used date-fns and had a locale set through `dateFns.setDefaultOptions`, then the internal calls to date-fns within DayPicker would use this client defined default (instead of the en-US default) in the cases where `props.locale` was being used (namely `useCalendar`).

Once we cross the threshold into DayPicker, we should always be using a resolved locale object to ensure consistency of rendered dates across components.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes

Fixes #2509
Related #2511