### PR TITLE
docs: rewrite v10 migration guide

### DIFF
--- a/website/versioned_docs/version-next/upgrading.mdx
+++ b/website/versioned_docs/version-next/upgrading.mdx
@@ -4,291 +4,159 @@ sidebar_position: 5
 
 # Upgrading to v10
 
-This release includes significant updates related to accessibility, styles, internationalization, and performance. See the [changelog](./changelog.mdx) for the full list of changes.
+DayPicker v10 removes the APIs that were deprecated in v9.
 
-## Upgrading from v7
+:::note Easy upgrade path
+If your app is already on v9 and does not rely on deprecated APIs, the upgrade
+is mostly mechanical.
 
-If you are upgrading from v7, this guide is still valid. First, read the [migration guide from v7 to v8](/v8/upgrading), then follow the steps below.
+The main behavior change outside the removed APIs is that omitting
+`navLayout` now behaves like `navLayout="after"`.
+:::
 
-## Checklist
+If you are upgrading from v8 or earlier, first follow the
+[v9 upgrade guide](/upgrading) and remove the v9 deprecations there.
 
-### 1. Upgrade to the Next Version
+## 1. Upgrade the package
 
 ```bash npm2yarn
 npm install react-day-picker@next
 ```
 
-If you are not using `date-fns` directly in your code (e.g., when using a [different locale](./localization/changing-locale.mdx)), remove it from your dependencies:
+## 2. Replace removed navigation props
 
-```bash npm2yarn
-npm remove date-fns
-```
-
-### 2. Update Your Custom Styles
-
-The default design has changed slightly. You may need to adjust DayPicker to match your design. See the [styling docs](./docs/styling.mdx) for more information.
-
-### 3. Add the `onSelect` Prop When Using `selected`
-
-The `selected` prop is now controlled. Add an `onSelect` prop to handle the selected state and keep it in sync with your component.
+| Removed prop | Use instead |
+| --- | --- |
+| `fromMonth` | [`startMonth`](./api/interfaces/PropsBase.md#startmonth) |
+| `fromYear` | [`startMonth`](./api/interfaces/PropsBase.md#startmonth) with the first month of that year |
+| `toMonth` | [`endMonth`](./api/interfaces/PropsBase.md#endmonth) |
+| `toYear` | [`endMonth`](./api/interfaces/PropsBase.md#endmonth) with the last month of that year |
+| `fromDate` | [`hidden`](./api/interfaces/PropsBase.md#hidden) with a `before` matcher, and optionally [`startMonth`](./api/interfaces/PropsBase.md#startmonth) |
+| `toDate` | [`hidden`](./api/interfaces/PropsBase.md#hidden) with an `after` matcher, and optionally [`endMonth`](./api/interfaces/PropsBase.md#endmonth) |
 
 ```diff
-+ const [selected, setSelected] = useState<Date | undefined>(undefined);
-  <DayPicker
-    mode="single"
-    selected={selected} // controlled prop
-+   onSelect={setSelected} // update the selected date
-  />
-```
-
-### 4. Update Class Names
-
-Class names for UI elements have been updated for clarity and consistency. If you use custom styles via the `classNames` or `styles` prop, update them accordingly.
-
-For example, `day_disabled` is now `disabled`:
-
-```diff
- <DayPicker
-   classNames={{
--    day_disabled: 'day-disabled',
-+    disabled: 'day-disabled', // applies `.day_disabled` to disabled days
-   }}
- />
-```
-
-Additionally, the `day` element is now `day_button`, and the `cell` element is now `day`:
-
-```diff
- <DayPicker
-   classNames={{
--    cell: 'day-cell',
-+    day: 'day-cell',
--    day: 'day-button',
-+    day_button: 'day-button',
-   }}
- />
-```
-
-See the current class name keys in the [`UI`](./api/enumerations/UI.md) enum.
-
-<details>
-  <summary>**List of Updated Class Names**</summary>
-
-| Old Name              | New Name                                                   |
-| --------------------- | ---------------------------------------------------------- |
-| `button`              | `button_previous`, `button_next`                           |
-| `button_reset`        | `button_previous`, `button_next`                           |
-| `caption`             | `month_caption`                                            |
-| `caption_between`     | Removed                                                    |
-| `caption_dropdowns`   | `dropdowns`                                                |
-| `caption_end`         | Removed                                                    |
-| `caption_start`       | Removed                                                    |
-| `cell`                | `day` – ⚠️ The previous `day` element is now `day_button`. |
-| `day_disabled`        | `disabled`                                                 |
-| `day_hidden`          | `hidden`                                                   |
-| `day_outside`         | `outside`                                                  |
-| `day_range_end`       | `range_end`                                                |
-| `day_range_middle`    | `range_middle`                                             |
-| `day_range_start`     | `range_start`                                              |
-| `day_selected`        | `selected`                                                 |
-| `day_today`           | `today`                                                    |
-| `dropdown_icon`       | `chevron`                                                  |
-| `dropdown_month`      | `months_dropdown`                                          |
-| `dropdown_year`       | `years_dropdown`                                           |
-| `head`                | Removed                                                    |
-| `head_cell`           | `weekday`                                                  |
-| `head_row`            | `weekdays`                                                 |
-| `multiple_months`     | Removed. Use `data-multiple-months` data attribute.        |
-| `nav_button`          | `button_previous`, `button_next`                           |
-| `nav_button_next`     | `button_next`                                              |
-| `nav_button_previous` | `button_previous`                                          |
-| `nav_icon`            | `chevron`, `button_next`, `button_previous`                |
-| `row`                 | `week`                                                     |
-| `table`               | `month_grid`                                               |
-| `tbody`               | `weeks`                                                    |
-| `tfoot`               | `footer`                                                   |
-| `vhidden`             | Removed                                                    |
-| `weeknumber`          | `week_number`                                              |
-| `with_weeknumber`     | Removed. Use `data-week-numbers` data attribute.           |
-
-</details>
-
-### 5. Replace `fromDate` and `toDate`
-
-Replace `fromDate` and `toDate` with the `hidden`, `startMonth`, and `endMonth` props.
-
-#### Example: Replace `fromDate`
-
-```diff
- <DayPicker
--   fromDate={new Date(2010, 11, 03)}
-+   startMonth={new Date(2010, 11)}
-+   hidden={[{ before: new Date(2010, 11, 03) }]}
- />
-```
-
-#### Example: Replace `toDate`
-
-```diff
- <DayPicker
--   toDate={new Date(2010, 11, 03)}
-+   endMonth={new Date(2010, 11)}
-+   hidden={[{ after: new Date(2010, 11, 03) }]}
- />
-```
-
-### 6. Update Tests and Translations
-
-DayPicker's ARIA labels have been updated for clarity. Update your tests and translations accordingly.
-
-#### Updated ARIA Labels
-
-| Label                                                                    | Old Label                | New Label                                                                                                  |
-| ------------------------------------------------------------------------ | ------------------------ | ---------------------------------------------------------------------------------------------------------- |
-| [`labelDayButton`](./api/functions/labelDayButton)<br/>_ex_ ~`labelDay`~ | `21st November (Monday)` | `Monday, November 21st, 2024`<br/>`Monday, November 21st, 2024, selected`<br/>`Today, November 21st, 2024` |
-| [`labelPrevious`](./api/functions/labelPrevious)                         | `Go to previous month`   | `Go to the Previous Month`                                                                                 |
-| [`labelNext`](./api/functions/labelNext)                                 | `Go to next month`       | `Go to the Next Month`                                                                                     |
-| [`labelWeekNumber`](./api/functions/labelWeekNumber.md)                  | `Week nr. ##`            | `Week ##`                                                                                                  |
-
-Update test selectors as needed:
-
-```diff
-- screen.getByRole('button', 'Go to next month');
-+ screen.getByRole('button', 'Go to the Next Month');
-```
-
-#### `labelDay` Changes
-
-The `labelDay` function has been renamed to `labelDayButton`. It now includes the year and communicates the selected and today status. See [Translating DayPicker](./guides/translation.mdx) for more information.
-
-### 7. Update Formatters to Return a String
-
-Formatters now return a `string` instead of a `ReactNode`. Update your code accordingly.
-
-```diff
-  <DayPicker
-    formatters={{
--      formatCaption: (month) => <strong>{format(month, "LLLL y")}</strong> // ❌ returned an element
-+      formatCaption: (month) => format(month, "LLLL y") // ✅ return a string
-    }}
-  />;
-```
-
-If you need to return a `ReactElement`, use a [custom component](./guides/custom-components.mdx):
-
-```tsx
 <DayPicker
-  formatters={{
-    formatCaption: (month) => format(month, "LLLL y"), // ✅ return a string
-  }}
+- fromYear={2010}
+- toYear={2021}
++ startMonth={new Date(2010, 0)}
++ endMonth={new Date(2021, 11)}
+/>
+```
+
+```diff
+<DayPicker
+- fromDate={new Date(2010, 11, 3)}
++ startMonth={new Date(2010, 11)}
++ hidden={{ before: new Date(2010, 11, 3) }}
+/>
+```
+
+```diff
+<DayPicker
+- toDate={new Date(2010, 11, 3)}
++ endMonth={new Date(2010, 11)}
++ hidden={{ after: new Date(2010, 11, 3) }}
+/>
+```
+
+## 3. Replace removed focus and event props
+
+| Removed prop | Use instead |
+| --- | --- |
+| `initialFocus` | [`autoFocus`](./api/interfaces/PropsBase.md#autofocus) |
+| `onWeekNumberClick` | A custom [`WeekNumber`](./api/functions/WeekNumber.md) component |
+| `onDayKeyUp` | A custom [`DayButton`](./api/functions/DayButton.md) component |
+| `onDayKeyPress` | A custom [`DayButton`](./api/functions/DayButton.md) component |
+| `onDayPointerEnter` | A custom [`DayButton`](./api/functions/DayButton.md) component |
+| `onDayPointerLeave` | A custom [`DayButton`](./api/functions/DayButton.md) component |
+| `onDayTouchCancel` | A custom [`DayButton`](./api/functions/DayButton.md) component |
+| `onDayTouchEnd` | A custom [`DayButton`](./api/functions/DayButton.md) component |
+| `onDayTouchMove` | A custom [`DayButton`](./api/functions/DayButton.md) component |
+| `onDayTouchStart` | A custom [`DayButton`](./api/functions/DayButton.md) component |
+
+For week-based selections, follow the
+[week selection example](./guides/custom-selections.mdx#week-numbers-and-starts).
+
+For extra DOM event handlers on each day, compose around the default
+[`DayButton`](./api/functions/DayButton.md) in the
+[Custom Components guide](./guides/custom-components.mdx).
+
+## 4. Replace removed aliases
+
+| Removed API | Use instead |
+| --- | --- |
+| `formatMonthCaption` | [`formatCaption`](./api/functions/formatCaption.md) |
+| `formatYearCaption` | [`formatYearDropdown`](./api/functions/formatYearDropdown.md) |
+| `labelDay` | [`labelDayButton`](./api/functions/labelDayButton.md) |
+| `labelCaption` | [`labelGrid`](./api/functions/labelGrid.md) |
+| `isMatch` | [`dateMatchModifiers`](./api/functions/dateMatchModifiers.md) |
+| `isDateInRange` | [`rangeIncludesDate`](./api/functions/rangeIncludesDate.md) |
+
+If you already migrated to the v9 names, there is nothing to change here.
+
+## 5. Update custom components
+
+The deprecated `components.Button` entry was removed in v10.
+
+Use
+[`PreviousMonthButton`](./api/functions/PreviousMonthButton.md) and
+[`NextMonthButton`](./api/functions/NextMonthButton.md) instead.
+
+```diff
+<DayPicker
   components={{
-    Caption: ({ children }) => <strong>{children}</strong>, // ✅ return a ReactElement
+-   Button: MyButton
++   PreviousMonthButton: MyPreviousButton,
++   NextMonthButton: MyNextButton
   }}
 />
 ```
 
-### 8. Update Custom Components
+## 6. Update `classNames` and `styles` keys
 
-If you use the `components` prop, update your code as some components have changed. See the [custom components guide](./guides/custom-components.mdx) for details.
+The deprecated compatibility keys were removed from `classNames` and `styles`.
+Use only the current keys from
+[`UI`](./api/enumerations/UI.md),
+[`DayFlag`](./api/enumerations/DayFlag.md),
+[`SelectionState`](./api/enumerations/SelectionState.md), and
+[`Animation`](./api/enumerations/Animation.md).
 
-```diff
-  <DayPicker
-    components={{
--     IconRight: MyRightIcon,
--     IconLeft: MyLeftIcon,
-+     Chevron: (props) => {
-+       if (props.orientation === "left") {
-+         return <ChevronLeftIcon {...props} />;
-+       }
-+       return <ChevronRightIcon {...props} />;
-+     },
-    }}
-  />
-```
+Common migrations:
 
-<details>
-  <summary>**List of Updated Components**</summary>
+| Removed key | Use instead |
+| --- | --- |
+| `table` | `month_grid` |
+| `nav_button` | `button_previous` and `button_next` |
+| `day_selected` | `selected` |
+| `day_disabled` | `disabled` |
 
-| Component      | Changes                                                                     |
-| -------------- | --------------------------------------------------------------------------- |
-| `Caption`      | Renamed to [`MonthCaption`](./api/functions/MonthCaption.md).               |
-| `Day`          | Now renders a [`DayButton`](./api/functions/DayButton.md).                  |
-| `DayContent`   | Removed. Use [`formatDay`](./api/functions/formatDay.md) to change content. |
-| `Head`         | Removed.                                                                    |
-| `HeadRow`      | Renamed to [`Weekdays`](./api/functions/Weekdays.md).                       |
-| `IconDropdown` | Removed. The icon is rendered by [`Chevron`](./api/functions/Chevron.md).   |
-| `IconLeft`     | Removed. The icon is rendered by [`Chevron`](./api/functions/Chevron.md).   |
-| `IconRight`    | Removed. The icon is rendered by [`Chevron`](./api/functions/Chevron.md).   |
-| `Row`          | Renamed to [`Week`](./api/functions/Week.md).                               |
+## 7. Update imports
 
-</details>
+These imports were removed in v10:
 
-### Deprecations
+- `react-day-picker/jalali` - use `react-day-picker/persian`
+- Deprecated aliases from `types/deprecated`
 
-Deprecated props and types will be removed in the next major version. Update your code to avoid breaking changes.
+## 8. Review the new `navLayout` default
 
-#### Deprecated Props
+In v10, omitting [`navLayout`](./api/interfaces/PropsBase.md#navlayout) is
+equivalent to `navLayout="after"`.
 
-| Deprecated Prop | Replacement  | Notes                                            |
-| --------------- | ------------ | ------------------------------------------------ |
-| ~`fromMonth`~   | `startMonth` | Renamed. The start month for the navigation.     |
-| ~`toMonth`~     | `endMonth`   | Renamed. The end month for the navigation.       |
-| ~`fromYear`~    | `startMonth` | Pass the first month of the year to `startMonth` |
-| ~`toYear`~      | `endMonth`   | Pass the last month of the year to `endMonth`.   |
+Check:
 
-#### Example
+- Navigation button placement
+- Focus order and keyboard navigation
+- Tests or snapshots that assert DOM order or `data-nav-layout`
 
-```diff
-  <DayPicker
--   fromYear={2010}
-+   startMonth={new Date(2010, 0)}  // January 2010
--   toYear={2021}
-+   endMonth={new Date(2021, 11)} // December 2021
-  />
-```
+If you want the behavior to stay explicit across upgrades, set `navLayout`
+directly to `"after"` or `"around"`.
 
-#### Deprecated Types
+## 9. Audit copied wrappers
 
-If you use TypeScript, some types have been deprecated for clarity and shorter names.
+If your app uses a copied wrapper around DayPicker, audit that local file after
+upgrading.
 
-```diff
-- import type { DayPickerDefaultProps } from 'react-day-picker';
-+ import type { PropsBase } from 'react-day-picker';
-```
-
-These aliases were kept in v9 for migration and are removed in v10. If you need the historical reference list, see the [v9.14.0 `types/deprecated.ts` source](https://github.com/gpbl/react-day-picker/blob/v9.14.0/src/types/deprecated.ts).
-
-<details>
-  <summary>**List of Deprecated Types**</summary>
-
-| Deprecated Type                | Deprecation Reason                                                                                            |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| ~`Caption`~                    | Renamed to [`MonthCaption`](./api/functions/MonthCaption.md).                                                 |
-| ~`HeadRow`~                    | Removed.                                                                                                      |
-| ~`Row`~                        | Renamed to [`Week`](./api/functions/Week.md).                                                                 |
-| ~`DayPickerSingleProps`~       | Renamed to [`PropsSingle`](./api/interfaces/PropsSingle.md).                                                  |
-| ~`DayPickerMultipleProps`~     | Renamed to [`PropsMulti`](./api/interfaces/PropsMulti.md).                                                    |
-| ~`DayPickerRangeProps`~        | Renamed to [`PropsRange`](./api/interfaces/PropsRange.md).                                                    |
-| ~`DayPickerDefaultProps`~      | Renamed to [`PropsBase`](./api/interfaces/PropsBase.md).                                                      |
-| ~`DaySelectionMode`~           | Renamed to [`Mode`](./api/type-aliases/Mode.md).                                                              |
-| ~`Modifier`~                   | Will be removed. Use `string` instead.                                                                        |
-| ~`InternaModifier`~            | Split into [`DayFlag`](./api/enumerations/DayFlag) and [`SelectionState`](./api/enumerations/SelectionState). |
-| ~`SelectSingleEventHandler`~   | Will be removed. Use [`PropsSingle["onSelect]`](./api/interfaces/PropsSingle.md) instead.                     |
-| ~`SelectMultipleEventHandler`~ | Will be removed. Use [`PropsMulti["onSelect]`](./api/interfaces/PropsMulti.md) instead.                       |
-| ~`SelectRangeEventHandler`~    | Will be removed. Use [`PropsRange["onSelect]`](./api/interfaces/PropsRange.md) instead.                       |
-| ~`DayPickerProviderProps`~     | Not used anymore.                                                                                             |
-| ~`useNavigation`~              | Included in [`useDayPicker`](./api/functions/useDayPicker.md).                                                |
-| ~`useDayRender`~               | Removed. Customize day rendering with the `htmlAttributes` prop in a custom `Day` component.                  |
-| ~`ContextProvidersProps`~      | Not used anymore.                                                                                             |
-| ~`DayLabel`~                   | Use `typeof labelDayButton` instead.                                                                          |
-| ~`NavButtonLabel`~             | Use `typeof labelNext` or `typeof labelPrevious` instead.                                                     |
-| ~`WeekdayLabel`~               | Use `typeof labelWeekday` instead.                                                                            |
-| ~`WeekNumberLabel`~            | Use `typeof labelWeekNumber` instead.                                                                         |
-| ~`DayClickEventHandler`~       | Use `DayMouseEventHandler` instead.                                                                           |
-| ~`DayFocusEventHandler`~       | Will be removed. Use `DayEventHandler<React.FocusEvent \| React.KeyboardEvent>` instead.                      |
-| ~`DayKeyboardEventHandler`~    | Will be removed. Use `DayEventHandler<React.KeyboardEvent>` instead.                                          |
-| ~`DayMouseEventHandler`~       | Will be removed. Use `DayEventHandler<React.MouseEvent>` instead.                                             |
-| ~`DayPointerEventHandler`~     | Will be removed. Use `DayEventHandler<React.PointerEvent>` instead.                                           |
-| ~`DayTouchEventHandler`~       | Will be removed. Use `DayEventHandler<React.TouchEvent>` instead.                                             |
-
-</details>
+This is especially important for wrappers that still reference removed props
+like `initialFocus`, `fromMonth`, `toMonth`, `fromYear`, or `toYear`, or old
+class name keys like `table`, `nav_button`, `day_selected`, and
+`day_disabled`.


### PR DESCRIPTION
## Summary
- replace the outdated `version-next` v10 upgrade page that still mirrored the old v9 migration guide
- document the removed v9-deprecated props, aliases, and compatibility keys together with their current v10 replacements
- call out the `navLayout="after"` default and recommend auditing copied wrappers after upgrading

## Why
PR #2903 had useful migration ideas, but most of its website/versioning plumbing has already landed separately on `main`.

This extracts the still-relevant migration guidance into a smaller patch that matches the current docs structure.

## Impact
Developers reading the `next` docs now get a real v9-to-v10 migration path instead of a page that still describes v9-era deprecations as upcoming.

## Validation
- `pnpm build`
- `pnpm exec prettier --check website/versioned_docs/version-next/upgrading.mdx`
