### PR TITLE
fix: duplicated years in dropdown for some timezones

### DIFF
--- a/examples/TestCase2835.tsx
+++ b/examples/TestCase2835.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+import { DayPicker } from "react-day-picker";
+
+/**
+ * Test case for issue #2835. Note that this cannot be replicated in jsdom.
+ *
+ * @see https://github.com/gpbl/react-day-picker/issues/1567
+ */
+export function TestCase2835() {
+  return (
+    <DayPicker
+      mode="single"
+      startMonth={new Date(1900, 1, 1)}
+      captionLayout="dropdown-years"
+      timeZone="America/Sao_Paulo"
+    />
+  );
+}

--- a/examples/TestCase2835.tsx
+++ b/examples/TestCase2835.tsx
@@ -11,7 +11,8 @@ export function TestCase2835() {
   return (
     <DayPicker
       mode="single"
-      startMonth={new Date(1900, 1, 1)}
+      startMonth={new Date(1910, 1, 1)}
+      endMonth={new Date(1915, 1, 1)}
       captionLayout="dropdown-years"
       timeZone="America/Sao_Paulo"
     />

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -93,6 +93,7 @@ export * from "./TestCase2047";
 export * from "./TestCase2389";
 export * from "./TestCase2511";
 export * from "./TestCase2585";
+export * from "./TestCase2835";
 export * from "./Testcase1567";
 export * from "./TimeZone";
 export * from "./Utc";

--- a/src/classes/DateLib.ts
+++ b/src/classes/DateLib.ts
@@ -373,9 +373,19 @@ export class DateLib {
    * @since 9.11.1
    */
   eachYearOfInterval = (interval: Interval): Date[] => {
-    return this.overrides?.eachYearOfInterval
-      ? this.overrides.eachYearOfInterval(interval)
-      : eachYearOfInterval(interval);
+    const years = eachYearOfInterval(interval);
+    // Remove duplicates that may happen across DST transitions (e.g., "America/Sao_Paulo")
+    const uniqueYears = new Set(years.map((d) => this.getYear(d)));
+    if (uniqueYears.size === years.length) {
+      // No duplicates, return as is
+      return years;
+    }
+    // Rebuild the array to ensure one date per year
+    const yearsArray: Date[] = [];
+    uniqueYears.forEach((y) => {
+      yearsArray.push(new Date(y, 0, 1));
+    });
+    return yearsArray;
   };
 
   /**

--- a/src/classes/DateLib.ts
+++ b/src/classes/DateLib.ts
@@ -16,6 +16,7 @@ import {
   differenceInCalendarDays,
   differenceInCalendarMonths,
   eachMonthOfInterval,
+  eachYearOfInterval,
   endOfISOWeek,
   endOfMonth,
   endOfWeek,
@@ -362,6 +363,19 @@ export class DateLib {
     return this.overrides?.eachMonthOfInterval
       ? this.overrides.eachMonthOfInterval(interval)
       : eachMonthOfInterval(interval);
+  };
+
+  /**
+   * Returns the years between the given dates.
+   *
+   * @param interval The interval to get the years for.
+   * @returns The array of years in the interval.
+   * @since 9.11.1
+   */
+  eachYearOfInterval = (interval: Interval): Date[] => {
+    return this.overrides?.eachYearOfInterval
+      ? this.overrides.eachYearOfInterval(interval)
+      : eachYearOfInterval(interval);
   };
 
   /**

--- a/src/helpers/getYearOptions.ts
+++ b/src/helpers/getYearOptions.ts
@@ -25,17 +25,10 @@ export function getYearOptions(
 ): DropdownOption[] | undefined {
   if (!navStart) return undefined;
   if (!navEnd) return undefined;
-  const { startOfYear, endOfYear, addYears, getYear, isBefore, isSameYear } =
-    dateLib;
+  const { startOfYear, endOfYear, eachYearOfInterval, getYear } = dateLib;
   const firstNavYear = startOfYear(navStart);
   const lastNavYear = endOfYear(navEnd);
-  const years: Date[] = [];
-
-  let year = firstNavYear;
-  while (isBefore(year, lastNavYear) || isSameYear(year, lastNavYear)) {
-    years.push(year);
-    year = addYears(year, 1);
-  }
+  const years = eachYearOfInterval({ start: firstNavYear, end: lastNavYear });
 
   if (reverse) years.reverse();
 


### PR DESCRIPTION
## Bug Description

Year dropdowns rendered via `captionLayout="dropdown"` duplicated certain years when the calendar ran in DST-heavy zones such as `America/Sao_Paulo`, triggering React key warnings and breaking the UX. See the new repro in `examples/TestCase2835.tsx`

Root cause was the helper returning more than one date per year when DST transitions warped the interval boundaries.

## Fix Implemented

- Wrapped date-fns’ `eachYearOfInterval` inside `DateLib` so it can dedupe by calendar year and rebuild the list with clean Date objects (src/classes/DateLib.ts:375).
- Swapped the year-building loop in `getYearOptions` to this new helper, ensuring the dropdown always receives unique years in the intended order.

See https://github.com/date-fns/tz/issues/72.
Fixes #2835.
