### PR TITLE
fix: remove selectionStates from useGetModifiers()

### DIFF
--- a/examples/__snapshots__/Range.test.tsx.snap
+++ b/examples/__snapshots__/Range.test.tsx.snap
@@ -338,7 +338,7 @@ exports[`should match the snapshot 1`] = `
                 </td>
                 <td
                   aria-selected="true"
-                  class="rdp-day rdp-range_start rdp-selected"
+                  class="rdp-day rdp-selected rdp-range_start"
                   data-day="2020-06-15"
                   data-selected="true"
                 >
@@ -353,7 +353,7 @@ exports[`should match the snapshot 1`] = `
                 </td>
                 <td
                   aria-selected="true"
-                  class="rdp-day rdp-range_middle rdp-selected"
+                  class="rdp-day rdp-selected rdp-range_middle"
                   data-day="2020-06-16"
                   data-selected="true"
                 >
@@ -368,7 +368,7 @@ exports[`should match the snapshot 1`] = `
                 </td>
                 <td
                   aria-selected="true"
-                  class="rdp-day rdp-range_middle rdp-selected"
+                  class="rdp-day rdp-selected rdp-range_middle"
                   data-day="2020-06-17"
                   data-selected="true"
                 >
@@ -383,7 +383,7 @@ exports[`should match the snapshot 1`] = `
                 </td>
                 <td
                   aria-selected="true"
-                  class="rdp-day rdp-range_middle rdp-selected"
+                  class="rdp-day rdp-selected rdp-range_middle"
                   data-day="2020-06-18"
                   data-selected="true"
                 >
@@ -398,7 +398,7 @@ exports[`should match the snapshot 1`] = `
                 </td>
                 <td
                   aria-selected="true"
-                  class="rdp-day rdp-range_end rdp-selected"
+                  class="rdp-day rdp-selected rdp-range_end"
                   data-day="2020-06-19"
                   data-selected="true"
                 >

--- a/src/useGetModifiers.test.tsx
+++ b/src/useGetModifiers.test.tsx
@@ -1,0 +1,73 @@
+import { DayFlag } from "./UI";
+import { CalendarDay, defaultDateLib } from "./classes/index";
+import { useGetModifiers } from "./useGetModifiers";
+
+const dateLib = defaultDateLib;
+
+const month1 = new Date(2022, 10, 1);
+const month2 = new Date(2022, 11, 1);
+
+const date1 = new Date(2022, 10, 10);
+const date2 = new Date(2022, 10, 11);
+const date3 = new Date(2022, 10, 12);
+const date4 = new Date(2022, 10, 13);
+const date5 = new Date(2022, 10, 14);
+const date6 = new Date(2022, 10, 30);
+
+const day1 = new CalendarDay(date1, month1);
+const day2 = new CalendarDay(date2, month1);
+const day3 = new CalendarDay(date3, month1);
+const day4 = new CalendarDay(date4, month1);
+const day5 = new CalendarDay(date5, month1);
+const day6 = new CalendarDay(date6, month2);
+
+const days: CalendarDay[] = [day1, day2, day3, day4, day5, day6];
+
+const props = {
+  disabled: [date1],
+  hidden: [date2],
+  modifiers: {
+    custom: [date3]
+  },
+  selected: date6,
+  showOutsideDays: true,
+  today: date4,
+  timeZone: "UTC"
+};
+
+describe("useGetModifiers", () => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const getModifiers = useGetModifiers(days, props, dateLib);
+
+  test("return the modifiers for a given day", () => {
+    const modifiers = getModifiers(day1);
+
+    expect(modifiers[DayFlag.focused]).toBe(false);
+    expect(modifiers[DayFlag.disabled]).toBe(true);
+    expect(modifiers[DayFlag.hidden]).toBe(false);
+    expect(modifiers[DayFlag.outside]).toBe(false);
+    expect(modifiers[DayFlag.today]).toBe(false);
+    expect(modifiers.custom).toBe(false);
+  });
+
+  test("return the custom modifiers for a given day", () => {
+    const modifiers = getModifiers(day3);
+    expect(modifiers.custom).toBe(true);
+  });
+
+  test("return the today modifier for a given day", () => {
+    const modifiers = getModifiers(day4);
+    expect(modifiers[DayFlag.today]).toBe(true);
+  });
+
+  test("return the hidden modifier for a given day", () => {
+    const modifiers = getModifiers(day2);
+    expect(modifiers[DayFlag.hidden]).toBe(true);
+  });
+
+  test("return the outside modifier for a given day", () => {
+    const modifiers = getModifiers(day6);
+
+    expect(modifiers[DayFlag.outside]).toBe(true);
+  });
+});

--- a/src/useGetModifiers.test.tsx
+++ b/src/useGetModifiers.test.tsx
@@ -27,7 +27,8 @@ const props = {
   disabled: [date1],
   hidden: [date2],
   modifiers: {
-    custom: [date3]
+    custom: [date3],
+    selected: [date5]
   },
   selected: date6,
   showOutsideDays: true,
@@ -53,6 +54,11 @@ describe("useGetModifiers", () => {
   test("return the custom modifiers for a given day", () => {
     const modifiers = getModifiers(day3);
     expect(modifiers.custom).toBe(true);
+  });
+
+  test("return the custom `selected` modifier for a given day", () => {
+    const modifiers = getModifiers(day5);
+    expect(modifiers.selected).toBe(true);
   });
 
   test("return the today modifier for a given day", () => {

--- a/src/useGetModifiers.tsx
+++ b/src/useGetModifiers.tsx
@@ -21,7 +21,7 @@ export function useGetModifiers(
 
   const { isSameDay, isSameMonth } = dateLib;
 
-  const dayFlagsMap: Record<DayFlag, CalendarDay[]> = {
+  const internalModifiersMap: Record<DayFlag, CalendarDay[]> = {
     [DayFlag.focused]: [],
     [DayFlag.outside]: [],
     [DayFlag.disabled]: [],
@@ -29,7 +29,7 @@ export function useGetModifiers(
     [DayFlag.today]: []
   };
 
-  const modifiersMap: Record<string, CalendarDay[]> = {};
+  const customModifiersMap: Record<string, CalendarDay[]> = {};
 
   for (const day of days) {
     const { date, displayMonth } = day;
@@ -54,10 +54,10 @@ export function useGetModifiers(
             : new Date())
     );
 
-    if (isOutside) dayFlagsMap.outside.push(day);
-    if (isDisabled) dayFlagsMap.disabled.push(day);
-    if (isHidden) dayFlagsMap.hidden.push(day);
-    if (isToday) dayFlagsMap.today.push(day);
+    if (isOutside) internalModifiersMap.outside.push(day);
+    if (isDisabled) internalModifiersMap.disabled.push(day);
+    if (isHidden) internalModifiersMap.hidden.push(day);
+    if (isToday) internalModifiersMap.today.push(day);
 
     // Add custom modifiers
     if (modifiers) {
@@ -67,10 +67,10 @@ export function useGetModifiers(
           ? dateMatchModifiers(date, modifierValue, dateLib)
           : false;
         if (!isMatch) return;
-        if (modifiersMap[name]) {
-          modifiersMap[name].push(day);
+        if (customModifiersMap[name]) {
+          customModifiersMap[name].push(day);
         } else {
-          modifiersMap[name] = [day];
+          customModifiersMap[name] = [day];
         }
       });
     }
@@ -88,12 +88,12 @@ export function useGetModifiers(
     const customModifiers: Modifiers = {};
 
     // Find the modifiers for the given day
-    for (const name in dayFlagsMap) {
-      const days = dayFlagsMap[name as DayFlag];
+    for (const name in internalModifiersMap) {
+      const days = internalModifiersMap[name as DayFlag];
       dayFlags[name as DayFlag] = days.some((d) => d === day);
     }
-    for (const name in modifiersMap) {
-      customModifiers[name] = modifiersMap[name].some((d) => d === day);
+    for (const name in customModifiersMap) {
+      customModifiers[name] = customModifiersMap[name].some((d) => d === day);
     }
 
     return {


### PR DESCRIPTION
Before implementing changes to the `useGetModifiers` function in #2578, I’m adding some tests. 

I could find  a bug where `getModifiers` was returning always an empty `selected` modifier. The selection modifiers are handled separately so they shouldn't appear here.

cc @rodgobbi 