### PR TITLE
fix: add timezone to `Date` props

### DIFF
--- a/src/DayPicker.tsx
+++ b/src/DayPicker.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useMemo, useRef } from "react";
 import type { MouseEvent, FocusEvent, KeyboardEvent, ChangeEvent } from "react";
 
+import { TZDate } from "@date-fns/tz";
+
 import { UI, DayFlag, SelectionState } from "./UI.js";
 import type { CalendarDay } from "./classes/CalendarDay.js";
 import { DateLib, defaultLocale } from "./classes/DateLib.js";
@@ -37,7 +39,42 @@ import { isDateRange } from "./utils/typeguards.js";
  * @group DayPicker
  * @see https://daypicker.dev
  */
-export function DayPicker(props: DayPickerProps) {
+export function DayPicker(initialProps: DayPickerProps) {
+  const props = { ...initialProps };
+
+  if (props.timeZone) {
+    if (props.today) {
+      props.today = new TZDate(props.today, props.timeZone);
+    }
+    if (props.month) {
+      props.month = new TZDate(props.month, props.timeZone);
+    }
+    if (props.defaultMonth) {
+      props.defaultMonth = new TZDate(props.defaultMonth, props.timeZone);
+    }
+    if (props.startMonth) {
+      props.startMonth = new TZDate(props.startMonth, props.timeZone);
+    }
+    if (props.endMonth) {
+      props.endMonth = new TZDate(props.endMonth, props.timeZone);
+    }
+    if (props.mode === "single" && props.selected) {
+      props.selected = new TZDate(props.selected, props.timeZone);
+    } else if (props.mode === "multiple" && props.selected) {
+      props.selected = props.selected?.map(
+        (date) => new TZDate(date, props.timeZone)
+      );
+    } else if (props.mode === "range" && props.selected) {
+      props.selected = {
+        from: props.selected.from
+          ? new TZDate(props.selected.from, props.timeZone)
+          : undefined,
+        to: props.selected.to
+          ? new TZDate(props.selected.to, props.timeZone)
+          : undefined
+      };
+    }
+  }
   const { components, formatters, labels, dateLib, locale, classNames } =
     useMemo(() => {
       const locale = { ...defaultLocale, ...props.locale };

--- a/src/DayPicker.tsx
+++ b/src/DayPicker.tsx
@@ -40,9 +40,12 @@ import { isDateRange } from "./utils/typeguards.js";
  * @see https://daypicker.dev
  */
 export function DayPicker(initialProps: DayPickerProps) {
-  const props = { ...initialProps };
+  let props = initialProps;
 
   if (props.timeZone) {
+    props = {
+      ...initialProps
+    };
     if (props.today) {
       props.today = new TZDate(props.today, props.timeZone);
     }

--- a/src/helpers/getInitialMonth.ts
+++ b/src/helpers/getInitialMonth.ts
@@ -1,5 +1,3 @@
-import { TZDate } from "@date-fns/tz";
-
 import { type DateLib } from "../classes/DateLib.js";
 import { type DayPickerProps } from "../types/props.js";
 
@@ -25,8 +23,7 @@ export function getInitialMonth(
     today = dateLib.today(),
     numberOfMonths = 1,
     endMonth,
-    startMonth,
-    timeZone
+    startMonth
   } = props;
   let initialMonth = month || defaultMonth || today;
   const { differenceInCalendarMonths, addMonths, startOfMonth } = dateLib;
@@ -40,8 +37,6 @@ export function getInitialMonth(
   if (startMonth && differenceInCalendarMonths(initialMonth, startMonth) < 0) {
     initialMonth = startMonth;
   }
-  // When timeZone is provided, convert initialMonth to TZDate type to ensure proper timezone handling
-  initialMonth = timeZone ? new TZDate(initialMonth, timeZone) : initialMonth;
 
   return startOfMonth(initialMonth);
 }


### PR DESCRIPTION
In #2658, we fixed the `initialMonth` prop to account the timezone when using a `Date` object to set the initial month. In this PR, I am applying the same fix to other props that rely on `Date`.

Relevant comment about tests failing due to timezone overrides:

https://github.com/gpbl/react-day-picker/commit/814cb76b584e4be35a64d807ab0de01e99400cdd#commitcomment-155917971