### PR TITLE
Prepare v10 prerelease publish

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: false
         type: boolean
+      npm_tag:
+        description: npm dist-tag to publish under
+        required: false
+        default: latest
+        type: string
 
 permissions:
   id-token: write # Required for OIDC
@@ -113,4 +118,4 @@ jobs:
         with:
           name: rdp-dist
           path: dist
-      - run: npm publish --provenance --tag latest
+      - run: npm publish --provenance --tag ${{ github.event.inputs.npm_tag || 'latest' }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-day-picker",
-  "version": "10.0.0",
+  "version": "10.0.0-next.0",
   "description": "Customizable Date Picker for React",
   "author": "Giampaolo Bellavite <io@gpbl.dev>",
   "homepage": "https://daypicker.dev",


### PR DESCRIPTION
## Summary
- bump the package version to `10.0.0-next.0`
- allow the package workflow to choose the npm dist-tag on manual runs

## How to use
Run the `react-day-picker` workflow on this branch with:
- `publish=true`
- `npm_tag=next`

This will publish the prerelease to npm as `react-day-picker@next` without touching `latest`.
