### PR TITLE
feat: animation when changing months

### DIFF
--- a/src/DayPicker.tsx
+++ b/src/DayPicker.tsx
@@ -5,7 +5,6 @@ import { flushSync } from "react-dom";
 
 import { UI, DayFlag, SelectionState } from "./UI.js";
 import type { CalendarDay } from "./classes/CalendarDay.js";
-import { CalendarMonth } from "./classes/CalendarMonth.js";
 import { DateLib, defaultLocale } from "./classes/DateLib.js";
 import { getClassNamesForModifiers } from "./helpers/getClassNamesForModifiers.js";
 import { getComponents } from "./helpers/getComponents.js";
@@ -305,7 +304,7 @@ export function DayPicker(props: DayPickerProps) {
           {!props.hideNavigation && (
             <components.Nav
               className={classNames[UI.Nav]}
-              style={{ ...styles?.[UI.Nav], zIndex: 1 }}
+              style={styles?.[UI.Nav]}
               aria-label={labelNav()}
               onPreviousClick={handlePreviousClick}
               onNextClick={handleNextClick}
@@ -313,11 +312,7 @@ export function DayPicker(props: DayPickerProps) {
               nextMonth={nextMonth}
             />
           )}
-          {[
-            previousMonth && new CalendarMonth(previousMonth, []),
-            ...months,
-            nextMonth && new CalendarMonth(nextMonth, [])
-          ].map((calendarMonth, displayIndex) => {
+          {months.map((calendarMonth, displayIndex) => {
             if (!calendarMonth) return null;
             const dropdownMonths = getMonthOptions(
               calendarMonth.date,
@@ -334,278 +329,313 @@ export function DayPicker(props: DayPickerProps) {
               dateLib
             );
 
-            return (
-              <components.Month
-                className={classNames[UI.Month]}
-                style={{
-                  ...styles?.[UI.Month],
-                  viewTransitionName: `month-${calendarMonth.date.getMonth()}`,
-                  opacity: displayIndex === 0 || displayIndex === 2 ? 0 : 1,
-                  position:
-                    displayIndex === 0 || displayIndex === 2
-                      ? "absolute"
-                      : undefined,
-                  width:
-                    displayIndex === 0 || displayIndex === 2 ? 300 : undefined,
-                  transform:
-                    displayIndex === 0
-                      ? "translateX(-100%)"
-                      : displayIndex === 2
-                        ? "translateX(100%)"
-                        : undefined
-                }}
-                key={displayIndex}
-                displayIndex={displayIndex}
-                calendarMonth={calendarMonth}
-              >
-                <components.MonthCaption
-                  className={classNames[UI.MonthCaption]}
-                  style={styles?.[UI.MonthCaption]}
-                  calendarMonth={calendarMonth}
+            const renderMonth = (
+              index: number,
+              ...children: React.ReactNode[]
+            ) => {
+              return (
+                <components.Month
+                  key={index}
+                  className={classNames[UI.Month]}
+                  aria-hidden={displayIndex !== index}
+                  style={{
+                    ...styles?.[UI.Month],
+                    opacity: displayIndex !== index ? 0 : undefined,
+                    pointerEvents: displayIndex !== index ? "none" : undefined,
+                    position: displayIndex !== index ? "absolute" : undefined,
+                    overflow: displayIndex !== index ? "hidden" : undefined,
+                    transform:
+                      index === displayIndex - 1
+                        ? "translateX(-100%)"
+                        : index === displayIndex + 1
+                          ? "translateX(100%)"
+                          : undefined
+                  }}
                   displayIndex={displayIndex}
+                  calendarMonth={calendarMonth}
                 >
-                  {captionLayout?.startsWith("dropdown") ? (
-                    <components.DropdownNav
-                      className={classNames[UI.Dropdowns]}
-                      style={styles?.[UI.Dropdowns]}
-                    >
-                      {captionLayout === "dropdown" ||
-                      captionLayout === "dropdown-months" ? (
-                        <components.MonthsDropdown
-                          className={classNames[UI.MonthsDropdown]}
-                          aria-label={labelMonthDropdown()}
-                          classNames={classNames}
-                          components={components}
-                          disabled={Boolean(props.disableNavigation)}
-                          onChange={handleMonthChange(calendarMonth.date)}
-                          options={dropdownMonths}
-                          style={styles?.[UI.Dropdown]}
-                          value={dateLib.getMonth(calendarMonth.date)}
-                        />
-                      ) : (
-                        <span role="status" aria-live="polite">
-                          {formatMonthDropdown(calendarMonth.date, dateLib)}
-                        </span>
-                      )}
-                      {captionLayout === "dropdown" ||
-                      captionLayout === "dropdown-years" ? (
-                        <components.YearsDropdown
-                          className={classNames[UI.YearsDropdown]}
-                          aria-label={labelYearDropdown(dateLib.options)}
-                          classNames={classNames}
-                          components={components}
-                          disabled={Boolean(props.disableNavigation)}
-                          onChange={handleYearChange(calendarMonth.date)}
-                          options={dropdownYears}
-                          style={styles?.[UI.Dropdown]}
-                          value={dateLib.getYear(calendarMonth.date)}
-                        />
-                      ) : (
-                        <span role="status" aria-live="polite">
-                          {formatYearDropdown(calendarMonth.date, dateLib)}
-                        </span>
-                      )}
-                    </components.DropdownNav>
-                  ) : (
-                    <components.CaptionLabel
-                      className={classNames[UI.CaptionLabel]}
-                      role="status"
-                      aria-live="polite"
-                    >
-                      {formatCaption(
-                        calendarMonth.date,
-                        dateLib.options,
-                        dateLib
-                      )}
-                    </components.CaptionLabel>
-                  )}
-                </components.MonthCaption>
-                <components.MonthGrid
-                  role="grid"
-                  aria-multiselectable={mode === "multiple" || mode === "range"}
-                  aria-label={
-                    labelGrid(calendarMonth.date, dateLib.options, dateLib) ||
-                    undefined
-                  }
-                  className={classNames[UI.MonthGrid]}
-                  style={styles?.[UI.MonthGrid]}
-                >
-                  {!props.hideWeekdays && (
-                    <components.Weekdays
-                      className={classNames[UI.Weekdays]}
-                      style={styles?.[UI.Weekdays]}
-                    >
-                      {showWeekNumber && (
-                        <components.WeekNumberHeader
-                          aria-label={labelWeekNumberHeader(dateLib.options)}
-                          className={classNames[UI.WeekNumberHeader]}
-                          style={styles?.[UI.WeekNumberHeader]}
-                          scope="col"
-                        >
-                          {formatWeekNumberHeader()}
-                        </components.WeekNumberHeader>
-                      )}
-                      {weekdays.map((weekday, i) => (
-                        <components.Weekday
-                          aria-label={labelWeekday(
-                            weekday,
-                            dateLib.options,
-                            dateLib
-                          )}
-                          className={classNames[UI.Weekday]}
-                          key={i}
-                          style={styles?.[UI.Weekday]}
-                          scope="col"
-                        >
-                          {formatWeekdayName(weekday, dateLib.options, dateLib)}
-                        </components.Weekday>
-                      ))}
-                    </components.Weekdays>
-                  )}
-                  <components.Weeks
-                    className={classNames[UI.Weeks]}
-                    style={styles?.[UI.Weeks]}
+                  {children}
+                  <components.MonthCaption
+                    className={classNames[UI.MonthCaption]}
+                    style={styles?.[UI.MonthCaption]}
+                    calendarMonth={calendarMonth}
+                    displayIndex={displayIndex}
                   >
-                    {calendarMonth.weeks.map((week, weekIndex) => {
-                      return (
-                        <components.Week
-                          className={classNames[UI.Week]}
-                          key={week.weekNumber}
-                          style={styles?.[UI.Week]}
-                          week={week}
-                        >
-                          {showWeekNumber && (
-                            <components.WeekNumber
-                              week={week}
-                              style={styles?.[UI.WeekNumber]}
-                              aria-label={labelWeekNumber(week.weekNumber, {
-                                locale
-                              })}
-                              className={classNames[UI.WeekNumber]}
-                              scope="row"
-                              role="rowheader"
-                            >
-                              {formatWeekNumber(week.weekNumber)}
-                            </components.WeekNumber>
-                          )}
-                          {week.days.map((day: CalendarDay) => {
-                            const { date } = day;
-                            const modifiers = getModifiers(day);
-
-                            modifiers[DayFlag.focused] =
-                              !modifiers.hidden &&
-                              Boolean(focused?.isEqualTo(day));
-
-                            modifiers[SelectionState.selected] =
-                              !modifiers.disabled &&
-                              (isSelected?.(date) || modifiers.selected);
-
-                            if (isDateRange(selectedValue)) {
-                              // add range modifiers
-                              const { from, to } = selectedValue;
-                              modifiers[SelectionState.range_start] = Boolean(
-                                from && to && dateLib.isSameDay(date, from)
-                              );
-                              modifiers[SelectionState.range_end] = Boolean(
-                                from && to && dateLib.isSameDay(date, to)
-                              );
-                              modifiers[SelectionState.range_middle] =
-                                rangeIncludesDate(
-                                  selectedValue,
-                                  date,
-                                  true,
-                                  dateLib
-                                );
-                            }
-
-                            const style = getStyleForModifiers(
-                              modifiers,
-                              styles,
-                              props.modifiersStyles
-                            );
-
-                            const className = getClassNamesForModifiers(
-                              modifiers,
-                              classNames,
-                              props.modifiersClassNames
-                            );
-
-                            const ariaLabel =
-                              !isInteractive && !modifiers.hidden
-                                ? labelGridcell(
-                                    date,
-                                    modifiers,
-                                    dateLib.options,
-                                    dateLib
-                                  )
-                                : undefined;
-
-                            return (
-                              <components.Day
-                                key={`${dateLib.format(date, "yyyy-MM-dd")}_${dateLib.format(day.displayMonth, "yyyy-MM")}`}
-                                day={day}
-                                modifiers={modifiers}
-                                className={className.join(" ")}
-                                style={style}
-                                role="gridcell"
-                                aria-selected={modifiers.selected || undefined}
-                                aria-label={ariaLabel}
-                                data-day={dateLib.format(date, "yyyy-MM-dd")}
-                                data-month={
-                                  day.outside
-                                    ? dateLib.format(date, "yyyy-MM")
-                                    : undefined
-                                }
-                                data-selected={modifiers.selected || undefined}
-                                data-disabled={modifiers.disabled || undefined}
-                                data-hidden={modifiers.hidden || undefined}
-                                data-outside={day.outside || undefined}
-                                data-focused={modifiers.focused || undefined}
-                                data-today={modifiers.today || undefined}
+                    {captionLayout?.startsWith("dropdown") ? (
+                      <components.DropdownNav
+                        className={classNames[UI.Dropdowns]}
+                        style={styles?.[UI.Dropdowns]}
+                      >
+                        {captionLayout === "dropdown" ||
+                        captionLayout === "dropdown-months" ? (
+                          <components.MonthsDropdown
+                            className={classNames[UI.MonthsDropdown]}
+                            aria-label={labelMonthDropdown()}
+                            classNames={classNames}
+                            components={components}
+                            disabled={Boolean(props.disableNavigation)}
+                            onChange={handleMonthChange(calendarMonth.date)}
+                            options={dropdownMonths}
+                            style={styles?.[UI.Dropdown]}
+                            value={dateLib.getMonth(calendarMonth.date)}
+                          />
+                        ) : (
+                          <span role="status" aria-live="polite">
+                            {formatMonthDropdown(calendarMonth.date, dateLib)}
+                          </span>
+                        )}
+                        {captionLayout === "dropdown" ||
+                        captionLayout === "dropdown-years" ? (
+                          <components.YearsDropdown
+                            className={classNames[UI.YearsDropdown]}
+                            aria-label={labelYearDropdown(dateLib.options)}
+                            classNames={classNames}
+                            components={components}
+                            disabled={Boolean(props.disableNavigation)}
+                            onChange={handleYearChange(calendarMonth.date)}
+                            options={dropdownYears}
+                            style={styles?.[UI.Dropdown]}
+                            value={dateLib.getYear(calendarMonth.date)}
+                          />
+                        ) : (
+                          <span role="status" aria-live="polite">
+                            {formatYearDropdown(calendarMonth.date, dateLib)}
+                          </span>
+                        )}
+                      </components.DropdownNav>
+                    ) : (
+                      <components.CaptionLabel
+                        className={classNames[UI.CaptionLabel]}
+                        role="status"
+                        aria-live="polite"
+                      >
+                        {formatCaption(
+                          calendarMonth.date,
+                          dateLib.options,
+                          dateLib
+                        )}
+                      </components.CaptionLabel>
+                    )}
+                  </components.MonthCaption>
+                  <components.MonthGrid
+                    role="grid"
+                    aria-multiselectable={
+                      mode === "multiple" || mode === "range"
+                    }
+                    aria-label={
+                      labelGrid(calendarMonth.date, dateLib.options, dateLib) ||
+                      undefined
+                    }
+                    className={classNames[UI.MonthGrid]}
+                    style={styles?.[UI.MonthGrid]}
+                  >
+                    {!props.hideWeekdays && (
+                      <components.Weekdays
+                        className={classNames[UI.Weekdays]}
+                        style={styles?.[UI.Weekdays]}
+                      >
+                        {showWeekNumber && (
+                          <components.WeekNumberHeader
+                            aria-label={labelWeekNumberHeader(dateLib.options)}
+                            className={classNames[UI.WeekNumberHeader]}
+                            style={styles?.[UI.WeekNumberHeader]}
+                            scope="col"
+                          >
+                            {formatWeekNumberHeader()}
+                          </components.WeekNumberHeader>
+                        )}
+                        {weekdays.map((weekday, i) => (
+                          <components.Weekday
+                            aria-label={labelWeekday(
+                              weekday,
+                              dateLib.options,
+                              dateLib
+                            )}
+                            className={classNames[UI.Weekday]}
+                            key={i}
+                            style={styles?.[UI.Weekday]}
+                            scope="col"
+                          >
+                            {formatWeekdayName(
+                              weekday,
+                              dateLib.options,
+                              dateLib
+                            )}
+                          </components.Weekday>
+                        ))}
+                      </components.Weekdays>
+                    )}
+                    <components.Weeks
+                      className={classNames[UI.Weeks]}
+                      style={{
+                        ...styles?.[UI.Weeks],
+                        viewTransitionName: `month-${displayIndex}-${calendarMonth.date.getFullYear() * 12 + calendarMonth.date.getMonth() + index}`
+                      }}
+                    >
+                      {calendarMonth.weeks.map((week, weekIndex) => {
+                        return (
+                          <components.Week
+                            className={classNames[UI.Week]}
+                            key={week.weekNumber}
+                            style={styles?.[UI.Week]}
+                            week={week}
+                          >
+                            {showWeekNumber && (
+                              <components.WeekNumber
+                                week={week}
+                                style={styles?.[UI.WeekNumber]}
+                                aria-label={labelWeekNumber(week.weekNumber, {
+                                  locale
+                                })}
+                                className={classNames[UI.WeekNumber]}
+                                scope="row"
+                                role="rowheader"
                               >
-                                {!modifiers.hidden && isInteractive ? (
-                                  <components.DayButton
-                                    className={classNames[UI.DayButton]}
-                                    style={styles?.[UI.DayButton]}
-                                    type="button"
-                                    day={day}
-                                    modifiers={modifiers}
-                                    disabled={modifiers.disabled || undefined}
-                                    tabIndex={isFocusTarget(day) ? 0 : -1}
-                                    aria-label={labelDayButton(
+                                {formatWeekNumber(week.weekNumber)}
+                              </components.WeekNumber>
+                            )}
+                            {week.days.map((day: CalendarDay) => {
+                              const { date } = day;
+                              const modifiers = getModifiers(day);
+
+                              modifiers[DayFlag.focused] =
+                                !modifiers.hidden &&
+                                Boolean(focused?.isEqualTo(day));
+
+                              modifiers[SelectionState.selected] =
+                                !modifiers.disabled &&
+                                (isSelected?.(date) || modifiers.selected);
+
+                              if (isDateRange(selectedValue)) {
+                                // add range modifiers
+                                const { from, to } = selectedValue;
+                                modifiers[SelectionState.range_start] = Boolean(
+                                  from && to && dateLib.isSameDay(date, from)
+                                );
+                                modifiers[SelectionState.range_end] = Boolean(
+                                  from && to && dateLib.isSameDay(date, to)
+                                );
+                                modifiers[SelectionState.range_middle] =
+                                  rangeIncludesDate(
+                                    selectedValue,
+                                    date,
+                                    true,
+                                    dateLib
+                                  );
+                              }
+
+                              const style = getStyleForModifiers(
+                                modifiers,
+                                styles,
+                                props.modifiersStyles
+                              );
+
+                              const className = getClassNamesForModifiers(
+                                modifiers,
+                                classNames,
+                                props.modifiersClassNames
+                              );
+
+                              const ariaLabel =
+                                !isInteractive && !modifiers.hidden
+                                  ? labelGridcell(
                                       date,
                                       modifiers,
                                       dateLib.options,
                                       dateLib
-                                    )}
-                                    onClick={handleDayClick(day, modifiers)}
-                                    onBlur={handleDayBlur(day, modifiers)}
-                                    onFocus={handleDayFocus(day, modifiers)}
-                                    onKeyDown={handleDayKeyDown(day, modifiers)}
-                                    onMouseEnter={handleDayMouseEnter(
-                                      day,
-                                      modifiers
-                                    )}
-                                    onMouseLeave={handleDayMouseLeave(
-                                      day,
-                                      modifiers
-                                    )}
-                                  >
-                                    {formatDay(date, dateLib.options, dateLib)}
-                                  </components.DayButton>
-                                ) : (
-                                  !modifiers.hidden &&
-                                  formatDay(day.date, dateLib.options, dateLib)
-                                )}
-                              </components.Day>
-                            );
-                          })}
-                        </components.Week>
-                      );
-                    })}
-                  </components.Weeks>
-                </components.MonthGrid>
-              </components.Month>
+                                    )
+                                  : undefined;
+
+                              return (
+                                <components.Day
+                                  key={`${dateLib.format(date, "yyyy-MM-dd")}_${dateLib.format(day.displayMonth, "yyyy-MM")}`}
+                                  day={day}
+                                  modifiers={modifiers}
+                                  className={className.join(" ")}
+                                  style={style}
+                                  role="gridcell"
+                                  aria-selected={
+                                    modifiers.selected || undefined
+                                  }
+                                  aria-label={ariaLabel}
+                                  data-day={dateLib.format(date, "yyyy-MM-dd")}
+                                  data-month={
+                                    day.outside
+                                      ? dateLib.format(date, "yyyy-MM")
+                                      : undefined
+                                  }
+                                  data-selected={
+                                    modifiers.selected || undefined
+                                  }
+                                  data-disabled={
+                                    modifiers.disabled || undefined
+                                  }
+                                  data-hidden={modifiers.hidden || undefined}
+                                  data-outside={day.outside || undefined}
+                                  data-focused={modifiers.focused || undefined}
+                                  data-today={modifiers.today || undefined}
+                                >
+                                  {!modifiers.hidden && isInteractive ? (
+                                    <components.DayButton
+                                      className={classNames[UI.DayButton]}
+                                      style={styles?.[UI.DayButton]}
+                                      type="button"
+                                      day={day}
+                                      modifiers={modifiers}
+                                      disabled={modifiers.disabled || undefined}
+                                      tabIndex={isFocusTarget(day) ? 0 : -1}
+                                      aria-label={labelDayButton(
+                                        date,
+                                        modifiers,
+                                        dateLib.options,
+                                        dateLib
+                                      )}
+                                      onClick={handleDayClick(day, modifiers)}
+                                      onBlur={handleDayBlur(day, modifiers)}
+                                      onFocus={handleDayFocus(day, modifiers)}
+                                      onKeyDown={handleDayKeyDown(
+                                        day,
+                                        modifiers
+                                      )}
+                                      onMouseEnter={handleDayMouseEnter(
+                                        day,
+                                        modifiers
+                                      )}
+                                      onMouseLeave={handleDayMouseLeave(
+                                        day,
+                                        modifiers
+                                      )}
+                                    >
+                                      {formatDay(
+                                        date,
+                                        dateLib.options,
+                                        dateLib
+                                      )}
+                                    </components.DayButton>
+                                  ) : (
+                                    !modifiers.hidden &&
+                                    formatDay(
+                                      day.date,
+                                      dateLib.options,
+                                      dateLib
+                                    )
+                                  )}
+                                </components.Day>
+                              );
+                            })}
+                          </components.Week>
+                        );
+                      })}
+                    </components.Weeks>
+                  </components.MonthGrid>
+                </components.Month>
+              );
+            };
+
+            return renderMonth(
+              displayIndex,
+              renderMonth(displayIndex - 1),
+              renderMonth(displayIndex + 1)
             );
           })}
         </components.Months>


### PR DESCRIPTION
## Description

Draft PR for discussion on the implementation of animation when changing months.
The changes in this PR are applied all the time, just for testing purposes. Still, in the final version, the component only renders the animation when passing a specific property like `animation`.

The main point of the implementation is to use the [View Transition API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API) for the animation and rely purely on the native browser API.

The results look great with minimal changes:

https://github.com/user-attachments/assets/1a47775b-f728-4ab3-8400-e5cfcfafbbad

https://github.com/user-attachments/assets/03f90c00-70c9-40b2-acf6-b85ac760717f

With x6 CPU throttling the multiple months is jank and unusable, but one month looks great, though it can be improved by looking at the performance chart:

https://github.com/user-attachments/assets/78c4a8ee-3946-4e05-885e-bb5e753033fd

<img width="824" alt="One month CPU throttling x6 performance chart" src="https://github.com/user-attachments/assets/84b9bbc2-b8eb-411e-9f4e-65d0a03c90f4" />

## Notes

To use the View Transition API and make it performant, we ensure that the DOM elements representing a month in the calendar that will be animated are always mounted in the DOM but hidden. After changing their state, the browser will take care of animating them to their final state.

We need to use [flushSync](https://react.dev/reference/react-dom/flushSync) to use the View Transition API to enforce React executes the state changes and render the result within the context of the `document.startViewTransition` call.
Without `flushSync`, the normal behavior of React is to schedule updates, which would happen outside the `document.startViewTransition` scope.

I noticed that the browser automatically applies fade-in and out animations to elements that are not explicitly marked to be animated with the View Transition API, e.g. the month label in the videos above, so we get this animation by default.
I imagine this happens because it looks much more fluid to the user together with other animations happening on the page.

The main trick in this implementation of the animation is to mount the same DOM structure of a calendar month, directly as a child of the calendar month, and hide and translate to another position.
Even though we are mounting the same month to be animated later in a different month, that has a different DOM structure, with possibly different amounts of weeks and days in different positions, the browser interpolates the difference between the initial state and the final state, and the animation looks _almost_ perfect.
(This API looks amazing! 🙏 )

Furthermore, it's only _almost_ perfect because there's a missing feature of the API that causes an issue to our use case.
If you check closely the examples, you will notice that the animation is displayed outside the calendar box, this is because in the current state of the View Transition API the animations don't respect the [clipping of the normal DOM structure](https://stackoverflow.com/questions/79059408/view-transition-api-overflow-is-ignored).
That's why animating up/down looks worse:

https://github.com/user-attachments/assets/90a3f413-bba9-489a-b33e-17584838a4fa

We may need to wait until the [Nested View Transitions](https://github.com/WICG/view-transitions/blob/main/nested-explainer.md) feature is implemented to follow this approach.
It seems worth to use the view transition API and wait for when it's complete enough to fulfill our use case.
