### PR TITLE
chore(style): remove unused CSS variable

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -27,7 +27,6 @@
   --rdp-nav-height: 2.75rem; /* The height of the navigation bar. */
   
   --rdp-range_middle-background-color: var(--rdp-accent-background-color); /* The color of the background for days in the middle of a range. */
-  --rdp-range_middle-foreground-color: white; /* The foregraound color for days in the middle of a range. */
   --rdp-range_middle-color: inherit;/* The color of the range text. */
   
   --rdp-range_start-color: white; /* The color of the range text. */

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -27,7 +27,6 @@
   --rdp-nav-height: 2.75rem; /* The height of the navigation bar. */
   
   --rdp-range_middle-background-color: var(--rdp-accent-background-color); /* The color of the background for days in the middle of a range. */
-  --rdp-range_middle-foreground-color: white; /* The foregraound color for days in the middle of a range. */
   --rdp-range_middle-color: inherit;/* The color of the range text. */
   
   --rdp-range_start-color: white; /* The color of the range text. */

--- a/website/docs/docs/styling.mdx
+++ b/website/docs/docs/styling.mdx
@@ -74,7 +74,7 @@ The following table lists the CSS variables used by DayPicker within the `.rdp-r
 | `--rdp-nav_button-width`                  | The width of the navigation buttons.                                 |
 | `--rdp-nav-height`                        | The height of the navigation bar.                                    |
 | `--rdp-range_middle-background-color`     | The color of the background for days in the middle of a range.       |
-| `--rdp-range_middle-foreground-color`     | The color of the text for days in the middle of a range.             |
+| `--rdp-range_middle-color`                | The color of the text for days in the middle of a range.             |
 | `--rdp-range_start-color`                 | The color of the range text at the start of the range.               |
 | `--rdp-range_start-background`            | Used for the background of the start of the selected range.          |
 | `--rdp-range_start-date-background-color` | The background color of the date at the start of the selected range. |


### PR DESCRIPTION
`rdp-range_middle-foreground-color` is not used anywhere.
