### PR TITLE
fix(build): add back `src` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,9 +174,7 @@
   },
   "files": [
     "dist",
-    "src/style.css",
-    "src/style.module.css",
-    "src/style.module.css.d.ts",
+    "src",
     "jalali.js",
     "jalali.d.ts",
     "persian.js",


### PR DESCRIPTION
Fixes #2714.
