### PR TITLE
build(style): support importing styles in Sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
       "style": {
         "default": "./src/style.css"
       },
+      "sass": {
+        "default": "./src/style.css"
+      },
       "import": {
         "types": "./src/style.module.css.d.ts",
         "default": "./src/style.css"
@@ -67,6 +70,9 @@
     },
     "./style.module.css": {
       "style": {
+        "default": "./src/style.module.css"
+      },
+      "sass": {
         "default": "./src/style.module.css"
       },
       "import": {
@@ -82,6 +88,9 @@
       "style": {
         "default": "./src/style.css"
       },
+      "sass": {
+        "default": "./src/style.css"
+      },
       "import": {
         "types": "./src/style.module.css.d.ts",
         "default": "./src/style.css"
@@ -93,6 +102,9 @@
     },
     "./src/style.module.css": {
       "style": {
+        "default": "./src/style.module.css"
+      },
+      "sass": {
         "default": "./src/style.module.css"
       },
       "import": {
@@ -108,6 +120,9 @@
       "style": {
         "default": "./src/style.css"
       },
+      "sass": {
+        "default": "./src/style.css"
+      },
       "import": {
         "types": "./src/style.module.css.d.ts",
         "default": "./src/style.css"
@@ -119,6 +134,9 @@
     },
     "./dist/style.module.css": {
       "style": {
+        "default": "./src/style.module.css"
+      },
+      "sass": {
         "default": "./src/style.module.css"
       },
       "import": {

--- a/package.json
+++ b/package.json
@@ -52,11 +52,11 @@
         "default": "./dist/cjs/locale.js"
       }
     },
+    "./style": {
+      "sass": "./src/style.css"
+    },
     "./style.css": {
       "style": {
-        "default": "./src/style.css"
-      },
-      "sass": {
         "default": "./src/style.css"
       },
       "import": {
@@ -68,11 +68,11 @@
         "default": "./src/style.css"
       }
     },
+    "./style.module": {
+      "sass": "./src/style.module.css"
+    },
     "./style.module.css": {
       "style": {
-        "default": "./src/style.module.css"
-      },
-      "sass": {
         "default": "./src/style.module.css"
       },
       "import": {
@@ -88,9 +88,6 @@
       "style": {
         "default": "./src/style.css"
       },
-      "sass": {
-        "default": "./src/style.css"
-      },
       "import": {
         "types": "./src/style.module.css.d.ts",
         "default": "./src/style.css"
@@ -102,9 +99,6 @@
     },
     "./src/style.module.css": {
       "style": {
-        "default": "./src/style.module.css"
-      },
-      "sass": {
         "default": "./src/style.module.css"
       },
       "import": {
@@ -120,9 +114,6 @@
       "style": {
         "default": "./src/style.css"
       },
-      "sass": {
-        "default": "./src/style.css"
-      },
       "import": {
         "types": "./src/style.module.css.d.ts",
         "default": "./src/style.css"
@@ -134,9 +125,6 @@
     },
     "./dist/style.module.css": {
       "style": {
-        "default": "./src/style.module.css"
-      },
-      "sass": {
         "default": "./src/style.module.css"
       },
       "import": {


### PR DESCRIPTION

# Pull Request Template

Thanks for your PR! Make sure you have read the [CONTRIBUTING](./CONTRIBUTING.md) guide.

## What's Changed

Allows consumers to import base CSS using SASS. This gives consumers more flexibility to manipulate the base CSS. For example, forcing the styles under a CSS layer

```scss
@layer third-party-libs {
  @import 'pkg:react-day-picker/styles.module';
}
```

OR, forcing the styles to be scoped under a selector

```scss
.my-daypicker {
  @import 'pkg:react-day-picker/styles.module';
}
```

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Tips for a good PR

- If you are changing code, please add tests to cover the changes.
- Some screenshots or screen recording could help to understand the changes.
- If it is a bug, please provide the code to reproduce it.

Thanks

## Additional Notes

Add any extra comments or questions here.
