### PR TITLE
fix: match Date[] modifiers by day

### DIFF
--- a/examples/TestCase2864.test.tsx
+++ b/examples/TestCase2864.test.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+import { gridcell } from "@/test/elements";
+import { render } from "@/test/render";
+import { setTestTime } from "@/test/setTestTime";
+
+import { TestCase2864 } from "./TestCase2864";
+
+const january = new Date(2025, 0, 1);
+const holidays = [new Date(2025, 0, 10), new Date(2025, 0, 20)];
+
+setTestTime(january);
+
+test.each(holidays)("the holiday %s should be disabled", (day) => {
+  render(<TestCase2864 />);
+  expect(gridcell(day)).toHaveClass("rdp-disabled");
+});

--- a/examples/TestCase2864.tsx
+++ b/examples/TestCase2864.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import { DayPicker } from "react-day-picker";
+
+/**
+ * Reproduction for Date[] matchers inside `disabled`.
+ * When passing `[dates]` as a matcher, the dates should be disabled.
+ */
+export function TestCase2864() {
+  const holidays = React.useMemo(
+    () => [new Date(2025, 0, 10), new Date(2025, 0, 20)],
+    [],
+  );
+
+  return (
+    <div>
+      <p>
+        January 10 and 20, 2025 should be disabled when the Date[] matcher is
+        passed directly to `disabled`.
+      </p>
+      <DayPicker month={new Date(2025, 0, 1)} disabled={[holidays]} />
+    </div>
+  );
+}

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -95,6 +95,7 @@ export * from "./TestCase2511";
 export * from "./TestCase2585";
 export * from "./TestCase2835";
 export * from "./TestCase2843";
+export * from "./TestCase2864";
 export * from "./Testcase1567";
 export * from "./TimeZone";
 export * from "./timezone/TestCase2833";

--- a/src/utils/dateMatchModifiers.test.ts
+++ b/src/utils/dateMatchModifiers.test.ts
@@ -29,7 +29,11 @@ describe("when matching the same day", () => {
 });
 
 describe("when matching an array of dates including the day", () => {
-  const matcher = [addDays(testDay, -1), testDay, addDays(testDay, 1)];
+  const matcher = [
+    addDays(testDay, -1),
+    new Date(testDay),
+    addDays(testDay, 1),
+  ];
   const result = dateMatchModifiers(testDay, [matcher], defaultDateLib);
   test("should return true", () => {
     expect(result).toBe(true);

--- a/src/utils/dateMatchModifiers.ts
+++ b/src/utils/dateMatchModifiers.ts
@@ -35,7 +35,7 @@ export function dateMatchModifiers(
       return isSameDay(date, matcher);
     }
     if (isDatesArray(matcher, dateLib)) {
-      return matcher.includes(date);
+      return matcher.some((matcherDate) => isSameDay(date, matcherDate));
     }
     if (isDateRange(matcher)) {
       return rangeIncludesDate(matcher, date, false, dateLib);


### PR DESCRIPTION
## Bug description

Date-array matchers were comparing by reference, so `disabled={[dates]}` never matched calendar days. 

## Changes

- Updated `dateMatchModifiers` to compare with `isSameDay` and adjusted the unit test to cover new `Date` instances. 
- Added `TestCase2864` example and regression test to demonstrate `Date[]` matchers disabling the expected dates.

Fixes #2864 
