### PR TITLE
feat: add `reverseYears` prop

### DIFF
--- a/src/DayPicker.tsx
+++ b/src/DayPicker.tsx
@@ -383,6 +383,9 @@ export function DayPicker(initialProps: DayPickerProps) {
               navEnd,
               formatters,
               dateLib,
+              captionLayout === "dropdown" || captionLayout === "dropdown-years"
+                ? Boolean(props.reverseYears)
+                : false,
             );
             return (
               <components.Month

--- a/src/DayPicker.tsx
+++ b/src/DayPicker.tsx
@@ -370,23 +370,6 @@ export function DayPicker(initialProps: DayPickerProps) {
             />
           )}
           {months.map((calendarMonth, displayIndex) => {
-            const dropdownMonths = getMonthOptions(
-              calendarMonth.date,
-              navStart,
-              navEnd,
-              formatters,
-              dateLib,
-            );
-
-            const dropdownYears = getYearOptions(
-              navStart,
-              navEnd,
-              formatters,
-              dateLib,
-              captionLayout === "dropdown" || captionLayout === "dropdown-years"
-                ? Boolean(props.reverseYears)
-                : false,
-            );
             return (
               <components.Month
                 data-animated-month={props.animate ? "true" : undefined}
@@ -437,7 +420,13 @@ export function DayPicker(initialProps: DayPickerProps) {
                           components={components}
                           disabled={Boolean(props.disableNavigation)}
                           onChange={handleMonthChange(calendarMonth.date)}
-                          options={dropdownMonths}
+                          options={getMonthOptions(
+                            calendarMonth.date,
+                            navStart,
+                            navEnd,
+                            formatters,
+                            dateLib,
+                          )}
                           style={styles?.[UI.Dropdown]}
                           value={dateLib.getMonth(calendarMonth.date)}
                         />
@@ -455,7 +444,13 @@ export function DayPicker(initialProps: DayPickerProps) {
                           components={components}
                           disabled={Boolean(props.disableNavigation)}
                           onChange={handleYearChange(calendarMonth.date)}
-                          options={dropdownYears}
+                          options={getYearOptions(
+                            navStart,
+                            navEnd,
+                            formatters,
+                            dateLib,
+                            Boolean(props.reverseYears),
+                          )}
                           style={styles?.[UI.Dropdown]}
                           value={dateLib.getYear(calendarMonth.date)}
                         />

--- a/src/helpers/getYearOptions.test.ts
+++ b/src/helpers/getYearOptions.test.ts
@@ -44,3 +44,25 @@ test("return correct dropdown options", () => {
     { value: 2024, label: "2024", disabled: false },
   ]);
 });
+
+test("return reversed dropdown options when reverse is true", () => {
+  const startMonth = new Date(2022, 0, 1); // January 2022
+  const endMonth = new Date(2024, 11, 31); // December 2024
+  const formatters = getFormatters({
+    formatYearDropdown: (date: Date) => `${date.getFullYear()}`,
+  });
+
+  const result = getYearOptions(
+    startMonth,
+    endMonth,
+    formatters,
+    defaultDateLib,
+    true,
+  );
+
+  expect(result).toEqual([
+    { value: 2024, label: "2024", disabled: false },
+    { value: 2023, label: "2023", disabled: false },
+    { value: 2022, label: "2022", disabled: false },
+  ]);
+});

--- a/src/helpers/getYearOptions.ts
+++ b/src/helpers/getYearOptions.ts
@@ -12,6 +12,7 @@ import type { Formatters } from "../types/index.js";
  * @param navEnd The end date for navigation.
  * @param formatters The formatters to use for formatting the year labels.
  * @param dateLib The date library to use for date manipulation.
+ * @param reverse If true, reverses the order of the years (descending).
  * @returns An array of dropdown options representing the years, or `undefined`
  *   if `navStart` or `navEnd` is not provided.
  */
@@ -20,6 +21,7 @@ export function getYearOptions(
   navEnd: Date | undefined,
   formatters: Pick<Formatters, "formatYearDropdown">,
   dateLib: DateLib,
+  reverse: boolean = false,
 ): DropdownOption[] | undefined {
   if (!navStart) return undefined;
   if (!navEnd) return undefined;
@@ -34,6 +36,8 @@ export function getYearOptions(
     years.push(year);
     year = addYears(year, 1);
   }
+
+  if (reverse) years.reverse();
 
   return years.map((year) => {
     const label = formatters.formatYearDropdown(year, dateLib);

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -217,6 +217,15 @@ export interface PropsBase {
   captionLayout?: "label" | "dropdown" | "dropdown-months" | "dropdown-years";
 
   /**
+   * Reverse the order of years in the dropdown when using
+   * `captionLayout="dropdown"` or `captionLayout="dropdown-years"`.
+   *
+   * @since 9.9.0
+   * @see https://daypicker.dev/docs/customization#caption-layouts
+   */
+  reverseYears?: boolean;
+
+  /**
    * Adjust the positioning of the navigation buttons.
    *
    * - `around`: Displays the buttons on either side of the caption.

--- a/website/docs/docs/customization.mdx
+++ b/website/docs/docs/customization.mdx
@@ -9,11 +9,14 @@ Use the customization props to tailor the calendar's appearance.
 | Prop Name         | Type                                                                         | Description                                                                                                                                 |
 | ----------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `captionLayout`   | `"label"`<br/> `"dropdown"`<br/> `"dropdown-months"`<br/> `"dropdown-years"` | Choose the layout of the month caption. Default is `label`.                                                                                 |
+| `reverseYears`    | `boolean`                                                                    | Reverse the order of the years in the dropdown.                                                                                             |
 | `navLayout`       | `"around"` \| `"after"`                                                      | Adjust the positioning of the navigation buttons.                                                                                           |
 | `fixedWeeks`      | `boolean`                                                                    | Display 6 weeks per month.                                                                                                                  |
 | `footer`          | `ReactNode` \| `string`                                                      | Add a footer to the calendar, acting as a [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions). |
 | `hideWeekdays`    | `boolean`                                                                    | Hide the row displaying the weekday names.                                                                                                  |
 | `numberOfMonths`  | `number`                                                                     | The number of displayed months. Default is `1`.                                                                                             |
+| `reverseMonths`   | `boolean`                                                                    | When displaying multiple months, reverse the order of the months.                                                                           |
+| `pagedNavigation` | `boolean`                                                                    | Enable paginated navigation when displaying multiple months.                                                                                |
 | `showOutsideDays` | `boolean`                                                                    | Display the days falling into other months.                                                                                                 |
 | `showWeekNumber`  | `boolean`                                                                    | Display the column with the [week numbers](#showweeknumber).                                                                                |
 
@@ -34,7 +37,18 @@ Use the `captionLayout` prop to customize the layout of the month caption.
 
 ### Caption Dropdown
 
-To enable a navigation dropdown, set `captionLayout="dropdown"`. Use the `startMonth` and `endMonth` properties to define the start and end dates for the calendar navigation.
+To enable a navigation dropdown, set `captionLayout` to `dropdown`, `dropdown-months`, or `dropdown-years`.
+
+- When displaying the dropdown for the years, use the `reverseYears` prop to reverse the order of the years.
+- Use the `startMonth` and `endMonth` properties to define the start and end dates for the calendar navigation.
+
+:::info Default Range
+
+Without specifying the `startMonth` and `endMonth` properties, the dropdown will display the last 100 years.
+
+:::
+
+#### Example
 
 ```tsx
 <DayPicker
@@ -48,12 +62,6 @@ To enable a navigation dropdown, set `captionLayout="dropdown"`. Use the `startM
 <BrowserWindow>
   <Examples.Dropdown />
 </BrowserWindow>
-
-:::info Default Range
-
-Without specifying the `startMonth` and `endMonth` properties, the dropdown will display the last 100 years.
-
-:::
 
 ## Navigation Layouts
 

--- a/website/src/components/Playground/CustomizationFieldset.tsx
+++ b/website/src/components/Playground/CustomizationFieldset.tsx
@@ -41,6 +41,24 @@ export function CustomizationFieldset({
       </legend>
       <div className={styles.fields}>
         <label>
+          Navigation Layout:
+          <select
+            name="navLayout"
+            value={props.navLayout ?? ""}
+            onChange={(e) => {
+              const newProps = {
+                ...props,
+                navLayout: e.target.value ?? undefined,
+              } as DayPickerProps;
+              setProps(newProps);
+            }}
+          >
+            <option value=""></option>
+            <option value="around">Around</option>
+            <option value="after">After</option>
+          </select>
+        </label>
+        <label>
           Caption Layout:
           <select
             name="captionLayout"
@@ -71,28 +89,30 @@ export function CustomizationFieldset({
             <option></option>
             <option value="label">Label</option>
             <option value="dropdown">Dropdown</option>
-            <option value="dropdown-months">Dropdown months</option>
-            <option value="dropdown-years">Dropdown years</option>
+            <option value="dropdown-months">Dropdown Months</option>
+            <option value="dropdown-years">Dropdown Years</option>
           </select>
         </label>
-        <label>
-          Navigation Layout:
-          <select
-            name="navLayout"
-            value={props.navLayout ?? ""}
-            onChange={(e) => {
-              const newProps = {
-                ...props,
-                navLayout: e.target.value ?? undefined,
-              } as DayPickerProps;
-              setProps(newProps);
-            }}
-          >
-            <option value=""></option>
-            <option value="around">Around</option>
-            <option value="after">After</option>
-          </select>
-        </label>
+        {(props.captionLayout === "dropdown" ||
+          props.captionLayout === "dropdown-years") && (
+          <label>
+            <input
+              type="checkbox"
+              name="reverseYears"
+              checked={!!props.reverseYears}
+              onChange={(e) =>
+                setProps({ ...props, reverseYears: e.target.checked })
+              }
+              disabled={
+                !(
+                  props.captionLayout === "dropdown" ||
+                  props.captionLayout === "dropdown-years"
+                )
+              }
+            />
+            Reverse Dropdown Years
+          </label>
+        )}
         <label>
           <input
             type="checkbox"


### PR DESCRIPTION
A new `reverseYears` prop allows users to reverse the order of years in the dropdown, displaying the current year first. This enhancement improves the usability of the year selection feature.

Fixes #2819