### PR TITLE
Fix deprecation suggestion of select event handler types

### DIFF
--- a/src/types/deprecated.ts
+++ b/src/types/deprecated.ts
@@ -116,20 +116,20 @@ export type InternalModifier =
 
 /**
  * @ignore
- * @deprecated This type will be removed. Use `SelectHandler<"single">` instead.
+ * @deprecated This type will be removed. Use `SelectHandler<{mode: "single"}>` instead.
  */
 export type SelectSingleEventHandler = PropsSingle["onSelect"];
 
 /**
  * @ignore
- * @deprecated This type will be removed. Use `SelectHandler<"multiple">`
+ * @deprecated This type will be removed. Use `SelectHandler<{mode: "multiple"}>`
  *   instead.
  */
 export type SelectMultipleEventHandler = PropsMulti["onSelect"];
 
 /**
  * @ignore
- * @deprecated This type will be removed. Use `SelectHandler<"range">` instead.
+ * @deprecated This type will be removed. Use `SelectHandler<{mode: "range"}>` instead.
  */
 export type SelectRangeEventHandler = PropsRange["onSelect"];
 

--- a/src/types/deprecated.ts
+++ b/src/types/deprecated.ts
@@ -116,20 +116,22 @@ export type InternalModifier =
 
 /**
  * @ignore
- * @deprecated This type will be removed. Use `SelectHandler<{mode: "single"}>` instead.
+ * @deprecated This type will be removed. Use `SelectHandler<{mode: "single"}>`
+ *   instead.
  */
 export type SelectSingleEventHandler = PropsSingle["onSelect"];
 
 /**
  * @ignore
- * @deprecated This type will be removed. Use `SelectHandler<{mode: "multiple"}>`
- *   instead.
+ * @deprecated This type will be removed. Use `SelectHandler<{mode:
+ *   "multiple"}>` instead.
  */
 export type SelectMultipleEventHandler = PropsMulti["onSelect"];
 
 /**
  * @ignore
- * @deprecated This type will be removed. Use `SelectHandler<{mode: "range"}>` instead.
+ * @deprecated This type will be removed. Use `SelectHandler<{mode: "range"}>`
+ *   instead.
  */
 export type SelectRangeEventHandler = PropsRange["onSelect"];
 


### PR DESCRIPTION
## What's Changed

When I was updating from v8 -> v9 I came across the deprecation notice for the `SelectSingleEventHandler`, which gave me the deprecation notice before this PR. When using the suggestion, I was met with:

```
ts: Type '"single"' has no properties in common with type '{ mode?: Mode | undefined; required?: boolean | undefined; }'.
```

Implementing the change I've made on this PR made the warning disappear, though you can also do `SelectHandler<{ required: true }>` and I'm not sure if that's correct. So maybe a type change needs to be made also.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
