### PR TITLE
feat: ethiopic calendar

### DIFF
--- a/ethiopic.d.ts
+++ b/ethiopic.d.ts
@@ -1,0 +1,1 @@
+export * from "./dist/cjs/ethiopic/index.d.ts";

--- a/ethiopic.js
+++ b/ethiopic.js
@@ -1,0 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* eslint-disable no-undef */
+const ethiopic = require("./dist/cjs/ethiopic/index.js");
+module.exports = ethiopic;

--- a/examples/Ethiopic.test.tsx
+++ b/examples/Ethiopic.test.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+import { render } from "@/test/render";
+
+import { Ethiopic } from "./Ethiopic.jsx";
+
+const today = new Date(2021, 10, 25);
+
+beforeAll(() => jest.setSystemTime(today));
+afterAll(() => jest.useRealTimers());
+
+beforeEach(() => {
+  render(<Ethiopic />);
+});
+
+test.todo("should render the Ethiopic calendar");

--- a/examples/Ethiopic.tsx
+++ b/examples/Ethiopic.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+import { DayPicker } from "react-day-picker/ethiopic";
+
+export function Ethiopic() {
+  return <DayPicker />;
+}

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -18,6 +18,7 @@ export * from "./DisableNavigation";
 export * from "./Dropdown";
 export * from "./DropdownMonths";
 export * from "./DropdownMultipleMonths";
+export * from "./Ethiopic";
 export * from "./Fixedweeks";
 export * from "./FocusRecursive";
 export * from "./Footer";

--- a/package.json
+++ b/package.json
@@ -52,6 +52,16 @@
         "default": "./dist/cjs/persian.js"
       }
     },
+    "./ethiopic": {
+      "import": {
+        "types": "./dist/esm/ethiopic/index.d.ts",
+        "default": "./dist/esm/ethiopic/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/ethiopic/index.d.ts",
+        "default": "./dist/cjs/ethiopic/index.js"
+      }
+    },
     "./locale": {
       "import": {
         "types": "./dist/esm/locale.d.ts",

--- a/src/ethiopic/index.tsx
+++ b/src/ethiopic/index.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+
+import type { Locale } from "date-fns";
+
+import {
+  DateLib,
+  DateLibOptions,
+  DayPicker as DayPickerComponent
+} from "../index.js";
+import type { DayPickerProps } from "../types/props.js";
+
+import * as ethiopicDateLib from "./lib/index.js";
+
+/**
+ * Render the Persian Calendar.
+ *
+ * @see https://daypicker.dev/docs/localization#persian-calendar
+ */
+export function DayPicker(
+  props: DayPickerProps & {
+    /**
+     * The locale to use in the calendar.
+     *
+     * @default `am-ET`
+     */
+    locale?: Locale;
+    /**
+     * The numeral system to use when formatting dates.
+     *
+     * - `latn`: Latin (Western Arabic)
+     * - `arab`: Arabic-Indic
+     * - `arabext`: Eastern Arabic-Indic (Persian)
+     * - `deva`: Devanagari
+     * - `ethio`: Ethiopic
+     * - `beng`: Bengali
+     * - `guru`: Gurmukhi
+     * - `gujr`: Gujarati
+     * - `orya`: Oriya
+     * - `tamldec`: Tamil
+     * - `telu`: Telugu
+     * - `knda`: Kannada
+     * - `mlym`: Malayalam
+     *
+     * @defaultValue `ethio` Eastern Arabic-Indic (Persian)
+     * @see https://daypicker.dev/docs/translation#numeral-systems
+     */
+    numerals?: DayPickerProps["numerals"];
+  }
+) {
+  const dateLib = getDateLib({
+    locale: props.locale,
+    weekStartsOn: props.broadcastCalendar ? 1 : props.weekStartsOn,
+    firstWeekContainsDate: props.firstWeekContainsDate,
+    useAdditionalWeekYearTokens: props.useAdditionalWeekYearTokens,
+    useAdditionalDayOfYearTokens: props.useAdditionalDayOfYearTokens,
+    timeZone: props.timeZone
+  });
+  return (
+    <DayPickerComponent
+      {...props}
+      locale={props.locale ?? ({} as Locale)}
+      numerals={props.numerals ?? "ethio"}
+      dateLib={dateLib}
+    />
+  );
+}
+
+/** Returns the date library used in the calendar. */
+export const getDateLib = (options?: DateLibOptions) => {
+  return new DateLib(options, ethiopicDateLib);
+};

--- a/src/ethiopic/lib/index.ts
+++ b/src/ethiopic/lib/index.ts
@@ -1,0 +1,1 @@
+export { startOfYear } from "./startOfYear.js";

--- a/src/ethiopic/lib/startOfYear.ts
+++ b/src/ethiopic/lib/startOfYear.ts
@@ -1,0 +1,3 @@
+export function startOfYear() {
+  return new Date();
+}

--- a/src/persian.tsx
+++ b/src/persian.tsx
@@ -46,6 +46,7 @@ export function DayPicker(
      * - `arab`: Arabic-Indic
      * - `arabext`: Eastern Arabic-Indic (Persian)
      * - `deva`: Devanagari
+     * - `ethio`: Ethiopic
      * - `beng`: Bengali
      * - `guru`: Gurmukhi
      * - `gujr`: Gujarati

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -398,6 +398,7 @@ export interface PropsBase {
    * - `arab`: Arabic-Indic
    * - `arabext`: Eastern Arabic-Indic (Persian)
    * - `deva`: Devanagari
+   * - `ethio`: Ethiopic
    * - `beng`: Bengali
    * - `guru`: Gurmukhi
    * - `gujr`: Gujarati

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -416,6 +416,7 @@ export type MoveFocusBy =
  * - `arab`: Arabic-Indic
  * - `arabext`: Eastern Arabic-Indic (Persian)
  * - `deva`: Devanagari
+ * - `ethio`: Ethiopic
  * - `beng`: Bengali
  * - `guru`: Gurmukhi
  * - `gujr`: Gujarati
@@ -432,6 +433,7 @@ export type Numerals =
   | "arab"
   | "arabext"
   | "deva"
+  | "ethio"
   | "beng"
   | "guru"
   | "gujr"


### PR DESCRIPTION
This PR introduces support for the Ethiopic calendar in the DayPicker. 

The PR is still a work in progress. Switch to this branch to start applying changes to the source.

## How It Works 

The [Ethiopic calendar](https://en.wikipedia.org/wiki/Ethiopian_calendar) is rendered importing it from `react-day-picker/ethiopic`, as we do with the [Persian calendar](https://daypicker.dev/docs/localization#persian-calendar).

```tsx
import { DayPicker } from 'react-day-picker/ethiopic';

<DayPicker />
```

- [ ] Understand the correct name, Ethiopian or Ethiopic?

### Ethiopic Module

* [x] `src/ethiopic/index.tsx`: render DayPicker using the Ethiopic calendar, including the overridden locale and numeral system props.
* [ ] `src/ethiopic/lib`: module to contain the `date-fns` functions to override for date calculations and formatting (see below).

### Example Component, and Docs

* [x] `examples/Ethiopic.tsx`: the example components 
* [ ] `examples/Ethiopic.test.tsx`: test file for the new Ethiopic calendar example.
* [ ] `website/docs/docs/localization.mdx`: add Ethiopic Calendar paragraph.
* [ ] `website/components/playground`: add Ethiopic Calendar option.

> See [Working With the Source Code](https://daypicker.dev/development/contributing#working-with-the-source-code) to start the examples app and reach http://localhost:5173/?example=Ethiopic to see it running.

### Numeral System and Locale

* [ ] Understand which Locale should be used. Are they included in date-fns already?
* [ ] Understand which numeral systems we need to support.
* [ ] `src/types/props.ts`, `src/types/shared.ts` include the Ethiopic numeral system.
* [ ] Update `DateLib` to work with the new numeral system (e.g. `getDigitMap`)

### Ethiopic DateLib

Having the ethiopic date library compatible with the [DateLib](http://daypicker.dev/api/classes/DateLib) overrides protocol is the most challenging part of this project. The DateLib is initialized [here](https://github.com/gpbl/react-day-picker/blob/57662036f21ef4e054284b952e67ba4580ba5da2/src/ethiopic/index.tsx#L70) with the ethnic overrides, and should work out-of-the-box once we provide the correct .

In absence of a package like `date-fns-ethiopic`, we can initially include the ethiopic DateLib override's functions in the DayPicker package. Note that not all the functions may be require an ethiopic version.

- [ ] complete the missing functions (see list below) and their tests.

<details>
<summary>List of DateLib functions</summary>

- [ ] `addDays`
- [ ] `addMonths`
- [ ] `addWeeks`
- [ ] `addYears`
- [ ] `differenceInCalendarDays`
- [ ] `differenceInCalendarMonths`
- [ ] `eachMonthOfInterval`
- [ ] `endOfBroadcastWeek`
- [ ] `endOfISOWeek`
- [ ] `endOfMonth`
- [ ] `endOfWeek`
- [ ] `endOfYear`
- [ ] `format`
- [ ] `formatNumber`
- [ ] `getISOWeek`
- [ ] `getMonth`
- [ ] `getWeek`
- [ ] `getYear`
- [ ] `isAfter`
- [ ] `isBefore`
- [ ] `isSameDay`
- [ ] `isSameMonth`
- [ ] `isSameYear`
- [ ] `max`
- [ ] `min`
- [ ] `newDate`
- [ ] `setMonth`
- [ ] `setYear`
- [ ] `startOfBroadcastWeek`
- [ ] `startOfDay`
- [ ] `startOfISOWeek`
- [ ] `startOfMonth`
- [ ] `startOfWeek`
- [ ] `startOfYear`
- [ ] `today`

</details>

### Configuration and Build

* [x] `package.json`: includes the Ethiopic calendar module.
* [x] `ethiopic.js`: added module export for the Ethiopic calendar.
* [ ] Verify the type export with https://arethetypeswrong.github.io