### PR TITLE
docs(translation): Fix wrong import on example

### DIFF
--- a/website/docs/docs/translation.mdx
+++ b/website/docs/docs/translation.mdx
@@ -30,7 +30,7 @@ The `labels` prop allows you to customize the [ARIA labels](../guides/accessibil
 
 ```tsx
 import { format } from "date-fns";
-import { it } from "react-day-picker/locale";
+import { it } from "date-fns/locale";
 
 function ItalianLabels() {
   return (
@@ -88,7 +88,7 @@ The following labels are optional and should work out of the box in most languag
 To set the text direction to right-to-left, use the `dir` prop with the value `rtl`.
 
 ```tsx
-import { arSA } from "react-day-picker/locale";
+import { arSA } from "date-fns/locale";
 
 <DayPicker locale={arSA} dir="rtl" />;
 ```


### PR DESCRIPTION
# Pull Request

Thank you for the great library! This PR fixes a naming conflict in the code examples.

## What's Changed

- Resolved variable naming conflicts in documentation examples when importing locales from both `react-day-picker/locale` and `date-fns/locale`.

## Type of Change

- [x] Documentation update

## Additional Notes

This change improves clarity for developers using both libraries with localized calendars.
