### PR TITLE
performance: improve select in `useRange`

### DIFF
--- a/src/selection/useRange.tsx
+++ b/src/selection/useRange.tsx
@@ -45,8 +45,11 @@ export function useRange<T extends DayPickerProps>(
 
     if (newRange?.from && newRange.to) {
       let newDate = newRange.from;
-      while (dateLib.differenceInCalendarDays(newRange.to, newDate) > 0) {
+      const totalDays = dateLib.differenceInCalendarDays(newRange.to, newDate);
+
+      for (let i = 0; i < totalDays; i++) {
         newDate = dateLib.addDays(newDate, 1);
+
         if (
           excludeDisabled &&
           disabled &&


### PR DESCRIPTION
Improves the performance when selecting days in a range. (part of #2537)

### Lighthouse Report

Before: https://github.com/gpbl/react-day-picker/actions/runs/11543002155/artifacts/2109551350

<img width="500" alt="Screenshot 2024-10-27 at 2 00 09 PM" src="https://github.com/user-attachments/assets/daa22f23-1c29-45a3-ae72-5ad34a1c9314">

--- 

After: https://github.com/gpbl/react-day-picker/actions/runs/11542948480/artifacts/2109540839

<img width="500" alt="Screenshot 2024-10-27 at 1 59 57 PM" src="https://github.com/user-attachments/assets/d7e7f1b5-8e78-49d6-9593-40585f44553f">

