### PR TITLE
feat(accessibility): Shift+Arrows to navigate months/years

### DIFF
--- a/examples/Keyboard.test.tsx
+++ b/examples/Keyboard.test.tsx
@@ -78,6 +78,24 @@ describe.each(["ltr", "rtl"])("when text direction is %s", (dir: string) => {
         });
       }
     });
+    describe("when the Shift + Arrow Left is pressed", () => {
+      beforeEach(() => user.type(activeElement(), "{shift>}{arrowleft}"));
+      if (dir === "rtl") {
+        test("should display the next month", () => {
+          expect(grid("July 2022")).toBeInTheDocument();
+        });
+        test("should focus the first day in the next month", () => {
+          expect(dateButton(nextMonth)).toHaveFocus();
+        });
+      } else {
+        test("should display the previous month", () => {
+          expect(grid("May 2022")).toBeInTheDocument();
+        });
+        test("should focus the last day in the previous month", () => {
+          expect(dateButton(prevMonth)).toHaveFocus();
+        });
+      }
+    });
     describe("when the Arrow Right is pressed", () => {
       beforeEach(() => user.type(activeElement(), "{arrowright}"));
       if (dir === "rtl") {
@@ -93,6 +111,24 @@ describe.each(["ltr", "rtl"])("when text direction is %s", (dir: string) => {
         });
       }
     });
+    describe("when the Shift + Arrow Right is pressed", () => {
+      beforeEach(() => user.type(activeElement(), "{shift>}{arrowright}"));
+      if (dir === "rtl") {
+        test("should display the previous month", () => {
+          expect(grid("May 2022")).toBeInTheDocument();
+        });
+        test("should focus the last day in the previous month", () => {
+          expect(dateButton(prevMonth)).toHaveFocus();
+        });
+      } else {
+        test("should display the next month", () => {
+          expect(grid("July 2022")).toBeInTheDocument();
+        });
+        test("should focus the first day in the next month", () => {
+          expect(dateButton(nextMonth)).toHaveFocus();
+        });
+      }
+    });
     describe("when the Arrow Up is pressed", () => {
       beforeEach(() => user.type(activeElement(), "{arrowup}"));
       test("should display the previous month", () => {
@@ -102,6 +138,15 @@ describe.each(["ltr", "rtl"])("when text direction is %s", (dir: string) => {
         expect(dateButton(prevWeekDay)).toHaveFocus();
       });
     });
+    describe("when the Shift + Arrow Up is pressed", () => {
+      beforeEach(() => user.type(activeElement(), "{shift>}{arrowup}"));
+      test("should display the previous year", () => {
+        expect(grid("June 2021")).toBeInTheDocument();
+      });
+      test("should focus the day in the previous year", () => {
+        expect(dateButton(prevYear)).toHaveFocus();
+      });
+    });
     describe("when the Arrow Down is pressed", () => {
       beforeEach(() => user.type(activeElement(), "{arrowdown}"));
       test("should display the same month", () => {
@@ -109,6 +154,15 @@ describe.each(["ltr", "rtl"])("when text direction is %s", (dir: string) => {
       });
       test("should focus the day in the next week", () => {
         expect(dateButton(nextWeekDay)).toHaveFocus();
+      });
+    });
+    describe("when the Shift + Arrow Down is pressed", () => {
+      beforeEach(() => user.type(activeElement(), "{shift>}{arrowdown}"));
+      test("should display the next year", () => {
+        expect(grid("June 2023")).toBeInTheDocument();
+      });
+      test("should focus the day in the next year", () => {
+        expect(dateButton(nextYear)).toHaveFocus();
       });
     });
     describe("when Page Up is pressed", () => {

--- a/src/DayPicker.tsx
+++ b/src/DayPicker.tsx
@@ -239,10 +239,22 @@ export function DayPicker(initialProps: DayPickerProps) {
   const handleDayKeyDown = useCallback(
     (day: CalendarDay, modifiers: Modifiers) => (e: KeyboardEvent) => {
       const keyMap: Record<string, [MoveFocusBy, MoveFocusDir]> = {
-        ArrowLeft: [e.shiftKey ? "month" : "day", props.dir === "rtl" ? "after" : "before"],
-        ArrowRight: [e.shiftKey ? "month" : "day", props.dir === "rtl" ? "before" : "after"],
-        ArrowUp: [e.shiftKey ? "year" : "week", props.dir === "rtl" ? "after" : "before"],
-        ArrowDown: [e.shiftKey ? "year" : "week", props.dir === "rtl" ? "before" : "after"],
+        ArrowLeft: [
+          e.shiftKey ? "month" : "day",
+          props.dir === "rtl" ? "after" : "before"
+        ],
+        ArrowRight: [
+          e.shiftKey ? "month" : "day",
+          props.dir === "rtl" ? "before" : "after"
+        ],
+        ArrowUp: [
+          e.shiftKey ? "year" : "week",
+          props.dir === "rtl" ? "after" : "before"
+        ],
+        ArrowDown: [
+          e.shiftKey ? "year" : "week",
+          props.dir === "rtl" ? "before" : "after"
+        ],
         PageUp: [e.shiftKey ? "year" : "month", "before"],
         PageDown: [e.shiftKey ? "year" : "month", "after"],
         Home: ["startOfWeek", "before"],

--- a/src/DayPicker.tsx
+++ b/src/DayPicker.tsx
@@ -247,14 +247,8 @@ export function DayPicker(initialProps: DayPickerProps) {
           e.shiftKey ? "month" : "day",
           props.dir === "rtl" ? "before" : "after"
         ],
-        ArrowUp: [
-          e.shiftKey ? "year" : "week",
-          props.dir === "rtl" ? "after" : "before"
-        ],
-        ArrowDown: [
-          e.shiftKey ? "year" : "week",
-          props.dir === "rtl" ? "before" : "after"
-        ],
+        ArrowDown: [e.shiftKey ? "year" : "week", "after"],
+        ArrowUp: [e.shiftKey ? "year" : "week", "before"],
         PageUp: [e.shiftKey ? "year" : "month", "before"],
         PageDown: [e.shiftKey ? "year" : "month", "after"],
         Home: ["startOfWeek", "before"],

--- a/src/DayPicker.tsx
+++ b/src/DayPicker.tsx
@@ -239,10 +239,10 @@ export function DayPicker(initialProps: DayPickerProps) {
   const handleDayKeyDown = useCallback(
     (day: CalendarDay, modifiers: Modifiers) => (e: KeyboardEvent) => {
       const keyMap: Record<string, [MoveFocusBy, MoveFocusDir]> = {
-        ArrowLeft: ["day", props.dir === "rtl" ? "after" : "before"],
-        ArrowRight: ["day", props.dir === "rtl" ? "before" : "after"],
-        ArrowDown: ["week", "after"],
-        ArrowUp: ["week", "before"],
+        ArrowLeft: [e.shiftKey ? "month" : "day", props.dir === "rtl" ? "after" : "before"],
+        ArrowRight: [e.shiftKey ? "month" : "day", props.dir === "rtl" ? "before" : "after"],
+        ArrowUp: [e.shiftKey ? "year" : "week", props.dir === "rtl" ? "after" : "before"],
+        ArrowDown: [e.shiftKey ? "year" : "week", props.dir === "rtl" ? "before" : "after"],
         PageUp: [e.shiftKey ? "year" : "month", "before"],
         PageDown: [e.shiftKey ? "year" : "month", "after"],
         Home: ["startOfWeek", "before"],

--- a/website/docs/guides/accessibility.mdx
+++ b/website/docs/guides/accessibility.mdx
@@ -40,19 +40,23 @@ DayPicker automatically manages focus when users interact with the calendar. To 
 
 DayPicker supports keyboard navigation to make it easier for users to navigate the calendar. The following keys are supported:
 
-| Keys                         | Function                             |
-| ---------------------------- | ------------------------------------ |
-| <kbd>Arrow Up</kbd>          | Move focus to the previous week.     |
-| <kbd>Arrow Right</kbd>       | Move focus to the next day.          |
-| <kbd>Arrow Down</kbd>        | Move focus to the next week.         |
-| <kbd>Arrow Left</kbd>        | Move focus to the previous day.      |
-| <kbd>Page Up</kbd>           | Move focus to the previous month.    |
-| <kbd>Page Down</kbd>         | Move focus to the next month.        |
-| <kbd>Shift + Page Up</kbd>   | Move focus to the previous year.     |
-| <kbd>Shift + Page Down</kbd> | Move focus to the next year.         |
-| <kbd>Home</kbd>              | Move focus to the start of the week. |
-| <kbd>End</kbd>               | Move focus to the end of the week.   |
-| <kbd>Enter/Space</kbd>       | Select the focused day.              |
+| Keys                           | Function                             |
+| ------------------------------ | ------------------------------------ |
+| <kbd>Arrow Up</kbd>            | Move focus to the previous week.     |
+| <kbd>Shift + Arrow Up</kbd>    | Move focus to the previous year.     |
+| <kbd>Arrow Right</kbd>         | Move focus to the next day.          |
+| <kbd>Shift + Arrow Right</kbd> | Move focus to the next month.        |
+| <kbd>Arrow Down</kbd>          | Move focus to the next week.         |
+| <kbd>Shift + Arrow Down</kbd>  | Move focus to the next year.         |
+| <kbd>Arrow Left</kbd>          | Move focus to the previous day.      |
+| <kbd>Shift + Arrow Left</kbd>  | Move focus to the previous month.    |
+| <kbd>Page Up</kbd>             | Move focus to the previous month.    |
+| <kbd>Page Down</kbd>           | Move focus to the next month.        |
+| <kbd>Shift + Page Up</kbd>     | Move focus to the previous year.     |
+| <kbd>Shift + Page Down</kbd>   | Move focus to the next year.         |
+| <kbd>Home</kbd>                | Move focus to the start of the week. |
+| <kbd>End</kbd>                 | Move focus to the end of the week.   |
+| <kbd>Enter/Space</kbd>         | Select the focused day.              |
 
 ## Getting Help With Accessibility
 


### PR DESCRIPTION
### What's Changed

I added a Shift modifier to the keyboard navigation. Specifically,

Shift + ArrowLeft moves the focus to the previous month.
Shift + ArrowRight moves the focus to the next month.
Shift + ArrowUp moves the focus to the previous year.
Shift + ArrowDown moves the focus to the next year.

This feels quite natural and can be useful for those without PageUp/Down buttons on their keyboards.