### PR TITLE
fix: timezone-matcher-support

### DIFF
--- a/src/DayPicker.tsx
+++ b/src/DayPicker.tsx
@@ -30,6 +30,7 @@ import { useFocus } from "./useFocus.js";
 import { useSelection } from "./useSelection.js";
 import { rangeIncludesDate } from "./utils/rangeIncludesDate.js";
 import { isDateRange } from "./utils/typeguards.js";
+import { convertMatchersToTimeZone } from "./utils/convertMatcherToTimeZone.js";
 
 /**
  * Renders the DayPicker calendar component.
@@ -76,6 +77,36 @@ export function DayPicker(initialProps: DayPickerProps) {
           ? new TZDate(props.selected.to, props.timeZone)
           : undefined,
       };
+    }
+
+    // Convert disabled and hidden matchers to use timezone-aware dates
+    const dateLibInstance = new DateLib({ timeZone: props.timeZone });
+    if (props.disabled && props.timeZone) {
+      props.disabled = convertMatchersToTimeZone(
+        props.disabled,
+        props.timeZone,
+        dateLibInstance,
+      );
+    }
+    if (props.hidden && props.timeZone) {
+      props.hidden = convertMatchersToTimeZone(
+        props.hidden,
+        props.timeZone,
+        dateLibInstance,
+      );
+    }
+
+    // Convert custom modifiers to use timezone-aware dates
+    if (props.modifiers && props.timeZone) {
+      const convertedModifiers: typeof props.modifiers = {};
+      for (const [key, value] of Object.entries(props.modifiers)) {
+        convertedModifiers[key] = convertMatchersToTimeZone(
+          value,
+          props.timeZone,
+          dateLibInstance,
+        );
+      }
+      props.modifiers = convertedModifiers;
     }
   }
   const { components, formatters, labels, dateLib, locale, classNames } =

--- a/src/utils/convertMatcherToTimeZone.test.ts
+++ b/src/utils/convertMatcherToTimeZone.test.ts
@@ -1,0 +1,302 @@
+import { TZDate } from "@date-fns/tz";
+
+import { DateLib } from "../classes/DateLib.js";
+import type {
+  DateAfter,
+  DateBefore,
+  DateInterval,
+  DateRange,
+  DayOfWeek,
+  Matcher,
+} from "../types/index.js";
+
+import {
+  convertMatcherToTimeZone,
+  convertMatchersToTimeZone,
+} from "./convertMatcherToTimeZone.js";
+
+const testDate = new Date(2023, 5, 15, 12, 0, 0); // June 15, 2023, 12:00
+const timeZone = "America/New_York";
+const dateLib = new DateLib({ timeZone });
+
+describe("convertMatcherToTimeZone", () => {
+  describe("when matcher is a boolean", () => {
+    test("should return the boolean unchanged", () => {
+      expect(convertMatcherToTimeZone(true, timeZone, dateLib)).toBe(true);
+      expect(convertMatcherToTimeZone(false, timeZone, dateLib)).toBe(false);
+    });
+  });
+
+  describe("when matcher is a function", () => {
+    test("should return the function unchanged", () => {
+      const matcher = () => true;
+      expect(convertMatcherToTimeZone(matcher, timeZone, dateLib)).toBe(
+        matcher,
+      );
+    });
+  });
+
+  describe("when matcher is a single Date", () => {
+    test("should convert to TZDate with specified timezone", () => {
+      const result = convertMatcherToTimeZone(testDate, timeZone, dateLib);
+      expect(result).toBeInstanceOf(TZDate);
+      expect((result as TZDate).withTimeZone(timeZone).getTime()).toBe(
+        testDate.getTime(),
+      );
+    });
+  });
+
+  describe("when matcher is an array of Dates", () => {
+    test("should convert all dates to TZDate with specified timezone", () => {
+      const dates = [testDate, new Date(2023, 5, 16), new Date(2023, 5, 17)];
+      const result = convertMatcherToTimeZone(
+        dates,
+        timeZone,
+        dateLib,
+      ) as TZDate[];
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(3);
+      result.forEach((date, index) => {
+        expect(date).toBeInstanceOf(TZDate);
+        expect(date.withTimeZone(timeZone).getTime()).toBe(
+          dates[index].getTime(),
+        );
+      });
+    });
+  });
+
+  describe("when matcher is a DateRange", () => {
+    test("should convert both from and to dates to TZDate", () => {
+      const dateRange: DateRange = {
+        from: testDate,
+        to: new Date(2023, 5, 20),
+      };
+      const result = convertMatcherToTimeZone(
+        dateRange,
+        timeZone,
+        dateLib,
+      ) as DateRange;
+
+      expect(result.from).toBeInstanceOf(TZDate);
+      expect(result.to).toBeInstanceOf(TZDate);
+      expect((result.from as TZDate).withTimeZone(timeZone).getTime()).toBe(
+        dateRange.from!.getTime(),
+      );
+      expect((result.to as TZDate).withTimeZone(timeZone).getTime()).toBe(
+        dateRange.to!.getTime(),
+      );
+    });
+
+    test("should handle undefined from and to dates", () => {
+      const dateRange: DateRange = {
+        from: testDate,
+        to: undefined,
+      };
+      const result = convertMatcherToTimeZone(
+        dateRange,
+        timeZone,
+        dateLib,
+      ) as DateRange;
+
+      expect(result.from).toBeInstanceOf(TZDate);
+      expect(result.to).toBeUndefined();
+    });
+
+    test("should handle completely undefined DateRange", () => {
+      const dateRange: DateRange = {
+        from: undefined,
+        to: undefined,
+      };
+      const result = convertMatcherToTimeZone(
+        dateRange,
+        timeZone,
+        dateLib,
+      ) as DateRange;
+
+      expect(result.from).toBeUndefined();
+      expect(result.to).toBeUndefined();
+    });
+  });
+
+  describe("when matcher is a DateBefore", () => {
+    test("should convert before date to TZDate", () => {
+      const dateBefore: DateBefore = {
+        before: testDate,
+      };
+      const result = convertMatcherToTimeZone(
+        dateBefore,
+        timeZone,
+        dateLib,
+      ) as DateBefore;
+
+      expect(result.before).toBeInstanceOf(TZDate);
+      expect((result.before as TZDate).withTimeZone(timeZone).getTime()).toBe(
+        dateBefore.before.getTime(),
+      );
+    });
+  });
+
+  describe("when matcher is a DateAfter", () => {
+    test("should convert after date to TZDate", () => {
+      const dateAfter: DateAfter = {
+        after: testDate,
+      };
+      const result = convertMatcherToTimeZone(
+        dateAfter,
+        timeZone,
+        dateLib,
+      ) as DateAfter;
+
+      expect(result.after).toBeInstanceOf(TZDate);
+      expect((result.after as TZDate).withTimeZone(timeZone).getTime()).toBe(
+        dateAfter.after.getTime(),
+      );
+    });
+  });
+
+  describe("when matcher is a DateInterval", () => {
+    test("should convert both before and after dates to TZDate", () => {
+      const dateInterval: DateInterval = {
+        before: new Date(2023, 5, 20), // June 20, 2023
+        after: new Date(2023, 5, 10), // June 10, 2023 (after should be before "before" for open interval)
+      };
+
+      const result = convertMatcherToTimeZone(
+        dateInterval,
+        timeZone,
+        dateLib,
+      ) as DateInterval;
+
+      expect(result.before).toBeInstanceOf(TZDate);
+      expect(result.after).toBeInstanceOf(TZDate);
+      expect((result.before as TZDate).withTimeZone(timeZone).getTime()).toBe(
+        dateInterval.before.getTime(),
+      );
+      expect((result.after as TZDate).withTimeZone(timeZone).getTime()).toBe(
+        dateInterval.after.getTime(),
+      );
+    });
+  });
+
+  describe("when matcher is a DayOfWeek", () => {
+    test("should return DayOfWeek unchanged", () => {
+      const dayOfWeek: DayOfWeek = {
+        dayOfWeek: [0, 6], // Sunday and Saturday
+      };
+      const result = convertMatcherToTimeZone(dayOfWeek, timeZone, dateLib);
+
+      expect(result).toBe(dayOfWeek);
+    });
+  });
+
+  describe("when matcher is an unknown type", () => {
+    test("should return the matcher unchanged", () => {
+      const unknownMatcher = { unknown: "property" };
+      const result = convertMatcherToTimeZone(
+        unknownMatcher as any,
+        timeZone,
+        dateLib,
+      );
+
+      expect(result).toBe(unknownMatcher);
+    });
+  });
+});
+
+describe("convertMatchersToTimeZone", () => {
+  describe("when matchers is undefined", () => {
+    test("should return undefined", () => {
+      const result = convertMatchersToTimeZone(undefined, timeZone, dateLib);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("when matchers is a single matcher", () => {
+    test("should convert single date matcher", () => {
+      const result = convertMatchersToTimeZone(testDate, timeZone, dateLib);
+      expect(result).toBeInstanceOf(TZDate);
+    });
+
+    test("should convert single DateRange matcher", () => {
+      const dateRange: DateRange = {
+        from: testDate,
+        to: new Date(2023, 5, 20),
+      };
+      const result = convertMatchersToTimeZone(
+        dateRange,
+        timeZone,
+        dateLib,
+      ) as DateRange;
+
+      expect(result.from).toBeInstanceOf(TZDate);
+      expect(result.to).toBeInstanceOf(TZDate);
+    });
+  });
+
+  describe("when matchers is an array", () => {
+    test("should convert all matchers in array", () => {
+      const matchers: Matcher[] = [
+        testDate,
+        { before: new Date(2023, 5, 20) },
+        { after: new Date(2023, 5, 10) },
+        true,
+      ];
+      const result = convertMatchersToTimeZone(
+        matchers,
+        timeZone,
+        dateLib,
+      ) as Matcher[];
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(4);
+
+      // First matcher (Date) should be converted to TZDate
+      expect(result[0]).toBeInstanceOf(TZDate);
+
+      // Second matcher (DateBefore) should have before converted to TZDate
+      expect((result[1] as DateBefore).before).toBeInstanceOf(TZDate);
+
+      // Third matcher (DateAfter) should have after converted to TZDate
+      expect((result[2] as DateAfter).after).toBeInstanceOf(TZDate);
+
+      // Fourth matcher (boolean) should remain unchanged
+      expect(result[3]).toBe(true);
+    });
+
+    test("should handle empty array", () => {
+      const result = convertMatchersToTimeZone([], timeZone, dateLib);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("timezone handling", () => {
+    test("should work with different timezones", () => {
+      const pacificTimeZone = "America/Los_Angeles";
+      const result = convertMatchersToTimeZone(
+        testDate,
+        pacificTimeZone,
+        new DateLib({ timeZone: pacificTimeZone }),
+      );
+
+      expect(result).toBeInstanceOf(TZDate);
+      expect((result as TZDate).withTimeZone(pacificTimeZone).getTime()).toBe(
+        testDate.getTime(),
+      );
+    });
+
+    test("should work with UTC timezone", () => {
+      const utcTimeZone = "UTC";
+      const result = convertMatchersToTimeZone(
+        testDate,
+        utcTimeZone,
+        new DateLib({ timeZone: utcTimeZone }),
+      );
+
+      expect(result).toBeInstanceOf(TZDate);
+      expect((result as TZDate).withTimeZone(utcTimeZone).getTime()).toBe(
+        testDate.getTime(),
+      );
+    });
+  });
+});

--- a/src/utils/convertMatcherToTimeZone.ts
+++ b/src/utils/convertMatcherToTimeZone.ts
@@ -1,0 +1,108 @@
+import { TZDate } from "@date-fns/tz";
+import type { DateLib } from "../classes/DateLib.js";
+import type { Matcher } from "../types/shared.js";
+import {
+  isDateAfterType,
+  isDateBeforeType,
+  isDateInterval,
+  isDateRange,
+  isDatesArray,
+  isDayOfWeekType,
+} from "./typeguards.js";
+
+/**
+ * Converts a matcher to use time zone aware dates when a timeZone is specified.
+ * This ensures consistent date comparisons when using different time zones.
+ *
+ * @private
+ * @param matcher - The matcher to convert
+ * @param timeZone - The time zone to convert dates to
+ * @param dateLib - The date library instance
+ * @returns The converted matcher with time zone aware dates
+ */
+export function convertMatcherToTimeZone(
+  matcher: Matcher,
+  timeZone: string,
+  dateLib: DateLib,
+): Matcher {
+  // Return matcher as-is for non-date types
+  if (typeof matcher === "boolean" || typeof matcher === "function") {
+    return matcher;
+  }
+
+  // Convert single Date
+  if (dateLib.isDate(matcher)) {
+    return new TZDate(matcher, timeZone);
+  }
+
+  // Convert array of Dates
+  if (isDatesArray(matcher, dateLib)) {
+    return matcher.map((date) => new TZDate(date, timeZone));
+  }
+
+  // Convert DateRange
+  if (isDateRange(matcher)) {
+    return {
+      from: matcher.from ? new TZDate(matcher.from, timeZone) : undefined,
+      to: matcher.to ? new TZDate(matcher.to, timeZone) : undefined,
+    };
+  }
+
+  // Convert DateInterval (must be checked before DateBefore/DateAfter since it has both properties)
+  if (isDateInterval(matcher)) {
+    return {
+      before: new TZDate(matcher.before, timeZone),
+      after: new TZDate(matcher.after, timeZone),
+    };
+  }
+
+  // Convert DateBefore
+  if (isDateBeforeType(matcher)) {
+    return {
+      before: new TZDate(matcher.before, timeZone),
+    };
+  }
+
+  // Convert DateAfter
+  if (isDateAfterType(matcher)) {
+    return {
+      after: new TZDate(matcher.after, timeZone),
+    };
+  }
+
+  // DayOfWeek doesn't need conversion
+  if (isDayOfWeekType(matcher)) {
+    return matcher;
+  }
+
+  // Fallback: return original matcher
+  return matcher;
+}
+
+/**
+ * Converts an array of matchers or a single matcher to use time zone aware
+ * dates.
+ *
+ * @private
+ * @param matchers - The matchers to convert
+ * @param timeZone - The time zone to convert dates to
+ * @param dateLib - The date library instance
+ * @returns The converted matchers with time zone aware dates
+ */
+export function convertMatchersToTimeZone(
+  matchers: Matcher | Matcher[] | undefined,
+  timeZone: string,
+  dateLib: DateLib,
+): Matcher | Matcher[] | undefined {
+  if (!matchers) {
+    return matchers;
+  }
+
+  if (Array.isArray(matchers)) {
+    return matchers.map((matcher) =>
+      convertMatcherToTimeZone(matcher, timeZone, dateLib),
+    );
+  }
+
+  return convertMatcherToTimeZone(matchers, timeZone, dateLib);
+}


### PR DESCRIPTION
## What's Changed

- Add convertMatcherToTimeZone utility for timezone-aware date conversions
- Integrate timezone conversion for disabled, hidden, and custom modifiers
- Ensure consistent date comparisons across different timezones

### Problem Description:
When using a timezone that converts today to a different day, the disabled and hidden properties do not update according to the timezone conversion. For example, when today is September 26th in Taipei timezone and I convert to Hawaii timezone (which becomes September 25th), the September 25th date on the DayPicker still remains disabled, but I expect that day should not be disabled.

<img width="664" height="500" alt="image" src="https://github.com/user-attachments/assets/3a552f11-a541-4273-87c5-c00c0a5d8025" />

```
import React, { useState } from "react";

import { DayPicker, TZDate } from "react-day-picker";

export function TimeZone() {
  const timeZone = "Pacific/Honolulu";
  const [selected, setSelected] = useState<Date | undefined>(
    TZDate.tz(timeZone),
  );
  const now = new Date();
  return (
    <div>
      <h3>{TZDate.tz("Asia/Taipei", now).toString()}</h3>
      <h3>{TZDate.tz(timeZone, now).toString()}</h3>
      <DayPicker
        mode="single"
        timeZone={timeZone}
        selected={selected}
        onSelect={setSelected}
        disabled={{
          before: now,
        }}
        footer={
          selected
            ? selected.toString()
            : `Pick a day to see it is in ${timeZone} time zone.`
        }
      />
    </div>
  );
}
```

### Solution:
Implemented timezone-aware conversion for disabled, hidden, and custom modifiers properties in DayPicker. The fix ensures that all date matchers are properly converted to the specified timezone before being applied, maintaining consistent date comparisons across different timezones.

<img width="659" height="484" alt="image" src="https://github.com/user-attachments/assets/504df80a-ca63-4eca-bed8-ef990642c2b9" />

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
