### PR TITLE
fix(types): formatMonthDropdown throwing a type error

### DIFF
--- a/src/formatters/formatMonthDropdown.test.ts
+++ b/src/formatters/formatMonthDropdown.test.ts
@@ -1,11 +1,15 @@
 import { es } from "date-fns/locale/es";
 
+import { defaultLocale } from "../classes/DateLib";
+
 import { formatMonthDropdown } from "./formatMonthDropdown";
 
 const date = new Date(2022, 10, 21);
 
 test("should return the formatted month dropdown label", () => {
-  expect(formatMonthDropdown(date.getMonth())).toEqual("November");
+  expect(formatMonthDropdown(date.getMonth(), defaultLocale)).toEqual(
+    "November"
+  );
 });
 
 describe("when a locale is passed in", () => {

--- a/src/formatters/formatMonthDropdown.ts
+++ b/src/formatters/formatMonthDropdown.ts
@@ -1,5 +1,4 @@
-import type { DateFnsMonth } from "../classes/DateLib.js";
-import { defaultLocale } from "../classes/DateLib.js";
+import type { DateFnsMonth, Locale } from "../classes/DateLib.js";
 
 /**
  * Format the month number for the dropdown option label.
@@ -12,7 +11,7 @@ export function formatMonthDropdown(
   /** The month number to format. */
   monthNumber: number,
   /** The locale to use for formatting. */
-  locale = defaultLocale
+  locale: Locale
 ): string {
   return locale.localize?.month(monthNumber as DateFnsMonth);
 }

--- a/src/helpers/getMonthOptions.ts
+++ b/src/helpers/getMonthOptions.ts
@@ -1,4 +1,4 @@
-import type { DateLib } from "../classes/DateLib.js";
+import { defaultLocale, type DateLib } from "../classes/DateLib.js";
 import { DropdownOption } from "../components/Dropdown.js";
 import type { Formatters } from "../types/index.js";
 
@@ -26,7 +26,10 @@ export function getMonthOptions(
     return a - b;
   });
   const options = sortedMonths.map((value) => {
-    const label = formatters.formatMonthDropdown(value, dateLib.options.locale);
+    const label = formatters.formatMonthDropdown(
+      value,
+      dateLib.options.locale ?? defaultLocale
+    );
     const month = dateLib.Date
       ? new dateLib.Date(year, value)
       : new Date(year, value);


### PR DESCRIPTION
Update `formatMonthDropdown` to have the `locale` mandatory argument.

Fixes #2563.
