### PR TITLE
docs: Improve documentation for `captionLayout` prop

### DIFF
--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -203,11 +203,10 @@ export interface PropsBase {
   /**
    * Show dropdowns to navigate between months or years.
    *
-   * - `label`: display the month and the year as a label. Change the label with
-   *   the `formatCaption` formatter.
-   * - `dropdown`: display the dropdowns for both month and year
-   * - `dropdown-months`: display only the dropdown for the months
-   * - `dropdown-years`: display only the dropdown for the years
+   * - `label`: Displays the month and year as a label. Default value.
+   * - `dropdown`: Displays dropdowns for both month and year navigation.
+   * - `dropdown-months`: Displays a dropdown only for the month navigation.
+   * - `dropdown-years`: Displays a dropdown only for the year navigation.
    *
    * **Note:** By default, showing the dropdown will set the {@link startMonth}
    * to 100 years ago and {@link endMonth} to the end of the current year. You

--- a/website/docs/docs/customization.mdx
+++ b/website/docs/docs/customization.mdx
@@ -28,9 +28,9 @@ Use the `captionLayout` prop to customize the layout of the month caption.
 | Caption Layout      | Description                                            |
 | ------------------- | ------------------------------------------------------ |
 | `"label"`           | Displays the month and year as a label. Default value. |
-| `"dropdown"`        | Displays a dropdown with both months and years.        |
-| `"dropdown-months"` | Displays a dropdown with the months only.              |
-| `"dropdown-years"`  | Displays a dropdown with the years only.               |
+| `"dropdown"`        | Displays dropdowns for both month and year navigation.        |
+| `"dropdown-months"` | Displays a dropdown only for the month navigation.              |
+| `"dropdown-years"`  | Displays a dropdown only for the year navigation.               |
 
 ### Caption Dropdown
 


### PR DESCRIPTION
While reviewing https://github.com/gpbl/react-day-picker/pull/2787 I noticed that the documentation for the `captionLayout` prop could be improved.

This PR makes clearer what the prop does.