### PR TITLE
docs: fix custom components docs

### DIFF
--- a/examples/CustomDayButton.tsx
+++ b/examples/CustomDayButton.tsx
@@ -1,27 +1,39 @@
 import React from "react";
 
-import { DayPicker } from "react-day-picker";
+import { DayButtonProps, DayPicker } from "react-day-picker";
+
+const SelectedDateContext = React.createContext<{
+  selected?: Date;
+  setSelected?: React.Dispatch<React.SetStateAction<Date | undefined>>;
+}>({});
+
+function DayButton(props: DayButtonProps) {
+  const { day, modifiers, ...buttonProps } = props;
+
+  const { setSelected } = React.use(SelectedDateContext);
+  return (
+    <button
+      {...buttonProps}
+      onClick={() => setSelected?.(undefined)}
+      onDoubleClick={() => setSelected?.(day.date)}
+    />
+  );
+}
 
 export function CustomDayButton() {
   const [selected, setSelected] = React.useState<Date>();
+
   return (
-    <DayPicker
-      mode="single"
-      onSelect={setSelected}
-      selected={selected}
-      components={{
-        DayButton: (props) => {
-          const { day, modifiers, ...buttonProps } = props;
-          return (
-            <button
-              {...buttonProps}
-              onDoubleClick={() => setSelected(day.date)}
-              onClick={() => setSelected(undefined)}
-            />
-          );
-        }
-      }}
-      footer={selected?.toDateString() || "Double click to select a date"}
-    />
+    <SelectedDateContext.Provider value={{ selected, setSelected }}>
+      <DayPicker
+        mode="single"
+        selected={selected}
+        onSelect={setSelected}
+        components={{
+          DayButton
+        }}
+        footer={selected?.toDateString() || "Double click to select a date"}
+      />
+    </SelectedDateContext.Provider>
   );
 }

--- a/website/docs/guides/custom-components.mdx
+++ b/website/docs/guides/custom-components.mdx
@@ -33,8 +33,8 @@ Pass the components to customize to the `components` prop. See the [list of cust
 ```tsx
 <DayPicker
   components={{
-    Day: (props: DayProps) => <CustomDaycell {...props} />,
-    MonthGrid: (props: MonthGridProps) => <CustomMonthGrid {...props} />
+    Day: CustomDaycell,
+    MonthGrid: CustomMonthGrid
     // etc
   }}
 />
@@ -79,31 +79,41 @@ For example, you can use a custom [DayButton](../api/functions/DayButton.md) to 
 ```tsx title="./MyDatePicker.tsx"
 import React from "react";
 
-import { DayPicker } from "react-day-picker";
+import { DayButtonProps, DayPicker } from "react-day-picker";
 
-export function MyDatePicker() {
-  const [selected, setSelected] = React.useState<Date>();
+const SelectedDateContext = React.createContext<{
+  selected?: Date;
+  setSelected?: React.Dispatch<React.SetStateAction<Date | undefined>>;
+}>({});
+
+function DayButton(props: DayButtonProps) {
+  const { day, modifiers, ...buttonProps } = props;
+
+  const { setSelected } = React.use(SelectedDateContext);
   return (
-    <DayPicker
-      mode="single"
-      onSelect={setSelected}
-      selected={selected}
-      components={{
-        DayButton: (props) => {
-          const { day, modifiers, ...buttonProps } = props;
-          return (
-            <button
-              {...buttonProps}
-              // Prevent the default click event
-              onClick={() => setSelected(undefined)}
-              // Handle the double click event and reset the selection
-              onDoubleClick={() => setSelected(day.date)}
-            />
-          );
-        }
-      }}
-      footer={selected?.toDateString() || "Double click to select a date"}
+    <button
+      {...buttonProps}
+      onClick={() => setSelected?.(undefined)}
+      onDoubleClick={() => setSelected?.(day.date)}
     />
+  );
+}
+
+export function CustomDayButton() {
+  const [selected, setSelected] = React.useState<Date>();
+
+  return (
+    <SelectedDateContext.Provider value={{ selected, setSelected }}>
+      <DayPicker
+        mode="single"
+        selected={selected}
+        onSelect={setSelected}
+        components={{
+          DayButton
+        }}
+        footer={selected?.toDateString() || "Double click to select a date"}
+      />
+    </SelectedDateContext.Provider>
   );
 }
 ```


### PR DESCRIPTION
## What's Changed

- Fix [Custom Components](https://daypicker.dev/guides/custom-components) docs.
- Update `CustomDayButton` example to reflect documentation changes.

The documentation gives examples of customization based on a [render props](https://react.dev/reference/react/Children#calling-a-render-prop-to-customize-rendering) API, but the customization available is through a component-based API.  
E.g. the `DayButton` component is rendered as [`<components.DayButton {...} />`](https://github.com/gpbl/react-day-picker/blob/main/src/DayPicker.tsx#L535) in the [`DayPicker`](https://github.com/gpbl/react-day-picker/blob/main/src/DayPicker.tsx). To follow a [render props](https://react.dev/reference/react/Children#calling-a-render-prop-to-customize-rendering) API style, it should be manually called in the `DayPicker` component like `components.DayButton({...})`.
Using the `components` prop by passing inline functions for the custom components can cause issues like those reported in https://github.com/gpbl/react-day-picker/discussions/2667.
This happens because on every render a new function reference is created and mounted as a React component, the React's reconciliation algorithm considers that a new component has been rendered, and because of that it unmounts the previous component and mounts the new one.
This can cause performance issues and also bugs with state resetting because the component is unmounted and then mounted again, resetting the state to the initial values.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
