### PR TITLE
fix: setting defaultMonth the next year when using the dropdown mode does not render the calendar

### DIFF
--- a/examples/InvalidMonthDefaultLimit.test.tsx
+++ b/examples/InvalidMonthDefaultLimit.test.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+import { grid } from "@/test/elements";
+import { render } from "@/test/render";
+
+import { InvalidMonthDefaultLimit } from "./InvalidMonthDefaultLimit";
+
+test("should display calendar in December", () => {
+  render(<InvalidMonthDefaultLimit />);
+  expect(grid()).toHaveAccessibleName(`December ${new Date().getFullYear()}`);
+});

--- a/examples/InvalidMonthDefaultLimit.tsx
+++ b/examples/InvalidMonthDefaultLimit.tsx
@@ -1,0 +1,19 @@
+import React, { useState } from "react";
+
+import { DayPicker } from "react-day-picker";
+
+export function InvalidMonthDefaultLimit() {
+  const [month, setMonth] = useState(() => {
+    const date = new Date();
+    date.setFullYear(date.getFullYear() + 1);
+    return date;
+  });
+
+  return (
+    <DayPicker
+      month={month}
+      onMonthChange={setMonth}
+      captionLayout="dropdown"
+    />
+  );
+}

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -36,6 +36,7 @@ export * from "./Input";
 export * from "./InputRange";
 export * from "./InputTime";
 export * from "./InvalidMonth";
+export * from "./InvalidMonthDefaultLimit";
 export * from "./ItalianLabels";
 export * from "./ItalianLabels";
 export * from "./Keyboard";

--- a/src/DayPicker.tsx
+++ b/src/DayPicker.tsx
@@ -160,7 +160,13 @@ export function DayPicker(initialProps: DayPickerProps) {
     goToMonth
   } = calendar;
 
-  const getModifiers = createGetModifiers(days, props, dateLib);
+  const getModifiers = createGetModifiers(
+    days,
+    props,
+    navStart,
+    navEnd,
+    dateLib
+  );
 
   const {
     isSelected,

--- a/src/helpers/createGetModifiers.test.ts
+++ b/src/helpers/createGetModifiers.test.ts
@@ -1,3 +1,5 @@
+import { start } from "repl";
+
 import { DayFlag } from "../UI";
 import { CalendarDay, defaultDateLib } from "../classes/index";
 
@@ -40,7 +42,13 @@ const props = {
 
 describe("createGetModifiers", () => {
   describe("default props", () => {
-    const getModifiers = createGetModifiers(days, props, dateLib);
+    const getModifiers = createGetModifiers(
+      days,
+      props,
+      undefined,
+      undefined,
+      dateLib
+    );
 
     test("return the modifiers for a given day", () => {
       const modifiers = getModifiers(day2);
@@ -114,7 +122,9 @@ describe("createGetModifiers", () => {
 
     const getModifiers = createGetModifiers(
       days,
-      { ...props, startMonth, endMonth },
+      props,
+      startMonth,
+      endMonth,
       dateLib
     );
     test("return the modifiers for a given day", () => {

--- a/src/helpers/createGetModifiers.test.ts
+++ b/src/helpers/createGetModifiers.test.ts
@@ -1,5 +1,3 @@
-import { start } from "repl";
-
 import { DayFlag } from "../UI";
 import { CalendarDay, defaultDateLib } from "../classes/index";
 

--- a/src/helpers/createGetModifiers.ts
+++ b/src/helpers/createGetModifiers.ts
@@ -41,8 +41,8 @@ export function createGetModifiers(
     isAfter
   } = dateLib;
 
-  navStart = navStart && startOfMonth(navStart);
-  navEnd = navEnd && endOfMonth(navEnd);
+  const computedNavStart = navStart && startOfMonth(navStart);
+  const computedNavEnd = navEnd && endOfMonth(navEnd);
 
   const internalModifiersMap: Record<DayFlag, CalendarDay[]> = {
     [DayFlag.focused]: [],
@@ -59,9 +59,13 @@ export function createGetModifiers(
 
     const isOutside = Boolean(displayMonth && !isSameMonth(date, displayMonth));
 
-    const isBeforeNadStart = Boolean(navStart && isBefore(date, navStart));
+    const isBeforeNadStart = Boolean(
+      computedNavStart && isBefore(date, computedNavStart)
+    );
 
-    const isAfterNavEnd = Boolean(navEnd && isAfter(date, navEnd));
+    const isAfterNavEnd = Boolean(
+      computedNavEnd && isAfter(date, computedNavEnd)
+    );
 
     const isDisabled = Boolean(
       disabled && dateMatchModifiers(date, disabled, dateLib)

--- a/src/helpers/createGetModifiers.ts
+++ b/src/helpers/createGetModifiers.ts
@@ -19,6 +19,8 @@ import { dateMatchModifiers } from "../utils/dateMatchModifiers.js";
 export function createGetModifiers(
   days: CalendarDay[],
   props: DayPickerProps,
+  navStart: Date | undefined,
+  navEnd: Date | undefined,
   dateLib: DateLib
 ) {
   const {
@@ -39,8 +41,8 @@ export function createGetModifiers(
     isAfter
   } = dateLib;
 
-  const startMonth = props.startMonth && startOfMonth(props.startMonth);
-  const endMonth = props.endMonth && endOfMonth(props.endMonth);
+  navStart = navStart && startOfMonth(navStart);
+  navEnd = navEnd && endOfMonth(navEnd);
 
   const internalModifiersMap: Record<DayFlag, CalendarDay[]> = {
     [DayFlag.focused]: [],
@@ -57,11 +59,9 @@ export function createGetModifiers(
 
     const isOutside = Boolean(displayMonth && !isSameMonth(date, displayMonth));
 
-    const isBeforeStartMonth = Boolean(
-      startMonth && isBefore(date, startMonth)
-    );
+    const isBeforeNadStart = Boolean(navStart && isBefore(date, navStart));
 
-    const isAfterEndMonth = Boolean(endMonth && isAfter(date, endMonth));
+    const isAfterNavEnd = Boolean(navEnd && isAfter(date, navEnd));
 
     const isDisabled = Boolean(
       disabled && dateMatchModifiers(date, disabled, dateLib)
@@ -69,8 +69,8 @@ export function createGetModifiers(
 
     const isHidden =
       Boolean(hidden && dateMatchModifiers(date, hidden, dateLib)) ||
-      isBeforeStartMonth ||
-      isAfterEndMonth ||
+      isBeforeNadStart ||
+      isAfterNavEnd ||
       // Broadcast calendar will show outside days as default
       (!broadcastCalendar && !showOutsideDays && isOutside) ||
       (broadcastCalendar && showOutsideDays === false && isOutside);

--- a/src/helpers/createGetModifiers.ts
+++ b/src/helpers/createGetModifiers.ts
@@ -59,7 +59,7 @@ export function createGetModifiers(
 
     const isOutside = Boolean(displayMonth && !isSameMonth(date, displayMonth));
 
-    const isBeforeNadStart = Boolean(
+    const isBeforeNavStart = Boolean(
       computedNavStart && isBefore(date, computedNavStart)
     );
 
@@ -73,7 +73,7 @@ export function createGetModifiers(
 
     const isHidden =
       Boolean(hidden && dateMatchModifiers(date, hidden, dateLib)) ||
-      isBeforeNadStart ||
+      isBeforeNavStart ||
       isAfterNavEnd ||
       // Broadcast calendar will show outside days as default
       (!broadcastCalendar && !showOutsideDays && isOutside) ||

--- a/src/helpers/getInitialMonth.test.ts
+++ b/src/helpers/getInitialMonth.test.ts
@@ -6,7 +6,12 @@ import { getInitialMonth } from "./getInitialMonth";
 
 it("return start of month", () => {
   const month = new Date(2010, 11, 12);
-  const initialMonth = getInitialMonth({ month }, defaultDateLib);
+  const initialMonth = getInitialMonth(
+    { month },
+    undefined,
+    undefined,
+    defaultDateLib
+  );
   expect(isSameDay(initialMonth, startOfMonth(month))).toBe(true);
 });
 
@@ -18,6 +23,8 @@ describe("when no startMonth or endMonth is given", () => {
     it("return that month", () => {
       const initialMonth = getInitialMonth(
         { month, defaultMonth, today },
+        undefined,
+        undefined,
         defaultDateLib
       );
       expect(isSameMonth(initialMonth, month)).toBe(true);
@@ -27,6 +34,8 @@ describe("when no startMonth or endMonth is given", () => {
     it("return that month", () => {
       const initialMonth = getInitialMonth(
         { defaultMonth, today },
+        undefined,
+        undefined,
         defaultDateLib
       );
       expect(isSameMonth(initialMonth, defaultMonth)).toBe(true);
@@ -34,7 +43,12 @@ describe("when no startMonth or endMonth is given", () => {
   });
   describe("when no month or defaultMonth", () => {
     it("return the today month", () => {
-      const initialMonth = getInitialMonth({ today }, defaultDateLib);
+      const initialMonth = getInitialMonth(
+        { today },
+        undefined,
+        undefined,
+        defaultDateLib
+      );
       expect(isSameMonth(initialMonth, today)).toBe(true);
     });
   });
@@ -45,7 +59,9 @@ describe("when startMonth is given and is after the default initial month", () =
     const month = new Date(2010, 11, 12);
     const startMonth = addMonths(month, 1);
     const initialMonth = getInitialMonth(
-      { month, numberOfMonths: 3, startMonth },
+      { month, numberOfMonths: 3 },
+      startMonth,
+      undefined,
       defaultDateLib
     );
     expect(isSameMonth(initialMonth, startMonth)).toBe(true);
@@ -59,7 +75,9 @@ describe("when endMonth is given", () => {
     describe("when the number of month is 1", () => {
       it("return the endMonth", () => {
         const initialMonth = getInitialMonth(
-          { month, endMonth },
+          { month },
+          undefined,
+          endMonth,
           defaultDateLib
         );
         expect(isSameMonth(initialMonth, endMonth)).toBe(true);
@@ -68,7 +86,9 @@ describe("when endMonth is given", () => {
     describe("when the number of month is 3", () => {
       it("return the endMonth plus the number of months", () => {
         const initialMonth = getInitialMonth(
-          { month, numberOfMonths: 3, endMonth },
+          { month, numberOfMonths: 3 },
+          undefined,
+          endMonth,
           defaultDateLib
         );
         const expectedMonth = addMonths(endMonth, -1 * (3 - 1));

--- a/src/helpers/getInitialMonth.ts
+++ b/src/helpers/getInitialMonth.ts
@@ -17,35 +17,33 @@ export function getInitialMonth(
     DayPickerProps,
     | "fromYear"
     | "toYear"
-    | "startMonth"
-    | "endMonth"
     | "month"
     | "defaultMonth"
     | "today"
     | "numberOfMonths"
     | "timeZone"
   >,
+  navStart: Date | undefined,
+  navEnd: Date | undefined,
   dateLib: DateLib
 ): Date {
   const {
     month,
     defaultMonth,
     today = dateLib.today(),
-    numberOfMonths = 1,
-    endMonth,
-    startMonth
+    numberOfMonths = 1
   } = props;
   let initialMonth = month || defaultMonth || today;
   const { differenceInCalendarMonths, addMonths, startOfMonth } = dateLib;
 
-  // Adjust the initial month if it is after the endMonth
-  if (endMonth && differenceInCalendarMonths(endMonth, initialMonth) < 0) {
+  // Adjust the initial month if it is after the navEnd
+  if (navEnd && differenceInCalendarMonths(navEnd, initialMonth) < 0) {
     const offset = -1 * (numberOfMonths - 1);
-    initialMonth = addMonths(endMonth, offset);
+    initialMonth = addMonths(navEnd, offset);
   }
-  // Adjust the initial month if it is before the startMonth
-  if (startMonth && differenceInCalendarMonths(initialMonth, startMonth) < 0) {
-    initialMonth = startMonth;
+  // Adjust the initial month if it is before the navStart
+  if (navStart && differenceInCalendarMonths(initialMonth, navStart) < 0) {
+    initialMonth = navStart;
   }
 
   return startOfMonth(initialMonth);

--- a/src/useCalendar.ts
+++ b/src/useCalendar.ts
@@ -101,7 +101,7 @@ export function useCalendar(
   const [navStart, navEnd] = getNavMonths(props, dateLib);
 
   const { startOfMonth, endOfMonth } = dateLib;
-  const initialMonth = getInitialMonth(props, dateLib);
+  const initialMonth = getInitialMonth(props, navStart, navEnd, dateLib);
   const [firstMonth, setFirstMonth] = useControlledValue(
     initialMonth,
     // initialMonth is always computed from props.month if provided
@@ -109,7 +109,7 @@ export function useCalendar(
   );
 
   useEffect(() => {
-    const newInitialMonth = getInitialMonth(props, dateLib);
+    const newInitialMonth = getInitialMonth(props, navStart, navEnd, dateLib);
     setFirstMonth(newInitialMonth);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.timeZone]);


### PR DESCRIPTION
Fix https://github.com/gpbl/react-day-picker/issues/2776

## Description

The issue happens because the valid months of the calendar are calculated internally in the [`useCalendar` hook](https://github.com/gpbl/react-day-picker/blob/main/src/useCalendar.ts#L101) when the `layout` of the day picker is a `dropdown` type, but other inner logic parts of the day picker use the `startMonth` and `endMonth` props as the calendar limits, which in this use case is `undefined`.

## Changes

This PR unifies the source of truth for the start and end months of the day picker, using the `navStart` and `navEnd` returned by the [`getNavMonths` in the `useCalendar` hook](https://github.com/gpbl/react-day-picker/blob/main/src/useCalendar.ts#L101) as the source of truth.
This also means that from now on, we should **NOT** use the `startMonth` and `endMonth` props directly, and instead use the `navStart` and `navEnd` values.