### PR TITLE
fix: format week number with numerals

### DIFF
--- a/src/DayPicker.tsx
+++ b/src/DayPicker.tsx
@@ -531,7 +531,7 @@ export function DayPicker(initialProps: DayPickerProps) {
                               scope="row"
                               role="rowheader"
                             >
-                              {formatWeekNumber(week.weekNumber)}
+                              {formatWeekNumber(week.weekNumber, dateLib)}
                             </components.WeekNumber>
                           )}
                           {week.days.map((day: CalendarDay) => {

--- a/src/classes/DateLib.ts
+++ b/src/classes/DateLib.ts
@@ -162,7 +162,7 @@ export class DateLib {
    * @param value The number to format.
    * @returns The formatted number.
    */
-  formatNumber(value: number): string {
+  formatNumber(value: number | string): string {
     return this.replaceDigits(value.toString());
   }
 

--- a/src/formatters/formatWeekNumber.test.ts
+++ b/src/formatters/formatWeekNumber.test.ts
@@ -1,5 +1,16 @@
+import { DateLib } from "../classes";
+
 import { formatWeekNumber } from "./formatWeekNumber";
 
 test("should return the formatted week number", () => {
   expect(formatWeekNumber(10)).toEqual("10");
+});
+
+test("should return the formatted week number with leading zero", () => {
+  expect(formatWeekNumber(1)).toEqual("01");
+});
+
+test("should format with the provided numeral system", () => {
+  const dateLib = new DateLib({ numerals: "arab" });
+  expect(formatWeekNumber(1, dateLib)).toEqual("٠١");
 });

--- a/src/formatters/formatWeekNumber.ts
+++ b/src/formatters/formatWeekNumber.ts
@@ -1,3 +1,5 @@
+import { defaultDateLib } from "../classes/DateLib.js";
+
 /**
  * Format the week number.
  *
@@ -5,9 +7,9 @@
  * @group Formatters
  * @see https://daypicker.dev/docs/translation#custom-formatters
  */
-export function formatWeekNumber(weekNumber: number) {
+export function formatWeekNumber(weekNumber: number, dateLib = defaultDateLib) {
   if (weekNumber < 10) {
-    return `0${weekNumber.toLocaleString()}`;
+    return dateLib.formatNumber(`0${weekNumber.toLocaleString()}`);
   }
-  return `${weekNumber.toLocaleString()}`;
+  return dateLib.formatNumber(`${weekNumber.toLocaleString()}`);
 }


### PR DESCRIPTION
This PR fixes the week numbers not being properly formatted when using the `numerals` prop:

![Screen Shot 2025-05-04 at 14 59 25](https://github.com/user-attachments/assets/7a0e58c8-26f4-4481-96a0-03b988fe2892)

- Updated `formatWeekNumber` to use `DateLib` and `formatNumber`
- Added more tests

Result:

![Screen Shot 2025-05-04 at 14 59 53](https://github.com/user-attachments/assets/49e228ea-a498-4de4-8495-31968e247ec9)
