### PR TITLE
fix: add missing css types to package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "dist",
     "src/style.css",
     "src/style.module.css",
-    "src/style.css.d.ts",
+    "src/style.module.css.d.ts",
     "jalali.js",
     "jalali.d.ts",
     "locale.js",


### PR DESCRIPTION
## What's Changed

This change add the missing typescript types for css imports

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
