### PR TITLE
fix: Fix importing of whole locale from date-fns

### DIFF
--- a/src/classes/DateLib.ts
+++ b/src/classes/DateLib.ts
@@ -40,7 +40,7 @@ import type {
   Interval
 } from "date-fns";
 import type { Locale } from "date-fns/locale";
-import { enUS } from "date-fns/locale";
+import { enUS } from "date-fns/locale/en-US";
 
 import { endOfBroadcastWeek } from "../helpers/endOfBroadcastWeek.js";
 import { startOfBroadcastWeek } from "../helpers/startOfBroadcastWeek.js";


### PR DESCRIPTION
## What's Changed

Importing directly to the en-US locale instead of import from "date-fns/locale".
When using react-day-picker and, I found out that the bundle size increased quite a bit. After tweaking import of react-day-picker, look like this single line that import "date-fns/locale" is causing issue. When replace with a direct import to en-US, the bundle size reduced significantly, because only en-US is imported.

Note: normally one would look into https://date-fns.org/v4.1.0/docs/webpack for how to solve bundle size. However this is not necessary if you are not doing dynamic import. In my project we import the exact locale we need, and expect that only those locale will be bundle. However this was broken due to this line in react-day-picker.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
