### PR TITLE
docs: fix broken style.css link

### DIFF
--- a/website/docs/docs/styling.mdx
+++ b/website/docs/docs/styling.mdx
@@ -325,7 +325,7 @@ If you are including [Tailwind CSS](https://tailwindcss.com) in your project, us
 
 - Add the class names you want to override to the `classNames` prop.
 - Extend the default class names with [`getDefaultClassNames`](../api/functions/getDefaultClassNames.md).
-- Read the [`style.css`](https://github.com/gpbl/react-day-picker/blob/main/style.css) file from the source and get familiar with the [UI elements](../docs/anatomy.mdx).
+- Read the [`style.css`](https://github.com/gpbl/react-day-picker/blob/main/src/style.css) file from the source and get familiar with the [UI elements](../docs/anatomy.mdx).
 - Adopt [custom components](../guides/custom-components.mdx) to further customize the HTML elements.
 
 ```tsx


### PR DESCRIPTION
## What's Changed

Fixed the `style.css` link

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

