### PR TITLE
fix(styles): button height and width are reversed

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -11,8 +11,8 @@
   
   --rdp-day_button-border-radius: 100%; /* The border radius of the day cells. */
   --rdp-day_button-border: 2px solid transparent; /* The border of the day cells. */
-  --rdp-day_button-height: var(--rdp-day-width); /* The height of the day cells. */
-  --rdp-day_button-width: var(--rdp-day-height); /* The width of the day cells. */
+  --rdp-day_button-height: var(--rdp-day-height); /* The height of the day cells. */
+  --rdp-day_button-width: var(--rdp-day-width); /* The width of the day cells. */
   
   --rdp-selected-border: 2px solid var(--rdp-accent-color); /* The border of the selected days. */
   --rdp-selected-font: bold large var(--rdp-font-family); /* The font of the selected days. */


### PR DESCRIPTION
# Pull Request Template

Thanks for your PR! Make sure you have read the [CONTRIBUTING](./CONTRIBUTING.md) guide.

## What's Changed

Fixes a mixup between the CSS variables responsible for the day cells(and button) height & width.
Namely `--rdp-day_button-height` was being set to `var(--rdp-day-width)` and the same for the width.
This made it annoying to have different height and width values through CSS overrides like this since the `day_button` styling would be inverted.
With this small change different height and width values now work without issues.

```
.rdp-root {
      --rdp-day-height: 38px;
      --rdp-day-width: 46px; 
}
```

The following additional overrides make it work since they are identical to this PR
```
.rdp-root {
      --rdp-day-height: 38px;
      --rdp-day-width: 46px; 
      --rdp-day_button-height: var(
        --rdp-day-height
      ); /* The height of the day cells. */
      --rdp-day_button-width: var(
        --rdp-day-width
      ); /* The width of the day cells. */
}
```

It seems this issue was already previously discovered but not completely understood: https://github.com/gpbl/react-day-picker/discussions/2354


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Tips for a good PR

- If you are changing code, please add tests to cover the changes.
- Some screenshots or screen recording could help to understand the changes.
- If it is a bug, please provide the code to reproduce it.

Thanks

## Additional Notes


