### PR TITLE
chore: run jest in utc

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,3 +1,5 @@
+process.env.TZ = "UTC";
+
 import type { Config } from "@jest/types";
 
 const sharedConfig: Config.InitialOptions = {


### PR DESCRIPTION
Run Jest in UTC so the Hebrew calendar tests stop depending on the local timezone.

- Set `process.env.TZ = "UTC"` in `jest.config.ts` so the entire Jest process runs with consistent timezone semantics.
- This ensures all calendar conversions, especially Hebrew ones that normalize dates to UTC internally, receive the same input on every machine.