### PR TITLE
fix(types): argument of type 'Date' is not assignable to parameter of type 'never'

### DIFF
--- a/src/helpers/getWeekdays.ts
+++ b/src/helpers/getWeekdays.ts
@@ -26,7 +26,7 @@ export function getWeekdays(
     ? dateLib.startOfISOWeek(date)
     : dateLib.startOfWeek(date, { locale, weekStartsOn });
 
-  const days = [];
+  const days: Date[] = [];
   for (let i = 0; i < 7; i++) {
     const day = dateLib.addDays(start, i);
     days.push(day);


### PR DESCRIPTION

# Pull Request Template

Thanks for your PR! Make sure you have read the [CONTRIBUTING](./CONTRIBUTING.md) guide.

## What's Changed

```
TS2345: Argument of type 'Date' is not assignable to parameter of type 'never'.
    23 |   for (let i = 0; i < 7; i++) {
    24 |     const day = dateLib.addDays(start, i);
  > 25 |     days.push(day);
       |               ^^^
    26 |   }
    27 |   return days;
    28 | }
```


When starting a new CRA application, the compiler will throw the above error


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Tips for a good PR

- If you are changing code, please add tests to cover the changes.
- Some screenshots or screen recording could help to understand the changes.
- If it is a bug, please provide the code to reproduce it.

Thanks

## Additional Notes

Add any extra comments or questions here.
