### PR TITLE
fix: add persian localization to package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,8 @@
     "src/style.css.d.ts",
     "jalali.js",
     "jalali.d.ts",
+    "persian.js",
+    "persian.d.ts",
     "locale.js",
     "locale.d.ts"
   ],


### PR DESCRIPTION
resolves #2709

## What's Changed

This change adds the files for persian localization to the package.json files so that they will be published to npm.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
