### PR TITLE
fix: add visually hidden text to announce month/year

### DIFF
--- a/src/DayPicker.tsx
+++ b/src/DayPicker.tsx
@@ -362,7 +362,7 @@ export function DayPicker(props: DayPickerProps) {
                           value={dateLib.getMonth(calendarMonth.date)}
                         />
                       ) : (
-                        <span role="status" aria-live="polite">
+                        <span>
                           {formatMonthDropdown(calendarMonth.date, dateLib)}
                         </span>
                       )}
@@ -380,10 +380,32 @@ export function DayPicker(props: DayPickerProps) {
                           value={dateLib.getYear(calendarMonth.date)}
                         />
                       ) : (
-                        <span role="status" aria-live="polite">
+                        <span>
                           {formatYearDropdown(calendarMonth.date, dateLib)}
                         </span>
                       )}
+                      <span
+                        role="status"
+                        aria-live="polite"
+                        style={{
+                          border: 0,
+                          clip: "rect(0 0 0 0)",
+                          height: "1px",
+                          margin: "-1px",
+                          overflow: "hidden",
+                          padding: 0,
+                          position: "absolute",
+                          width: "1px",
+                          whiteSpace: "nowrap",
+                          wordWrap: "normal"
+                        }}
+                      >
+                        {formatCaption(
+                          calendarMonth.date,
+                          dateLib.options,
+                          dateLib
+                        )}
+                      </span>
                     </components.DropdownNav>
                   ) : (
                     <components.CaptionLabel


### PR DESCRIPTION
Fixes https://github.com/gpbl/react-day-picker/issues/2715

This PR adds a [visually hidden](https://github.com/reach/reach-ui/blob/main/packages/visually-hidden/src/reach-visually-hidden.tsx) text when the `captionLayout` is of any dropdown type. This text announces to screen readers when the month and year change, following the same pattern for the `CaptionLabel` component used in the default layout (without dropdown).

These changes fix the issue when using the previous or next month buttons.
When using the select dropdown though, the screen reader will announce the new option that gets selected, e.g. July or 2025, and will announce the month and year because the visually hidden text changes.
This in turn causes the screen reader to announce for example "July, July 2025" after selecting July with the dropdown, and after selecting a year, for example, it will announce "2025, July 2025".