### PR TITLE
fix: calculateFocusTarget logic

### DIFF
--- a/src/helpers/calculateFocusTarget.test.ts
+++ b/src/helpers/calculateFocusTarget.test.ts
@@ -1,0 +1,167 @@
+import { DayFlag } from "../UI.js";
+import { CalendarDay } from "../classes/index.js";
+import type { Modifiers } from "../types/index.js";
+
+import { calculateFocusTarget } from "./calculateFocusTarget";
+
+const todayModifiers = {
+  [DayFlag.today]: true
+};
+
+const todayHiddenModifiers = {
+  [DayFlag.today]: true,
+  [DayFlag.hidden]: true
+};
+
+const focusedModifiers = {
+  [DayFlag.focused]: true
+};
+
+const focusedDisabledModifiers = {
+  [DayFlag.focused]: true,
+  [DayFlag.disabled]: true
+};
+
+const outsideModifiers = {
+  [DayFlag.outside]: true
+};
+
+const hiddenModifiers = {
+  [DayFlag.hidden]: true
+};
+
+const disabledModifiers = {
+  [DayFlag.disabled]: true
+};
+
+const month = new Date(2021, 0, 1);
+const day1 = new CalendarDay(new Date(2021, 0, 1), month);
+const dayToday = new CalendarDay(new Date(2021, 0, 2), month);
+const daySelected = new CalendarDay(new Date(2021, 0, 3), month);
+const dayLastFocused = new CalendarDay(new Date(2021, 0, 4), month);
+const dayFocusedModifier = new CalendarDay(new Date(2021, 0, 5), month);
+const day6 = new CalendarDay(new Date(2021, 0, 6), month);
+
+const days: CalendarDay[] = [
+  day1,
+  dayToday,
+  daySelected,
+  dayLastFocused,
+  dayFocusedModifier,
+  day6
+];
+
+const isSelected = (date: Date) => {
+  return date.getTime() === daySelected.date.getTime();
+};
+
+function getModifiersFactory(
+  entries: [CalendarDay, Modifiers][]
+): (day: CalendarDay) => Modifiers {
+  const map = new Map(entries);
+  return (day) => map.get(day) ?? {};
+}
+
+describe("calculateFocusTarget", () => {
+  describe("should return the correct focus target in the list of days based on the priority", () => {
+    it("focused modifier", () => {
+      const getModifiers = getModifiersFactory([
+        [day1, outsideModifiers],
+        [dayToday, todayModifiers],
+        [daySelected, {}],
+        [dayLastFocused, {}],
+        [dayFocusedModifier, focusedModifiers],
+        [day6, {}]
+      ]);
+
+      const focusTarget = calculateFocusTarget(
+        days,
+        getModifiers,
+        isSelected,
+        dayLastFocused
+      );
+
+      expect(focusTarget).toBe(dayFocusedModifier);
+    });
+
+    it("last focused", () => {
+      const getModifiers = getModifiersFactory([
+        [day1, outsideModifiers],
+        [dayToday, todayModifiers],
+        [daySelected, {}],
+        [dayLastFocused, {}],
+        [dayFocusedModifier, focusedDisabledModifiers],
+        [day6, {}]
+      ]);
+
+      const focusTarget = calculateFocusTarget(
+        days,
+        getModifiers,
+        isSelected,
+        dayLastFocused
+      );
+
+      expect(focusTarget).toBe(dayLastFocused);
+    });
+
+    it("selected", () => {
+      const getModifiers = getModifiersFactory([
+        [day1, outsideModifiers],
+        [dayToday, todayModifiers],
+        [daySelected, {}],
+        [dayLastFocused, disabledModifiers],
+        [dayFocusedModifier, focusedDisabledModifiers],
+        [day6, {}]
+      ]);
+
+      const focusTarget = calculateFocusTarget(
+        days,
+        getModifiers,
+        isSelected,
+        dayLastFocused
+      );
+
+      expect(focusTarget).toBe(daySelected);
+    });
+
+    it("today", () => {
+      const getModifiers = getModifiersFactory([
+        [day1, outsideModifiers],
+        [dayToday, todayModifiers],
+        [daySelected, hiddenModifiers],
+        [dayLastFocused, disabledModifiers],
+        [dayFocusedModifier, focusedDisabledModifiers],
+        [day6, {}]
+      ]);
+
+      const focusTarget = calculateFocusTarget(
+        days,
+        getModifiers,
+        isSelected,
+        dayLastFocused
+      );
+
+      expect(focusTarget).toBe(dayToday);
+    });
+
+    it("first focusable day", () => {
+      const getModifiers = getModifiersFactory([
+        [day1, outsideModifiers],
+        [dayToday, todayHiddenModifiers],
+        [daySelected, hiddenModifiers],
+        [dayLastFocused, disabledModifiers],
+        [dayFocusedModifier, focusedDisabledModifiers],
+        [day6, {}]
+      ]);
+
+      const focusTarget = calculateFocusTarget(
+        days,
+        getModifiers,
+        isSelected,
+        dayLastFocused
+      );
+
+      expect(focusTarget).toBe(day6);
+    });
+  });
+});

--- a/src/helpers/calculateFocusTarget.test.ts
+++ b/src/helpers/calculateFocusTarget.test.ts
@@ -63,8 +63,8 @@ function getModifiersFactory(
 }
 
 describe("calculateFocusTarget", () => {
-  describe("should return the correct focus target in the list of days based on the priority", () => {
-    it("focused modifier", () => {
+  describe("when determining the focus target based on priority", () => {
+    it("should prioritize the day with the 'focused' modifier", () => {
       const getModifiers = getModifiersFactory([
         [day1, outsideModifiers],
         [dayToday, todayModifiers],
@@ -84,7 +84,7 @@ describe("calculateFocusTarget", () => {
       expect(focusTarget).toBe(dayFocusedModifier);
     });
 
-    it("last focused", () => {
+    it("should fall back to the last focused day if no day has the 'focused' modifier", () => {
       const getModifiers = getModifiersFactory([
         [day1, outsideModifiers],
         [dayToday, todayModifiers],
@@ -104,7 +104,7 @@ describe("calculateFocusTarget", () => {
       expect(focusTarget).toBe(dayLastFocused);
     });
 
-    it("selected", () => {
+    it("should prioritize the selected day if no day is focused or last focused", () => {
       const getModifiers = getModifiersFactory([
         [day1, outsideModifiers],
         [dayToday, todayModifiers],
@@ -124,7 +124,7 @@ describe("calculateFocusTarget", () => {
       expect(focusTarget).toBe(daySelected);
     });
 
-    it("today", () => {
+    it("should prioritize today if no day is focused, last focused, or selected", () => {
       const getModifiers = getModifiersFactory([
         [day1, outsideModifiers],
         [dayToday, todayModifiers],
@@ -144,7 +144,7 @@ describe("calculateFocusTarget", () => {
       expect(focusTarget).toBe(dayToday);
     });
 
-    it("first focusable day", () => {
+    it("should fall back to the first focusable day if no other priority is met", () => {
       const getModifiers = getModifiersFactory([
         [day1, outsideModifiers],
         [dayToday, todayHiddenModifiers],

--- a/src/helpers/calculateFocusTarget.ts
+++ b/src/helpers/calculateFocusTarget.ts
@@ -9,6 +9,14 @@ enum FocusTargetPriority {
   FocusedModifier
 }
 
+function isFocusableDay(modifiers: Modifiers) {
+  return (
+    !modifiers[DayFlag.disabled] &&
+    !modifiers[DayFlag.hidden] &&
+    !modifiers[DayFlag.outside]
+  );
+}
+
 export function calculateFocusTarget(
   days: CalendarDay[],
   getModifiers: (day: CalendarDay) => Modifiers,
@@ -21,11 +29,7 @@ export function calculateFocusTarget(
   for (const day of days) {
     const modifiers = getModifiers(day);
 
-    if (
-      !modifiers[DayFlag.disabled] &&
-      !modifiers[DayFlag.hidden] &&
-      !modifiers[DayFlag.outside]
-    ) {
+    if (isFocusableDay(modifiers)) {
       if (
         modifiers[DayFlag.focused] &&
         foundFocusTargetPriority < FocusTargetPriority.FocusedModifier
@@ -56,10 +60,7 @@ export function calculateFocusTarget(
 
   if (!focusTarget) {
     // return the first day that is focusable
-    focusTarget = days.find((day) => {
-      const m = getModifiers(day);
-      return !m[DayFlag.disabled] && !m[DayFlag.hidden] && !m[DayFlag.outside];
-    });
+    focusTarget = days.find((day) => isFocusableDay(getModifiers(day)));
   }
   return focusTarget;
 }


### PR DESCRIPTION
Fix #2725

## Changes

Fix the `calculateFocusTarget` logic.  
Implement a logic that iterates over all days shown in the calendar, and computes the final target day based on the priority of the valid focusable days.