### PR TITLE
Removes duplicate '--rdp-day-height' from styling documentation

### DIFF
--- a/website/docs/docs/styling.mdx
+++ b/website/docs/docs/styling.mdx
@@ -106,12 +106,6 @@ The following table lists the CSS variables used by DayPicker within the `.rdp-r
     </tr>
     <tr>
       <td>
-        <code>--rdp-day-height</code>
-      </td>
-      <td>The height of the day cells (default: `44px`).</td>
-    </tr>
-    <tr>
-      <td>
         <code>--rdp-day-width</code>
       </td>
       <td>The width of the day cells (default: `44px`).</td>


### PR DESCRIPTION
## What's Changed
I noticed when I was reading through the docs that there were duplicate `--rdp-day-height` definitions in the custom variable docs. 

<img width="599" alt="Screenshot 2025-03-11 at 11 11 08 PM" src="https://github.com/user-attachments/assets/0b96e538-f564-40fe-9ed5-bb0b64be87e5" />

This change removes the duplicate, very straightforward!

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update


