### PR TITLE
chore: align website workflow node version

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.16
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
@@ -35,7 +35,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.16
+          node-version: 24
           cache: pnpm
       - uses: actions/download-artifact@v4
         with:
@@ -52,7 +52,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.16
+          node-version: 24
           cache: pnpm
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- update `.github/workflows/website.yml` to use Node 24 in all jobs
- keep the website workflow aligned with the repo
- ensure the workflow stays compatible with the higher Node floor introduced by the examples app Vite upgrade work

## Why
The website workflow was still pinned to Node 20.16 while the main package workflow already runs on Node 24. Because the website workflow installs the workspace from the repo root, it should use a Node version that remains compatible with the newer examples app requirement.

## Impact
- consistent Node version across GitHub Actions workflows
- avoids installing the workspace under a Node version below the newer examples app floor
- no runtime or package changes outside CI configuration

## Validation
- parsed `.github/workflows/website.yml` locally with Ruby YAML
