### PR TITLE
allow to use react-day-picker v7 with any 15+ react version

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "homepage": "https://react-day-picker.js.org",
   "peerDependencies": {
-    "react": "~0.13.x || ~0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0"
+    "react": "~0.13.x || ~0.14.x || >=15.0.0"
   },
   "devDependencies": {
     "@types/react": "^16.9.2",


### PR DESCRIPTION
## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
