### PR TITLE
chore(types): update DateLib to not import types from date-fns

### DIFF
--- a/src/classes/DateLib.ts
+++ b/src/classes/DateLib.ts
@@ -36,7 +36,8 @@ import type {
   EndOfWeekOptions,
   StartOfWeekOptions,
   FormatOptions as DateFnsFormatOptions,
-  DateArg
+  GetWeekOptions,
+  Interval
 } from "date-fns";
 import type { Locale } from "date-fns/locale";
 import { enUS } from "date-fns/locale";
@@ -92,9 +93,9 @@ export interface DateLibOptions
 }
 
 /**
- * A wrapper class around [date-fns](http://date-fns.org) sharing the same
- * options. Methods of this class can be overridden using the
- * {@link PropsBase.dateLib} prop.
+ * Date manipulation and formatting library built around
+ * [date-fns](http://date-fns.org). Supports overrides, custom numeral systems,
+ * locales, and time zones.
  *
  * @since 9.2.0
  * @example
@@ -214,10 +215,8 @@ export class DateLib {
    * @param amount The number of days to add.
    * @returns The new date with the days added.
    */
-  addDays: typeof addDays = (date, amount) => {
-    return this.overrides?.addDays
-      ? this.overrides.addDays(date, amount)
-      : addDays(date, amount);
+  addDays = (date: Date, amount: number): Date => {
+    return this.overrides?.addDays?.(date, amount) ?? addDays(date, amount);
   };
 
   /**
@@ -227,10 +226,8 @@ export class DateLib {
    * @param amount The number of months to add.
    * @returns The new date with the months added.
    */
-  addMonths: typeof addMonths = (date, amount) => {
-    return this.overrides?.addMonths
-      ? this.overrides.addMonths(date, amount)
-      : addMonths(date, amount);
+  addMonths = (date: Date, amount: number): Date => {
+    return this.overrides?.addMonths?.(date, amount) ?? addMonths(date, amount);
   };
 
   /**
@@ -240,10 +237,8 @@ export class DateLib {
    * @param amount The number of weeks to add.
    * @returns The new date with the weeks added.
    */
-  addWeeks: typeof addWeeks = (date, amount) => {
-    return this.overrides?.addWeeks
-      ? this.overrides.addWeeks(date, amount)
-      : addWeeks(date, amount);
+  addWeeks = (date: Date, amount: number): Date => {
+    return this.overrides?.addWeeks?.(date, amount) ?? addWeeks(date, amount);
   };
 
   /**
@@ -253,10 +248,8 @@ export class DateLib {
    * @param amount The number of years to add.
    * @returns The new date with the years added.
    */
-  addYears: typeof addYears = (date, amount) => {
-    return this.overrides?.addYears
-      ? this.overrides.addYears(date, amount)
-      : addYears(date, amount);
+  addYears = (date: Date, amount: number): Date => {
+    return this.overrides?.addYears?.(date, amount) ?? addYears(date, amount);
   };
 
   /**
@@ -266,13 +259,11 @@ export class DateLib {
    * @param dateRight The earlier date.
    * @returns The number of calendar days between the dates.
    */
-  differenceInCalendarDays: typeof differenceInCalendarDays = (
-    dateLeft,
-    dateRight
-  ) => {
-    return this.overrides?.differenceInCalendarDays
-      ? this.overrides.differenceInCalendarDays(dateLeft, dateRight)
-      : differenceInCalendarDays(dateLeft, dateRight);
+  differenceInCalendarDays = (dateLeft: Date, dateRight: Date): number => {
+    return (
+      this.overrides?.differenceInCalendarDays?.(dateLeft, dateRight) ??
+      differenceInCalendarDays(dateLeft, dateRight)
+    );
   };
 
   /**
@@ -282,13 +273,11 @@ export class DateLib {
    * @param dateRight The earlier date.
    * @returns The number of calendar months between the dates.
    */
-  differenceInCalendarMonths: typeof differenceInCalendarMonths = (
-    dateLeft,
-    dateRight
-  ) => {
-    return this.overrides?.differenceInCalendarMonths
-      ? this.overrides.differenceInCalendarMonths(dateLeft, dateRight)
-      : differenceInCalendarMonths(dateLeft, dateRight);
+  differenceInCalendarMonths = (dateLeft: Date, dateRight: Date): number => {
+    return (
+      this.overrides?.differenceInCalendarMonths?.(dateLeft, dateRight) ??
+      differenceInCalendarMonths(dateLeft, dateRight)
+    );
   };
 
   /**
@@ -296,10 +285,11 @@ export class DateLib {
    *
    * @param interval The interval to get the months for.
    */
-  eachMonthOfInterval: typeof eachMonthOfInterval = (interval) => {
-    return this.overrides?.eachMonthOfInterval
-      ? this.overrides.eachMonthOfInterval(interval)
-      : eachMonthOfInterval(interval);
+  eachMonthOfInterval = (interval: Interval<Date>): Date[] => {
+    return (
+      this.overrides?.eachMonthOfInterval?.(interval) ??
+      eachMonthOfInterval(interval)
+    );
   };
 
   /**
@@ -308,10 +298,11 @@ export class DateLib {
    * @param date The original date.
    * @returns The end of the broadcast week.
    */
-  endOfBroadcastWeek: typeof endOfBroadcastWeek = (date: Date) => {
-    return this.overrides?.endOfBroadcastWeek
-      ? this.overrides.endOfBroadcastWeek(date, this)
-      : endOfBroadcastWeek(date, this);
+  endOfBroadcastWeek = (date: Date, dateLib?: DateLib): Date => {
+    return (
+      this.overrides?.endOfBroadcastWeek?.(date, dateLib) ??
+      endOfBroadcastWeek(date, this)
+    );
   };
 
   /**
@@ -320,10 +311,8 @@ export class DateLib {
    * @param date The original date.
    * @returns The end of the ISO week.
    */
-  endOfISOWeek: typeof endOfISOWeek = (date) => {
-    return this.overrides?.endOfISOWeek
-      ? this.overrides.endOfISOWeek(date)
-      : endOfISOWeek(date);
+  endOfISOWeek = (date: Date): Date => {
+    return this.overrides?.endOfISOWeek?.(date) ?? endOfISOWeek(date);
   };
 
   /**
@@ -332,10 +321,8 @@ export class DateLib {
    * @param date The original date.
    * @returns The end of the month.
    */
-  endOfMonth: typeof endOfMonth = (date) => {
-    return this.overrides?.endOfMonth
-      ? this.overrides.endOfMonth(date)
-      : endOfMonth(date);
+  endOfMonth = (date: Date): Date => {
+    return this.overrides?.endOfMonth?.(date) ?? endOfMonth(date);
   };
 
   /**
@@ -344,18 +331,11 @@ export class DateLib {
    * @param date The original date.
    * @returns The end of the week.
    */
-  endOfWeek: typeof endOfWeek = <
-    DateType extends Date,
-    ResultDate extends Date = DateType
-  >(
-    date: DateArg<DateType>
-  ): ResultDate => {
-    return this.overrides?.endOfWeek
-      ? this.overrides.endOfWeek(
-          date,
-          this.options as EndOfWeekOptions<ResultDate>
-        )
-      : endOfWeek(date, this.options as EndOfWeekOptions<ResultDate>);
+  endOfWeek = (date: Date, options?: EndOfWeekOptions<Date>): Date => {
+    return (
+      this.overrides?.endOfWeek?.(date, options ?? this.options) ??
+      endOfWeek(date, options ?? this.options)
+    );
   };
 
   /**
@@ -364,10 +344,8 @@ export class DateLib {
    * @param date The original date.
    * @returns The end of the year.
    */
-  endOfYear: typeof endOfYear = (date) => {
-    return this.overrides?.endOfYear
-      ? this.overrides.endOfYear(date)
-      : endOfYear(date);
+  endOfYear = (date: Date): Date => {
+    return this.overrides?.endOfYear?.(date) ?? endOfYear(date);
   };
 
   /**
@@ -377,10 +355,15 @@ export class DateLib {
    * @param formatStr The format string.
    * @returns The formatted date string.
    */
-  format: typeof format = (date, formatStr) => {
-    const formatted = this.overrides?.format
-      ? this.overrides.format(date, formatStr, this.options)
-      : format(date, formatStr, this.options);
+  format = (
+    date: Date,
+    formatStr: string,
+    options?: DateFnsFormatOptions
+  ): string => {
+    const formatted =
+      this.overrides?.format?.(date, formatStr, options ?? this.options) ??
+      format(date, formatStr, options ?? this.options);
+
     if (this.options.numerals && this.options.numerals !== "latn") {
       return this.replaceDigits(formatted);
     }
@@ -393,10 +376,8 @@ export class DateLib {
    * @param date The date to get the ISO week number for.
    * @returns The ISO week number.
    */
-  getISOWeek: typeof getISOWeek = (date) => {
-    return this.overrides?.getISOWeek
-      ? this.overrides.getISOWeek(date)
-      : getISOWeek(date);
+  getISOWeek = (date: Date): number => {
+    return this.overrides?.getISOWeek?.(date) ?? getISOWeek(date);
   };
 
   /**
@@ -405,10 +386,8 @@ export class DateLib {
    * @param date The date to get the month for.
    * @returns The month.
    */
-  getMonth: typeof getMonth = (date) => {
-    return this.overrides?.getMonth
-      ? this.overrides.getMonth(date, this.options)
-      : getMonth(date, this.options);
+  getMonth = (date: Date): number => {
+    return this.overrides?.getMonth?.(date) ?? getMonth(date);
   };
 
   /**
@@ -417,10 +396,8 @@ export class DateLib {
    * @param date The date to get the year for.
    * @returns The year.
    */
-  getYear: typeof getYear = (date) => {
-    return this.overrides?.getYear
-      ? this.overrides.getYear(date, this.options)
-      : getYear(date, this.options);
+  getYear = (date: Date): number => {
+    return this.overrides?.getYear?.(date) ?? getYear(date);
   };
 
   /**
@@ -429,10 +406,11 @@ export class DateLib {
    * @param date The date to get the week number for.
    * @returns The week number.
    */
-  getWeek: typeof getWeek = (date) => {
-    return this.overrides?.getWeek
-      ? this.overrides.getWeek(date, this.options)
-      : getWeek(date, this.options);
+  getWeek = (date: Date, options?: GetWeekOptions): number => {
+    return (
+      this.overrides?.getWeek?.(date, options ?? this.options) ??
+      getWeek(date, options ?? this.options)
+    );
   };
 
   /**
@@ -442,10 +420,11 @@ export class DateLib {
    * @param dateToCompare The date to compare with.
    * @returns True if the first date is after the second date.
    */
-  isAfter: typeof isAfter = (date, dateToCompare) => {
-    return this.overrides?.isAfter
-      ? this.overrides.isAfter(date, dateToCompare)
-      : isAfter(date, dateToCompare);
+  isAfter = (date: Date, dateToCompare: Date): boolean => {
+    return (
+      this.overrides?.isAfter?.(date, dateToCompare) ??
+      isAfter(date, dateToCompare)
+    );
   };
 
   /**
@@ -455,10 +434,11 @@ export class DateLib {
    * @param dateToCompare The date to compare with.
    * @returns True if the first date is before the second date.
    */
-  isBefore: typeof isBefore = (date, dateToCompare) => {
-    return this.overrides?.isBefore
-      ? this.overrides.isBefore(date, dateToCompare)
-      : isBefore(date, dateToCompare);
+  isBefore = (date: Date, dateToCompare: Date): boolean => {
+    return (
+      this.overrides?.isBefore?.(date, dateToCompare) ??
+      isBefore(date, dateToCompare)
+    );
   };
 
   /**
@@ -468,9 +448,7 @@ export class DateLib {
    * @returns True if the value is a Date object.
    */
   isDate: (value: unknown) => value is Date = (value): value is Date => {
-    return this.overrides?.isDate
-      ? this.overrides.isDate(value)
-      : isDate(value);
+    return this.overrides?.isDate?.(value) ?? isDate(value);
   };
 
   /**
@@ -480,10 +458,11 @@ export class DateLib {
    * @param dateRight The second date to compare.
    * @returns True if the dates are on the same day.
    */
-  isSameDay: typeof isSameDay = (dateLeft, dateRight) => {
-    return this.overrides?.isSameDay
-      ? this.overrides.isSameDay(dateLeft, dateRight)
-      : isSameDay(dateLeft, dateRight);
+  isSameDay = (dateLeft: Date, dateRight: Date): boolean => {
+    return (
+      this.overrides?.isSameDay?.(dateLeft, dateRight) ??
+      isSameDay(dateLeft, dateRight)
+    );
   };
 
   /**
@@ -493,10 +472,11 @@ export class DateLib {
    * @param dateRight The second date to compare.
    * @returns True if the dates are in the same month.
    */
-  isSameMonth: typeof isSameMonth = (dateLeft, dateRight) => {
-    return this.overrides?.isSameMonth
-      ? this.overrides.isSameMonth(dateLeft, dateRight)
-      : isSameMonth(dateLeft, dateRight);
+  isSameMonth = (dateLeft: Date, dateRight: Date): boolean => {
+    return (
+      this.overrides?.isSameMonth?.(dateLeft, dateRight) ??
+      isSameMonth(dateLeft, dateRight)
+    );
   };
 
   /**
@@ -506,10 +486,11 @@ export class DateLib {
    * @param dateRight The second date to compare.
    * @returns True if the dates are in the same year.
    */
-  isSameYear: typeof isSameYear = (dateLeft, dateRight) => {
-    return this.overrides?.isSameYear
-      ? this.overrides.isSameYear(dateLeft, dateRight)
-      : isSameYear(dateLeft, dateRight);
+  isSameYear = (dateLeft: Date, dateRight: Date): boolean => {
+    return (
+      this.overrides?.isSameYear?.(dateLeft, dateRight) ??
+      isSameYear(dateLeft, dateRight)
+    );
   };
 
   /**
@@ -518,8 +499,8 @@ export class DateLib {
    * @param dates The array of dates to compare.
    * @returns The latest date.
    */
-  max: typeof max = (dates) => {
-    return this.overrides?.max ? this.overrides.max(dates) : max(dates);
+  max = (dates: Date[]): Date => {
+    return this.overrides?.max?.(dates) ?? max(dates);
   };
 
   /**
@@ -528,8 +509,8 @@ export class DateLib {
    * @param dates The array of dates to compare.
    * @returns The earliest date.
    */
-  min: typeof min = (dates) => {
-    return this.overrides?.min ? this.overrides.min(dates) : min(dates);
+  min = (dates: Date[]): Date => {
+    return this.overrides?.min?.(dates) ?? min(dates);
   };
 
   /**
@@ -539,10 +520,8 @@ export class DateLib {
    * @param month The month to set (0-11).
    * @returns The new date with the month set.
    */
-  setMonth: typeof setMonth = (date, month) => {
-    return this.overrides?.setMonth
-      ? this.overrides.setMonth(date, month)
-      : setMonth(date, month);
+  setMonth = (date: Date, month: number): Date => {
+    return this.overrides?.setMonth?.(date, month) ?? setMonth(date, month);
   };
 
   /**
@@ -552,10 +531,8 @@ export class DateLib {
    * @param year The year to set.
    * @returns The new date with the year set.
    */
-  setYear: typeof setYear = (date, year) => {
-    return this.overrides?.setYear
-      ? this.overrides.setYear(date, year)
-      : setYear(date, year);
+  setYear = (date: Date, year: number): Date => {
+    return this.overrides?.setYear?.(date, year) ?? setYear(date, year);
   };
 
   /**
@@ -564,10 +541,11 @@ export class DateLib {
    * @param date The original date.
    * @returns The start of the broadcast week.
    */
-  startOfBroadcastWeek: typeof startOfBroadcastWeek = (date: Date) => {
-    return this.overrides?.startOfBroadcastWeek
-      ? this.overrides.startOfBroadcastWeek(date, this)
-      : startOfBroadcastWeek(date, this);
+  startOfBroadcastWeek = (date: Date, dateLib?: DateLib): Date => {
+    return (
+      this.overrides?.startOfBroadcastWeek?.(date, dateLib ?? this) ??
+      startOfBroadcastWeek(date, dateLib ?? this)
+    );
   };
 
   /**
@@ -576,10 +554,8 @@ export class DateLib {
    * @param date The original date.
    * @returns The start of the day.
    */
-  startOfDay: typeof startOfDay = (date) => {
-    return this.overrides?.startOfDay
-      ? this.overrides.startOfDay(date)
-      : startOfDay(date);
+  startOfDay = (date: Date): Date => {
+    return this.overrides?.startOfDay?.(date) ?? startOfDay(date);
   };
 
   /**
@@ -588,10 +564,8 @@ export class DateLib {
    * @param date The original date.
    * @returns The start of the ISO week.
    */
-  startOfISOWeek: typeof startOfISOWeek = (date) => {
-    return this.overrides?.startOfISOWeek
-      ? this.overrides.startOfISOWeek(date)
-      : startOfISOWeek(date);
+  startOfISOWeek = (date: Date): Date => {
+    return this.overrides?.startOfISOWeek?.(date) ?? startOfISOWeek(date);
   };
 
   /**
@@ -600,10 +574,8 @@ export class DateLib {
    * @param date The original date.
    * @returns The start of the month.
    */
-  startOfMonth: typeof startOfMonth = (date) => {
-    return this.overrides?.startOfMonth
-      ? this.overrides.startOfMonth(date)
-      : startOfMonth(date);
+  startOfMonth = (date: Date): Date => {
+    return this.overrides?.startOfMonth?.(date) ?? startOfMonth(date);
   };
 
   /**
@@ -612,18 +584,10 @@ export class DateLib {
    * @param date The original date.
    * @returns The start of the week.
    */
-  startOfWeek: typeof startOfWeek = <
-    DateType extends Date,
-    ResultDate extends Date = DateType
-  >(
-    date: DateArg<DateType>
-  ): ResultDate => {
-    return this.overrides?.startOfWeek
-      ? this.overrides.startOfWeek(
-          date,
-          this.options as StartOfWeekOptions<ResultDate>
-        )
-      : startOfWeek(date, this.options as StartOfWeekOptions<ResultDate>);
+  startOfWeek = (date: Date): Date => {
+    return (
+      this.overrides?.startOfWeek?.(date) ?? startOfWeek(date, this.options)
+    );
   };
 
   /**
@@ -632,10 +596,8 @@ export class DateLib {
    * @param date The original date.
    * @returns The start of the year.
    */
-  startOfYear: typeof startOfYear = (date) => {
-    return this.overrides?.startOfYear
-      ? this.overrides.startOfYear(date)
-      : startOfYear(date);
+  startOfYear = (date: Date): Date => {
+    return this.overrides?.startOfYear?.(date) ?? startOfYear(date);
   };
 }
 /** The default locale (English). */

--- a/src/classes/DateLib.ts
+++ b/src/classes/DateLib.ts
@@ -44,7 +44,6 @@ import { enUS } from "date-fns/locale";
 
 import { endOfBroadcastWeek } from "../helpers/endOfBroadcastWeek.js";
 import { startOfBroadcastWeek } from "../helpers/startOfBroadcastWeek.js";
-import type { PropsBase } from "../types/props.js";
 import { Numerals } from "../types/shared.js";
 
 export type { Locale } from "date-fns/locale";
@@ -93,9 +92,8 @@ export interface DateLibOptions
 }
 
 /**
- * Date manipulation and formatting library built around
- * [date-fns](http://date-fns.org). Supports overrides, custom numeral systems,
- * locales, and time zones.
+ * A wrapper class around [date-fns](http://date-fns.org) sharing the same
+ * options.
  *
  * @since 9.2.0
  * @example


### PR DESCRIPTION
- Improves typedoc compilation time by removing `typeof` from date-fns
- Removes extra documentation from API website