### PR TITLE
fix: initial month when number of month and endMonth are set

### DIFF
--- a/examples/MultipleWithEndMonth.test.tsx
+++ b/examples/MultipleWithEndMonth.test.tsx
@@ -14,7 +14,8 @@ beforeEach(() => {
   render(<MultipleWithEndMonth />);
 });
 
-test("should display two months", () => {
-  expect(grid("July 2025")).toBeInTheDocument();
+test("should display three months", () => {
   expect(grid("June 2025")).toBeInTheDocument();
+  expect(grid("July 2025")).toBeInTheDocument();
+  expect(grid("August 2025")).toBeInTheDocument();
 });

--- a/examples/MultipleWithEndMonth.test.tsx
+++ b/examples/MultipleWithEndMonth.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+import { grid } from "@/test/elements";
+import { render } from "@/test/render";
+
+import { MultipleWithEndMonth } from "./MultipleWithEndMonth";
+
+const today = new Date(2025, 6, 1);
+
+beforeAll(() => jest.setSystemTime(today));
+afterAll(() => jest.useRealTimers());
+
+beforeEach(() => {
+  render(<MultipleWithEndMonth />);
+});
+
+test("should display two months", () => {
+  expect(grid("July 2025")).toBeInTheDocument();
+  expect(grid("June 2025")).toBeInTheDocument();
+});

--- a/examples/MultipleWithEndMonth.tsx
+++ b/examples/MultipleWithEndMonth.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+import { DayPicker } from "react-day-picker";
+
+export function MultipleWithEndMonth() {
+  return (
+    <DayPicker
+      numberOfMonths={3}
+      endMonth={new Date()}
+      startMonth={new Date()}
+      pagedNavigation={false}
+    />
+  );
+}

--- a/examples/MultipleWithEndMonth.tsx
+++ b/examples/MultipleWithEndMonth.tsx
@@ -7,7 +7,6 @@ export function MultipleWithEndMonth() {
     <DayPicker
       numberOfMonths={3}
       endMonth={new Date()}
-      startMonth={new Date()}
       pagedNavigation={false}
     />
   );

--- a/examples/Start.tsx
+++ b/examples/Start.tsx
@@ -1,26 +1,19 @@
 import React, { useState } from "react";
 
-import { DateRange, DayPicker } from "react-day-picker";
+import { DayPicker } from "react-day-picker";
 
 export function Start() {
-  const [dates, setDates] = useState<DateRange | undefined>({
-    from: new Date(),
-    to: new Date()
-  });
-  const [monthFocused, setMonthFocused] = useState(dates?.from);
+  const [selected, setSelected] = useState<Date>();
 
   return (
     <DayPicker
-      endMonth={new Date()}
-      disabled={{ after: new Date() }}
-      min={2}
-      numberOfMonths={2}
-      pagedNavigation={false}
-      mode="range"
-      selected={dates}
-      onSelect={setDates}
-      month={monthFocused}
-      onMonthChange={(start) => setMonthFocused(start)}
+      animate
+      mode="single"
+      selected={selected}
+      onSelect={setSelected}
+      footer={
+        selected ? `Selected: ${selected.toLocaleDateString()}` : "Pick a day."
+      }
     />
   );
 }

--- a/examples/Start.tsx
+++ b/examples/Start.tsx
@@ -1,19 +1,26 @@
 import React, { useState } from "react";
 
-import { DayPicker } from "react-day-picker";
+import { DateRange, DayPicker } from "react-day-picker";
 
 export function Start() {
-  const [selected, setSelected] = useState<Date>();
+  const [dates, setDates] = useState<DateRange | undefined>({
+    from: new Date(),
+    to: new Date()
+  });
+  const [monthFocused, setMonthFocused] = useState(dates?.from);
 
   return (
     <DayPicker
-      animate
-      mode="single"
-      selected={selected}
-      onSelect={setSelected}
-      footer={
-        selected ? `Selected: ${selected.toLocaleDateString()}` : "Pick a day."
-      }
+      endMonth={new Date()}
+      disabled={{ after: new Date() }}
+      min={2}
+      numberOfMonths={2}
+      pagedNavigation={false}
+      mode="range"
+      selected={dates}
+      onSelect={setDates}
+      month={monthFocused}
+      onMonthChange={(start) => setMonthFocused(start)}
     />
   );
 }

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -52,6 +52,7 @@ export * from "./MultipleMinMax";
 export * from "./MultipleRequired";
 export * from "./MultipleMonths";
 export * from "./MultipleMonthsPaged";
+export * from "./MultipleWithEndMonth";
 export * from "./NavLayout";
 export * from "./NavLayoutAfter";
 export * from "./Numerals";

--- a/src/helpers/getInitialMonth.test.ts
+++ b/src/helpers/getInitialMonth.test.ts
@@ -73,7 +73,7 @@ describe("when endMonth is given", () => {
     const month = new Date(2010, 11, 12);
     const endMonth = addMonths(month, -2);
     describe("when the number of month is 1", () => {
-      it("return the endMonth", () => {
+      it("returns the endMonth as the initial month so the last displayed month does not exceed endMonth", () => {
         const initialMonth = getInitialMonth(
           { month },
           undefined,
@@ -84,14 +84,15 @@ describe("when endMonth is given", () => {
       });
     });
     describe("when the number of month is 3", () => {
-      it("return the endMonth plus the number of months", () => {
+      it("returns the initial month so that initialMonth + 2 months = endMonth (last displayed month is endMonth)", () => {
         const initialMonth = getInitialMonth(
           { month, numberOfMonths: 3 },
           undefined,
           endMonth,
           defaultDateLib
         );
-        const expectedMonth = addMonths(endMonth, -1 * (3 - 1));
+        // The last displayed month should be endMonth, so initialMonth = endMonth - 2 months
+        const expectedMonth = addMonths(endMonth, -2);
         expect(isSameMonth(initialMonth, expectedMonth)).toBe(true);
       });
     });

--- a/src/helpers/getInitialMonth.ts
+++ b/src/helpers/getInitialMonth.ts
@@ -36,10 +36,13 @@ export function getInitialMonth(
   let initialMonth = month || defaultMonth || today;
   const { differenceInCalendarMonths, addMonths, startOfMonth } = dateLib;
 
-  // Adjust the initial month if it is after the navEnd
-  if (navEnd && differenceInCalendarMonths(navEnd, initialMonth) < 0) {
-    const offset = -1 * (numberOfMonths - 1);
-    initialMonth = addMonths(navEnd, offset);
+  // Adjust the initial month if it is after the navEnd, considering numberOfMonths
+  if (navEnd) {
+    const lastMonthToShow = addMonths(initialMonth, numberOfMonths - 1);
+    if (differenceInCalendarMonths(lastMonthToShow, navEnd) > 0) {
+      const offset = -1 * (numberOfMonths - 1);
+      initialMonth = addMonths(navEnd, offset);
+    }
   }
   // Adjust the initial month if it is before the navStart
   if (navStart && differenceInCalendarMonths(initialMonth, navStart) < 0) {


### PR DESCRIPTION
This update improves the initial month calculation to ensure that the correct number of months is displayed.

Fixes #2782