### PR TITLE
fix: prevent timezone override when initialMonth is Date type

### DIFF
--- a/src/helpers/getInitialMonth.ts
+++ b/src/helpers/getInitialMonth.ts
@@ -1,3 +1,5 @@
+import { TZDate } from "@date-fns/tz";
+
 import { type DateLib } from "../classes/DateLib.js";
 import { type DayPickerProps } from "../types/props.js";
 
@@ -23,7 +25,8 @@ export function getInitialMonth(
     today = dateLib.today(),
     numberOfMonths = 1,
     endMonth,
-    startMonth
+    startMonth,
+    timeZone
   } = props;
   let initialMonth = month || defaultMonth || today;
   const { differenceInCalendarMonths, addMonths, startOfMonth } = dateLib;
@@ -37,5 +40,8 @@ export function getInitialMonth(
   if (startMonth && differenceInCalendarMonths(initialMonth, startMonth) < 0) {
     initialMonth = startMonth;
   }
+  // When timeZone is provided, convert initialMonth to TZDate type to ensure proper timezone handling
+  initialMonth = timeZone ? new TZDate(initialMonth, timeZone) : initialMonth;
+
   return startOfMonth(initialMonth);
 }


### PR DESCRIPTION
## What's Changed

When month passed as Date type, it would override the provided timezone settings. This fix ensures proper timezone handling.

![image](https://github.com/user-attachments/assets/6537cf24-7723-45d9-b8ec-fa1b95d1816b)
In `react-day-picker\examples\TimeZone.tsx`, when passing a Date type for the month parameter, the timezone setting was ignored:

Expected:
- First day should be: "Tue Apr 01 2025 00:00:00 GMT+1400 (Line Islands Time)"
- Current day displays correctly

Actual:
- First day shows: "Tue Apr 01 2025 00:00:00 GMT+0800 (台北標準時間)"
- Current day displays incorrectly

![image](https://github.com/user-attachments/assets/dfcfc49b-fe11-4951-9ceb-b8c756fb5ddf)

![image](https://github.com/user-attachments/assets/f6201126-e9d0-4e43-b023-aef88561f27e)


After fix:
![image](https://github.com/user-attachments/assets/24e53ff4-796a-42e8-a787-7509cd2f80bf)

![image](https://github.com/user-attachments/assets/23e6b323-f24c-425e-ab6e-295659970142)


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
