### PR TITLE
website: split stable and next playgrounds

### DIFF
--- a/website/src/components/BrowserWindow.tsx
+++ b/website/src/components/BrowserWindow.tsx
@@ -11,6 +11,7 @@ import { ShadowDomWrapper } from "./ShadowDomWrapper";
 
 interface Props {
   children: ReactNode;
+  baseStyleCss?: string;
   minHeight?: number;
   url?: string;
   style?: CSSProperties;
@@ -23,6 +24,7 @@ interface Props {
 
 export function BrowserWindow({
   children,
+  baseStyleCss,
   minHeight,
   style,
   bodyStyle,
@@ -57,7 +59,9 @@ export function BrowserWindow({
 
       <div className={`${styles.browserWindowBody} rdp-demo`} style={bodyStyle}>
         {shadow ? (
-          <ShadowDomWrapper styleStr={styleStr}>{children}</ShadowDomWrapper>
+          <ShadowDomWrapper baseStyleCss={baseStyleCss} styleStr={styleStr}>
+            {children}
+          </ShadowDomWrapper>
         ) : (
           children
         )}

--- a/website/src/components/Playground/index.tsx
+++ b/website/src/components/Playground/index.tsx
@@ -42,8 +42,8 @@ import { CustomizationFieldset } from "./CustomizationFieldset";
 import { LocalizationFieldset } from "./LocalizationFieldset";
 import { NavigationFieldset } from "./NavigationFieldset";
 import { SelectionFieldset } from "./SelectionFieldset";
-import styles from "./styles.module.css";
 import { toJSX } from "./shared/toJSX";
+import styles from "./styles.module.css";
 import { useQueryStringSync } from "./useQueryStringSync";
 
 const localeImportsByCalendar = {

--- a/website/src/components/Playground/shared/queryString.ts
+++ b/website/src/components/Playground/shared/queryString.ts
@@ -1,0 +1,176 @@
+type LocaleLike = {
+  code?: string;
+};
+
+const qsProps = [
+  "animate",
+  "broadcastCalendar",
+  "captionLayout",
+  "defaultMonth",
+  "dir",
+  "disabled",
+  "disableNavigation",
+  "calendar",
+  "firstDayOfWeek",
+  "firstWeekContainsDate",
+  "fixedWeeks",
+  "hideNavigation",
+  "hideWeekdays",
+  "ISOWeek",
+  "locale",
+  "max",
+  "min",
+  "mode",
+  "navLayout",
+  "numberOfMonths",
+  "numerals",
+  "noonSafe",
+  "pagedNavigation",
+  "required",
+  "resetOnSelect",
+  "reverseMonths",
+  "reverseYears",
+  "selected",
+  "showOutsideDays",
+  "showWeekNumber",
+  "startMonth",
+  "endMonth",
+  "month",
+  "timeZone",
+  "weeksStartOn",
+  "weekStartsOn",
+] as const;
+
+const legacyMonthBounds = {
+  fromMonth: "startMonth",
+  toMonth: "endMonth",
+} as const;
+
+const typeMap: Record<
+  string,
+  "boolean" | "number" | "string" | "locale" | "date"
+> = {
+  animate: "boolean",
+  broadcastCalendar: "boolean",
+  calendar: "string",
+  captionLayout: "string",
+  defaultMonth: "date",
+  dir: "string",
+  disabled: "string",
+  disableNavigation: "boolean",
+  endMonth: "date",
+  firstDayOfWeek: "number",
+  firstWeekContainsDate: "number",
+  fixedWeeks: "boolean",
+  fromMonth: "date",
+  hideNavigation: "boolean",
+  hideWeekdays: "boolean",
+  ISOWeek: "boolean",
+  locale: "locale",
+  max: "number",
+  min: "number",
+  mode: "string",
+  month: "date",
+  navLayout: "string",
+  numberOfMonths: "number",
+  numerals: "string",
+  noonSafe: "boolean",
+  pagedNavigation: "boolean",
+  required: "boolean",
+  resetOnSelect: "boolean",
+  reverseMonths: "boolean",
+  reverseYears: "boolean",
+  selected: "string",
+  showOutsideDays: "boolean",
+  showWeekNumber: "boolean",
+  startMonth: "date",
+  timeZone: "string",
+  toMonth: "date",
+  weeksStartOn: "number",
+  weekStartsOn: "number",
+};
+
+export function parsePlaygroundSearch<TLocale extends LocaleLike>(
+  search: string,
+  availableLocales: readonly TLocale[],
+) {
+  const params = new URLSearchParams(search);
+  const parsedProps: Record<string, unknown> = {};
+
+  [...qsProps, ...Object.keys(legacyMonthBounds)].forEach((key) => {
+    if (!params.has(key)) {
+      return;
+    }
+    const normalizedKey =
+      legacyMonthBounds[key as keyof typeof legacyMonthBounds] ?? key;
+    if (normalizedKey in parsedProps) {
+      return;
+    }
+    const value = params.get(key);
+    try {
+      switch (typeMap[key]) {
+        case "boolean":
+          parsedProps[normalizedKey] = true;
+          break;
+        case "number":
+          if (value !== null) {
+            parsedProps[normalizedKey] = Number(value);
+          }
+          break;
+        case "string":
+          parsedProps[normalizedKey] = value ?? "";
+          break;
+        case "locale":
+          if (!value) break;
+          parsedProps.locale = availableLocales.find(
+            (locale) => locale.code === value,
+          );
+          break;
+        case "date": {
+          if (!value) break;
+          const timestamp = Number(value);
+          const parsedDate = new Date(
+            Number.isNaN(timestamp) ? value : timestamp,
+          );
+          if (!Number.isNaN(parsedDate.getTime())) {
+            parsedProps[normalizedKey] = parsedDate;
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    } catch (error) {
+      console.error(`Error parsing query string key "${key}":`, error);
+    }
+  });
+
+  return parsedProps;
+}
+
+export function buildPlaygroundQueryString(
+  updatedProps: Record<string, unknown>,
+) {
+  const qs: string[] = [];
+
+  Object.entries(updatedProps)
+    .filter(([key, value]) => !!value && qsProps.includes(key as never))
+    .forEach(([key, value]) => {
+      if (key === "locale") {
+        if (
+          typeof value === "object" &&
+          value !== null &&
+          "code" in value &&
+          typeof value.code === "string"
+        ) {
+          qs.push(`locale=${value.code}`);
+        }
+      } else if (value instanceof Date) {
+        qs.push(`${key}=${value.getTime()}`);
+      } else {
+        qs.push(`${key}${value === true ? "" : `=${value}`}`);
+      }
+    });
+
+  return qs.length === 0 ? "" : `?${qs.join("&")}`;
+}

--- a/website/src/components/Playground/shared/toJSX.ts
+++ b/website/src/components/Playground/shared/toJSX.ts
@@ -1,10 +1,8 @@
-import type { DayPickerProps } from "react-day-picker";
-
 /**
  * Function to format a json object of props to a jsx source displaying the
  * props as example
  */
-export function toJSX(props: Partial<DayPickerProps>) {
+export function toJSX(props: Record<string, unknown>) {
   const formatDate = (value: Date) =>
     `={new Date(${value.getFullYear()}, ${value.getMonth()}, ${value.getDate()})}`;
 
@@ -17,16 +15,12 @@ export function toJSX(props: Partial<DayPickerProps>) {
     return `={${JSON.stringify(value)}}`;
   };
 
-  return (
-    Object.keys(props)
-      // @ts-expect-error abc
-      .filter((key) => props[key] !== undefined && props[key] !== false)
-      .sort((a, b) => a.localeCompare(b))
-      .map((key) => {
-        // @ts-expect-error abc
-        const formattedValue = formatValue(props[key]);
-        return formattedValue === null ? "" : ` ${key}${formattedValue}`;
-      })
-      .join("")
-  );
+  return Object.keys(props)
+    .filter((key) => props[key] !== undefined && props[key] !== false)
+    .sort((a, b) => a.localeCompare(b))
+    .map((key) => {
+      const formattedValue = formatValue(props[key]);
+      return formattedValue === null ? "" : ` ${key}${formattedValue}`;
+    })
+    .join("");
 }

--- a/website/src/components/PlaygroundV9/CustomizationFieldset.tsx
+++ b/website/src/components/PlaygroundV9/CustomizationFieldset.tsx
@@ -1,0 +1,228 @@
+import React from "react";
+import type { Locale } from "react-day-picker-v9";
+import { DateLib } from "react-day-picker-v9";
+import {
+  amET,
+  getDateLib as getDateLibEthiopic,
+} from "react-day-picker-v9/ethiopic";
+import { arSA, getDateLib as getDateLibHijri } from "react-day-picker-v9/hijri";
+import * as locales from "react-day-picker-v9/locale";
+import {
+  faIR,
+  getDateLib as getDateLibPersian,
+} from "react-day-picker-v9/persian";
+
+import styles from "../Playground/styles.module.css";
+import type { DayPickerPropsWithCalendar } from "./useQueryStringSync";
+
+interface CustomizationFieldsetProps {
+  props: DayPickerPropsWithCalendar;
+  setProps: React.Dispatch<React.SetStateAction<DayPickerPropsWithCalendar>>;
+  accentColor: string;
+  setAccentColor: React.Dispatch<React.SetStateAction<string>>;
+}
+
+function resolveDateLib(props: DayPickerPropsWithCalendar) {
+  if (props.calendar === "persian") {
+    return getDateLibPersian({
+      locale: (props.locale as Locale) ?? faIR,
+      timeZone: props.timeZone,
+      numerals: props.numerals,
+    });
+  }
+  if (props.calendar === "ethiopic") {
+    return getDateLibEthiopic({
+      locale: (props.locale as Locale) ?? (amET as Locale),
+      timeZone: props.timeZone,
+      numerals: props.numerals,
+    });
+  }
+  if (props.calendar === "hijri") {
+    return getDateLibHijri({
+      locale: (props.locale as Locale) ?? (arSA as Locale),
+      timeZone: props.timeZone,
+      numerals: props.numerals,
+    });
+  }
+  return new DateLib({
+    locale: (props.locale as Locale) ?? locales.enUS,
+    timeZone: props.timeZone,
+  });
+}
+
+function resolveReferenceDate(
+  props: DayPickerPropsWithCalendar,
+  dateLib: DateLib,
+) {
+  const candidates = [props.month, props.startMonth, props.defaultMonth];
+  for (const candidate of candidates) {
+    if (candidate instanceof Date) return candidate;
+  }
+  return dateLib.today();
+}
+
+export function CustomizationFieldset({
+  props,
+  setProps,
+  accentColor,
+  setAccentColor,
+}: CustomizationFieldsetProps) {
+  return (
+    <fieldset>
+      <legend>
+        Customization{" "}
+        <button
+          type="button"
+          onClick={() => {
+            setProps({
+              ...props,
+              captionLayout: undefined,
+              navLayout: undefined,
+              showOutsideDays: false,
+              showWeekNumber: false,
+              fixedWeeks: false,
+              hideWeekdays: false,
+              reverseYears: false,
+              startMonth: undefined,
+              endMonth: undefined,
+            });
+            setAccentColor("");
+          }}
+        >
+          Reset
+        </button>
+      </legend>
+      <div className={styles.fields}>
+        <label>
+          Navigation Layout:
+          <select
+            name="navLayout"
+            value={props.navLayout ?? ""}
+            onChange={(e) => {
+              const newProps: DayPickerPropsWithCalendar = {
+                ...props,
+                navLayout: (e.target.value ?? undefined) as
+                  | "around"
+                  | "after"
+                  | undefined,
+              };
+              setProps(newProps);
+            }}
+          >
+            <option value=""></option>
+            <option value="around">Around</option>
+            <option value="after">After</option>
+          </select>
+        </label>
+        <label>
+          Caption Layout:
+          <select
+            name="captionLayout"
+            value={props.captionLayout ?? ""}
+            onChange={(e) => {
+              const newCaptionLayout = e.target.value as
+                | "label"
+                | "dropdown"
+                | "dropdown-months"
+                | "dropdown-years";
+              const newProps: DayPickerPropsWithCalendar = {
+                ...props,
+                captionLayout: newCaptionLayout,
+              };
+              if (newCaptionLayout === "dropdown") {
+                const dateLib = resolveDateLib(newProps);
+                const referenceDate = resolveReferenceDate(newProps, dateLib);
+                const hundredYearsAgo = dateLib.addYears(referenceDate, -100);
+                newProps.startMonth = dateLib.startOfMonth(hundredYearsAgo);
+                newProps.endMonth = dateLib.startOfMonth(referenceDate);
+              } else if (newCaptionLayout === "label") {
+                newProps.startMonth = undefined;
+                newProps.endMonth = undefined;
+              }
+              setProps(newProps);
+            }}
+          >
+            <option></option>
+            <option value="label">Label</option>
+            <option value="dropdown">Dropdown</option>
+            <option value="dropdown-months">Dropdown Months</option>
+            <option value="dropdown-years">Dropdown Years</option>
+          </select>
+        </label>
+        {(props.captionLayout === "dropdown" ||
+          props.captionLayout === "dropdown-years") && (
+          <label>
+            <input
+              type="checkbox"
+              name="reverseYears"
+              checked={!!props.reverseYears}
+              onChange={(e) =>
+                setProps({ ...props, reverseYears: e.target.checked })
+              }
+              disabled={
+                !(
+                  props.captionLayout === "dropdown" ||
+                  props.captionLayout === "dropdown-years"
+                )
+              }
+            />
+            Reverse Dropdown Years
+          </label>
+        )}
+        <label>
+          <input
+            type="checkbox"
+            name="showOutsideDays"
+            checked={props.showOutsideDays}
+            onChange={(e) =>
+              setProps({ ...props, showOutsideDays: e.target.checked })
+            }
+          />
+          Show outside days
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            name="showWeekNumber"
+            checked={props.showWeekNumber}
+            onChange={(e) =>
+              setProps({ ...props, showWeekNumber: e.target.checked })
+            }
+          />
+          Show week number
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            name="fixedWeeks"
+            checked={props.fixedWeeks}
+            onChange={(e) =>
+              setProps({ ...props, fixedWeeks: e.target.checked })
+            }
+          />
+          Fixed weeks
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            name="hideWeekdays"
+            checked={props.hideWeekdays}
+            onChange={(e) =>
+              setProps({ ...props, hideWeekdays: e.target.checked })
+            }
+          />
+          Hide weekdays
+        </label>
+        <label>
+          Accent Color:
+          <input
+            value={accentColor ?? ""}
+            type="color"
+            name="accentColor"
+            onChange={(e) => setAccentColor(e.target.value)}
+          />
+        </label>
+      </div>
+    </fieldset>
+  );
+}

--- a/website/src/components/PlaygroundV9/LocalizationFieldset.tsx
+++ b/website/src/components/PlaygroundV9/LocalizationFieldset.tsx
@@ -13,10 +13,7 @@ import {
   amET as amETEthiopic,
   enUS as enUSEthiopic,
 } from "react-day-picker-v9/ethiopic";
-import {
-  enUS as enUSHebrew,
-  he as heHebrew,
-} from "react-day-picker-v9/hebrew";
+import { enUS as enUSHebrew, he as heHebrew } from "react-day-picker-v9/hebrew";
 import {
   arSA as arSAHijri,
   enUS as enUSHijri,

--- a/website/src/components/PlaygroundV9/LocalizationFieldset.tsx
+++ b/website/src/components/PlaygroundV9/LocalizationFieldset.tsx
@@ -1,0 +1,450 @@
+import React from "react";
+
+import {
+  type DayPickerProps,
+  defaultDateLib,
+  type Numerals,
+} from "react-day-picker-v9";
+import {
+  enUS as enUSBuddhist,
+  th as thBuddhist,
+} from "react-day-picker-v9/buddhist";
+import {
+  amET as amETEthiopic,
+  enUS as enUSEthiopic,
+} from "react-day-picker-v9/ethiopic";
+import {
+  enUS as enUSHebrew,
+  he as heHebrew,
+} from "react-day-picker-v9/hebrew";
+import {
+  arSA as arSAHijri,
+  enUS as enUSHijri,
+} from "react-day-picker-v9/hijri";
+import * as locales from "react-day-picker-v9/locale";
+import {
+  enUS as enUSPersian,
+  faIR as faIRPersian,
+} from "react-day-picker-v9/persian";
+
+import styles from "../Playground/styles.module.css";
+import type { DayPickerPropsWithCalendar } from "./useQueryStringSync";
+
+const timeZones = [
+  "UTC",
+  "Africa/Cairo",
+  "Africa/Johannesburg",
+  "Africa/Lagos",
+  "America/Buenos_Aires",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "America/Mexico_City",
+  "America/New_York",
+  "America/Sao_Paulo",
+  "America/Toronto",
+  "America/Vancouver",
+  "Antarctica/Palmer",
+  "Asia/Dubai",
+  "Asia/Hong_Kong",
+  "Asia/Kolkata",
+  "Asia/Saigon",
+  "Asia/Seoul",
+  "Asia/Shanghai",
+  "Asia/Singapore",
+  "Asia/Tokyo",
+  "Australia/Brisbane",
+  "Australia/Melbourne",
+  "Australia/Sydney",
+  "Europe/Berlin",
+  "Europe/London",
+  "Europe/Madrid",
+  "Europe/Moscow",
+  "Europe/Paris",
+  "Europe/Rome",
+  "Pacific/Auckland",
+  "Pacific/Honolulu",
+];
+
+const numerals: { value: Numerals; label: string }[] = [
+  { value: "latn", label: "Latin (Western Arabic)" },
+  { value: "arab", label: "Arabic-Indic" },
+  { value: "arabext", label: "Eastern Arabic-Indic (persian)" },
+  { value: "deva", label: "Devanagari" },
+  { value: "beng", label: "Bengali" },
+  { value: "guru", label: "Gurmukhi" },
+  { value: "gujr", label: "Gujarati" },
+  { value: "orya", label: "Oriya" },
+  { value: "tamldec", label: "Tamil" },
+  { value: "telu", label: "Telugu" },
+  { value: "knda", label: "Kannada" },
+  { value: "mlym", label: "Malayalam" },
+  { value: "geez" as Numerals, label: "Ge'ez (Ethiopic)" },
+  { value: "thai" as Numerals, label: "Thai" },
+  { value: "mymr", label: "Myanmar" },
+  { value: "khmr", label: "Khmer" },
+  { value: "laoo", label: "Lao" },
+  { value: "tibt", label: "Tibetan" },
+];
+const calendars: (
+  | "persian"
+  | "hijri"
+  | "ethiopic"
+  | "buddhist"
+  | "gregorian"
+  | "hebrew"
+)[] = ["gregorian", "persian", "hijri", "ethiopic", "buddhist", "hebrew"];
+const persianLocales = { faIR: faIRPersian, enUS: enUSPersian };
+const hijriLocales = { arSA: arSAHijri, enUS: enUSHijri };
+const ethiopicLocales = { amET: amETEthiopic, enUS: enUSEthiopic };
+const buddhistLocales = { th: thBuddhist, enUS: enUSBuddhist };
+const hebrewLocales = { he: heHebrew, enUS: enUSHebrew };
+
+type CalendarType = NonNullable<DayPickerPropsWithCalendar["calendar"]>;
+
+const allLocales = Object.values(locales) as DayPickerProps["locale"][];
+
+const calendarLocales: Record<CalendarType, DayPickerProps["locale"][]> = {
+  gregorian: allLocales,
+  persian: Object.values(persianLocales),
+  hijri: Object.values(hijriLocales),
+  ethiopic: Object.values(ethiopicLocales),
+  buddhist: Object.values(buddhistLocales),
+  hebrew: Object.values(hebrewLocales),
+};
+
+const calendarDefaults: Partial<
+  Record<
+    CalendarType,
+    {
+      locale?: DayPickerProps["locale"];
+      dir?: DayPickerPropsWithCalendar["dir"];
+      numerals?: Numerals;
+    }
+  >
+> = {
+  persian: { locale: faIRPersian, dir: "rtl" },
+  hijri: { locale: arSAHijri, dir: "rtl", numerals: "arab" as Numerals },
+  ethiopic: { locale: amETEthiopic, numerals: "geez" as Numerals },
+  buddhist: { locale: thBuddhist, numerals: "thai" as Numerals },
+  hebrew: { numerals: "latn" as Numerals },
+};
+
+function getLocalesForCalendar(
+  calendar?: DayPickerPropsWithCalendar["calendar"],
+) {
+  if (!calendar) {
+    return allLocales;
+  }
+  return calendarLocales[calendar as CalendarType] ?? allLocales;
+}
+
+interface LocalizationFieldsetProps {
+  props: DayPickerPropsWithCalendar;
+  setProps: React.Dispatch<React.SetStateAction<DayPickerPropsWithCalendar>>;
+  currentTimeZone: string;
+}
+
+export function LocalizationFieldset({
+  props,
+  setProps,
+  currentTimeZone,
+}: LocalizationFieldsetProps) {
+  const availableLocales = React.useMemo(
+    () => getLocalesForCalendar(props.calendar),
+    [props.calendar],
+  );
+
+  const handleCalendarChange = (
+    event: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
+    const rawValue = event.target.value as CalendarType | "";
+    const calendar = (
+      rawValue === "" ? undefined : rawValue
+    ) as DayPickerPropsWithCalendar["calendar"];
+    const defaults = calendar
+      ? calendarDefaults[calendar as CalendarType]
+      : undefined;
+
+    const nextProps: DayPickerPropsWithCalendar = {
+      ...props,
+      calendar,
+      locale: calendar ? (defaults?.locale ?? undefined) : undefined,
+      dir: calendar ? (defaults?.dir ?? undefined) : undefined,
+    };
+
+    if (defaults?.numerals) {
+      nextProps.numerals = defaults.numerals;
+    }
+
+    setProps(nextProps);
+  };
+
+  const handleLocaleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const { value } = event.target;
+
+    if (!value) {
+      setProps({ ...props, locale: undefined });
+      return;
+    }
+
+    const locale = availableLocales.find((item) => item?.code === value);
+    setProps({ ...props, locale });
+  };
+
+  const handleNumeralsChange = (
+    event: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
+    const { value } = event.target;
+
+    if (!value) {
+      setProps({ ...props, numerals: undefined });
+      return;
+    }
+
+    setProps({ ...props, numerals: value as Numerals });
+  };
+
+  const handleWeekStartsOnChange = (
+    event: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
+    const { value } = event.target;
+    const nextProps: DayPickerPropsWithCalendar = { ...props };
+
+    if (!value) {
+      nextProps.weekStartsOn = undefined;
+    } else {
+      nextProps.weekStartsOn = Number(value) as DayPickerProps["weekStartsOn"];
+    }
+
+    setProps(nextProps);
+  };
+
+  const handleFirstWeekContainsDateChange = (
+    event: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
+    const { value } = event.target;
+    const nextProps: DayPickerPropsWithCalendar = { ...props };
+
+    if (!value) {
+      nextProps.firstWeekContainsDate = undefined;
+    } else {
+      nextProps.firstWeekContainsDate = Number(
+        value,
+      ) as DayPickerProps["firstWeekContainsDate"];
+    }
+
+    setProps(nextProps);
+  };
+
+  const handleDirectionChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const { checked } = event.target;
+    const nextProps: DayPickerPropsWithCalendar = { ...props };
+
+    if (checked) {
+      nextProps.dir = "rtl";
+    } else {
+      nextProps.dir = undefined;
+    }
+
+    setProps(nextProps);
+  };
+
+  const handleBroadcastCalendarChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const { checked } = event.target;
+    const nextProps: DayPickerPropsWithCalendar = {
+      ...props,
+      broadcastCalendar: checked,
+    };
+
+    if (checked) {
+      nextProps.showOutsideDays = true;
+    }
+
+    setProps(nextProps);
+  };
+
+  return (
+    <fieldset>
+      <legend>
+        Localization{" "}
+        <button
+          type="button"
+          onClick={() => {
+            setProps({
+              ...props,
+              calendar: undefined,
+              locale: undefined,
+              timeZone: undefined,
+              noonSafe: undefined,
+              numerals: undefined,
+              weekStartsOn: undefined,
+              firstWeekContainsDate: undefined,
+              ISOWeek: false,
+              dir: undefined,
+              broadcastCalendar: false,
+            });
+          }}
+        >
+          Reset
+        </button>
+      </legend>
+      <div className={styles.fields}>
+        <label>
+          Calendar:
+          <select
+            name="calendar"
+            value={props.calendar ?? ""}
+            onChange={handleCalendarChange}
+          >
+            <option></option>
+            {calendars.map((calendar) => (
+              <option key={calendar} value={calendar}>
+                {calendar}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Time Zone:
+          <select
+            name="timeZone"
+            value={props.timeZone ?? ""}
+            onChange={(e) =>
+              setProps({
+                ...props,
+                timeZone: e.target.value,
+              })
+            }
+          >
+            <option></option>
+            <option value={currentTimeZone}>{currentTimeZone}</option>
+            {timeZones.map((tz) => (
+              <option key={tz} value={tz}>
+                {tz}
+              </option>
+            ))}
+          </select>
+        </label>
+        {props.timeZone ? (
+          <label>
+            <input
+              type="checkbox"
+              name="noonSafe"
+              checked={!!props.noonSafe}
+              onChange={(e) =>
+                setProps({
+                  ...props,
+                  noonSafe: e.target.checked || undefined,
+                })
+              }
+            />
+            Noon-safe date math
+          </label>
+        ) : null}
+        <label>
+          Locale:
+          <select
+            name="locale"
+            value={props.locale?.code ?? ""}
+            onChange={handleLocaleChange}
+          >
+            <option value=""></option>
+            {availableLocales
+              .filter((locale) => locale && typeof locale.code === "string")
+              .map((locale) =>
+                locale ? (
+                  <option key={locale.code} value={locale.code}>
+                    {locale.code}
+                  </option>
+                ) : null,
+              )}
+          </select>
+        </label>
+
+        <label>
+          Numerals:
+          <select
+            style={{ maxWidth: 100 }}
+            name="numerals"
+            value={props.numerals ?? ""}
+            onChange={handleNumeralsChange}
+          >
+            <option></option>
+            {numerals.map((numeral) => (
+              <option key={numeral.value} value={numeral.value}>
+                {numeral.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          Weeks start on:
+          <select
+            name="weekStartsOn"
+            disabled={props.broadcastCalendar || props.ISOWeek}
+            value={props.weekStartsOn ?? ""}
+            onChange={handleWeekStartsOnChange}
+          >
+            <option></option>
+            {[...Array(7).keys()].map((day) => (
+              <option key={day} value={day}>
+                {defaultDateLib.format(new Date(2021, 0, day + 3), "EEEE")}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          First week contains:
+          <select
+            disabled={props.broadcastCalendar || props.ISOWeek}
+            name="firstWeekContainsDate"
+            value={props.firstWeekContainsDate ?? ""}
+            onChange={handleFirstWeekContainsDateChange}
+          >
+            <option></option>
+            {[1, 4].map((day) => (
+              <option key={day} value={day}>
+                {defaultDateLib.format(new Date(2021, 0, day), "EEEE")}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            name="ISOWeek"
+            checked={props.ISOWeek}
+            disabled={props.broadcastCalendar}
+            onChange={(e) => setProps({ ...props, ISOWeek: e.target.checked })}
+          />
+          ISO Week
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            name="rtl"
+            checked={props.dir === "rtl"}
+            onChange={handleDirectionChange}
+          />
+          Right-to-left Direction
+        </label>
+
+        <label>
+          <input
+            type="checkbox"
+            name="broadcastCalendar"
+            checked={props.broadcastCalendar}
+            onChange={handleBroadcastCalendarChange}
+          />
+          Broadcast Weeks
+        </label>
+      </div>
+    </fieldset>
+  );
+}

--- a/website/src/components/PlaygroundV9/NavigationFieldset.tsx
+++ b/website/src/components/PlaygroundV9/NavigationFieldset.tsx
@@ -1,0 +1,363 @@
+import { startOfMonth } from "date-fns";
+import React from "react";
+import type { DayPickerProps } from "react-day-picker-v9";
+
+import styles from "../Playground/styles.module.css";
+
+interface NavigationFieldsetProps {
+  props: DayPickerProps;
+  setProps: React.Dispatch<React.SetStateAction<DayPickerProps>>;
+}
+
+export function NavigationFieldset({
+  props,
+  setProps,
+}: NavigationFieldsetProps) {
+  return (
+    <fieldset>
+      <legend>
+        Navigation{" "}
+        <button
+          type="button"
+          onClick={() =>
+            setProps({
+              ...props,
+              animate: false,
+              month: undefined,
+              startMonth: undefined,
+              endMonth: undefined,
+              hideNavigation: false,
+              disableNavigation: false,
+              numberOfMonths: undefined,
+              reverseMonths: false,
+              pagedNavigation: false,
+            })
+          }
+        >
+          Reset
+        </button>
+      </legend>
+
+      <div className={styles.fields}>
+        <label>
+          Number of months:
+          <input
+            type="number"
+            min={1}
+            max={12}
+            size={4}
+            value={props.numberOfMonths ?? ""}
+            name="numberOfMonths"
+            onChange={(e) => {
+              const value = e.target.value;
+              setProps({
+                ...props,
+                numberOfMonths:
+                  value === "" ? undefined : Math.max(1, Number(value)),
+              });
+            }}
+          />
+        </label>
+
+        {props.numberOfMonths !== undefined && props.numberOfMonths > 1 && (
+          <label>
+            <input
+              type="checkbox"
+              name="reverseMonths"
+              checked={props.reverseMonths}
+              onChange={(e) =>
+                setProps({
+                  ...props,
+                  reverseMonths: e.target.checked,
+                })
+              }
+            />
+            Reverse Months
+          </label>
+        )}
+        {props.numberOfMonths !== undefined && props.numberOfMonths > 1 && (
+          <label>
+            <input
+              type="checkbox"
+              name="pagedNavigation"
+              checked={props.pagedNavigation}
+              onChange={(e) =>
+                setProps({
+                  ...props,
+                  pagedNavigation: e.target.checked,
+                })
+              }
+            />
+            Paged Navigation
+          </label>
+        )}
+        <label>
+          <input
+            type="checkbox"
+            name="animate"
+            checked={props.animate}
+            onChange={(e) => setProps({ ...props, animate: e.target.checked })}
+          />
+          Animate
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            name="hideNavigation"
+            checked={props.hideNavigation}
+            onChange={(e) =>
+              setProps({ ...props, hideNavigation: e.target.checked })
+            }
+          />
+          Hide Navigation
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            name="disableNavigation"
+            checked={props.disableNavigation}
+            onChange={(e) =>
+              setProps({ ...props, disableNavigation: e.target.checked })
+            }
+          />
+          Disable Navigation
+        </label>
+        <hr
+          style={{
+            borderTop: "1px solid var(--ifm-color-emphasis-200)",
+            marginBottom: "1rem",
+            marginTop: "1rem",
+          }}
+        />
+        <label>
+          Month:
+          <div>
+            <input
+              type="number"
+              min={1}
+              max={12}
+              value={props.month ? new Date(props.month).getMonth() + 1 : ""}
+              name="month"
+              onChange={(e) => {
+                if (e.target.value === "") {
+                  setProps({
+                    ...props,
+                    month: undefined,
+                    startMonth: undefined,
+                    endMonth: undefined,
+                  });
+                  return;
+                }
+                const newMonth = Number(e.target.value) - 1;
+                const newDate = props.month
+                  ? new Date(props.month)
+                  : new Date();
+                newDate.setMonth(newMonth);
+                const newMonthDate = startOfMonth(newDate);
+                setProps({
+                  ...props,
+                  month: newMonthDate,
+                  startMonth: undefined,
+                  endMonth: undefined,
+                });
+              }}
+            />
+
+            <input
+              type="number"
+              min={1900}
+              max={2100}
+              value={props.month ? new Date(props.month).getFullYear() : ""}
+              name="year"
+              onChange={(e) => {
+                if (e.target.value === "") {
+                  setProps({
+                    ...props,
+                    month: undefined,
+                    startMonth: undefined,
+                    endMonth: undefined,
+                  });
+                  return;
+                }
+                const newYear = Number(e.target.value);
+                const newDate = props.month
+                  ? new Date(props.month)
+                  : new Date();
+                newDate.setFullYear(newYear);
+                const newMonthDate = startOfMonth(newDate);
+                setProps({
+                  ...props,
+                  month: newMonthDate,
+                  startMonth: undefined,
+                  endMonth: undefined,
+                });
+              }}
+            />
+          </div>
+        </label>
+        <label>
+          Start month:
+          <div>
+            <input
+              type="number"
+              min={1}
+              max={12}
+              value={
+                props.startMonth
+                  ? new Date(props.startMonth).getMonth() + 1
+                  : ""
+              }
+              name="startMonthMonth"
+              onChange={(e) => {
+                if (e.target.value === "") {
+                  setProps({
+                    ...props,
+                    startMonth: undefined,
+                    month: props.month,
+                  });
+                  return;
+                }
+                const newMonth = Number(e.target.value) - 1;
+                const newDate = props.startMonth
+                  ? new Date(props.startMonth)
+                  : new Date();
+                newDate.setMonth(newMonth);
+                const newStartMonth = startOfMonth(newDate);
+                setProps({
+                  ...props,
+                  startMonth: newStartMonth,
+                  endMonth:
+                    props.endMonth && newStartMonth > new Date(props.endMonth)
+                      ? undefined
+                      : props.endMonth,
+                  month:
+                    props.month && new Date(props.month) < newStartMonth
+                      ? newStartMonth
+                      : (props.month ?? newStartMonth),
+                });
+              }}
+            />
+
+            <input
+              type="number"
+              min={1900}
+              max={2100}
+              value={
+                props.startMonth ? new Date(props.startMonth).getFullYear() : ""
+              }
+              name="startMonthYear"
+              onChange={(e) => {
+                if (e.target.value === "") {
+                  setProps({
+                    ...props,
+                    startMonth: undefined,
+                    month: props.month,
+                  });
+                  return;
+                }
+                const newYear = Number(e.target.value);
+                const newDate = props.startMonth
+                  ? new Date(props.startMonth)
+                  : new Date();
+                newDate.setFullYear(newYear);
+                const newStartMonth = startOfMonth(newDate);
+                setProps({
+                  ...props,
+                  startMonth: newStartMonth,
+                  endMonth:
+                    props.endMonth && newStartMonth > new Date(props.endMonth)
+                      ? undefined
+                      : props.endMonth,
+                  month:
+                    props.month && new Date(props.month) < newStartMonth
+                      ? newStartMonth
+                      : (props.month ?? newStartMonth),
+                });
+              }}
+            />
+          </div>
+        </label>
+        <label>
+          End month:
+          <div>
+            <input
+              type="number"
+              min={1}
+              max={12}
+              value={
+                props.endMonth ? new Date(props.endMonth).getMonth() + 1 : ""
+              }
+              name="endMonthMonth"
+              onChange={(e) => {
+                if (e.target.value === "") {
+                  setProps({
+                    ...props,
+                    endMonth: undefined,
+                    month: props.month,
+                  });
+                  return;
+                }
+                const newMonth = Number(e.target.value) - 1;
+                const newDate = props.endMonth
+                  ? new Date(props.endMonth)
+                  : new Date();
+                newDate.setMonth(newMonth);
+                const newEndMonth = startOfMonth(newDate);
+                setProps({
+                  ...props,
+                  endMonth: newEndMonth,
+                  startMonth:
+                    props.startMonth && newEndMonth < new Date(props.startMonth)
+                      ? undefined
+                      : props.startMonth,
+                  month:
+                    props.month && new Date(props.month) > newEndMonth
+                      ? newEndMonth
+                      : props.month,
+                });
+              }}
+            />
+
+            <input
+              type="number"
+              min={1900}
+              max={2100}
+              value={
+                props.endMonth ? new Date(props.endMonth).getFullYear() : ""
+              }
+              name="endMonthYear"
+              onChange={(e) => {
+                if (e.target.value === "") {
+                  setProps({
+                    ...props,
+                    endMonth: undefined,
+                    month: props.month,
+                  });
+                  return;
+                }
+                const newYear = Number(e.target.value);
+                const newDate = props.endMonth
+                  ? new Date(props.endMonth)
+                  : new Date();
+                newDate.setFullYear(newYear);
+                const newEndMonth = startOfMonth(newDate);
+                setProps({
+                  ...props,
+                  endMonth: newEndMonth,
+                  startMonth:
+                    props.startMonth && newEndMonth < new Date(props.startMonth)
+                      ? undefined
+                      : props.startMonth,
+                  month:
+                    props.month && new Date(props.month) > newEndMonth
+                      ? newEndMonth
+                      : props.month,
+                });
+              }}
+            />
+          </div>
+        </label>
+      </div>
+    </fieldset>
+  );
+}

--- a/website/src/components/PlaygroundV9/SelectionFieldset.tsx
+++ b/website/src/components/PlaygroundV9/SelectionFieldset.tsx
@@ -1,0 +1,166 @@
+import React from "react";
+
+import type { DateRange, DayPickerProps } from "react-day-picker-v9";
+
+import styles from "../Playground/styles.module.css";
+
+interface SelectionFieldsetProps {
+  props: DayPickerProps;
+  setProps: React.Dispatch<React.SetStateAction<DayPickerProps>>;
+  selected: Date | Date[] | DateRange | undefined;
+  setSelected: React.Dispatch<
+    React.SetStateAction<Date | Date[] | DateRange | undefined>
+  >;
+  backgroundAccentColor: string;
+  setBackgroundAccentColor: React.Dispatch<React.SetStateAction<string>>;
+  rangeMiddleColor: string | undefined;
+  setRangeMiddleColor: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export function SelectionFieldset({
+  props,
+  setProps,
+  setSelected,
+  backgroundAccentColor,
+  setBackgroundAccentColor,
+  rangeMiddleColor,
+  setRangeMiddleColor,
+}: SelectionFieldsetProps) {
+  return (
+    <fieldset>
+      <legend>
+        Selection{" "}
+        <button
+          type="button"
+          onClick={() => {
+            setSelected(undefined);
+            setProps({
+              ...props,
+              // @ts-expect-error Not working well with the union type
+              mode: undefined,
+              // @ts-expect-error Not working well with the union type
+              required: undefined,
+              min: undefined,
+              max: undefined,
+              selected: undefined,
+            });
+            setBackgroundAccentColor("");
+            setRangeMiddleColor("");
+          }}
+        >
+          Reset
+        </button>
+      </legend>
+      <div className={styles.fields}>
+        <label>
+          Selection mode:
+          <select
+            name="mode"
+            value={props.mode ?? ""}
+            onChange={(e) => {
+              const mode = e.target.value || undefined;
+              const newProps = {
+                ...props,
+                mode,
+              };
+              setSelected(undefined);
+              // @ts-expect-error Not working well with the union type
+              setProps(newProps);
+            }}
+          >
+            <option></option>
+            <option value="single">single</option>
+            <option value="multiple">multiple</option>
+            <option value="range">range</option>
+          </select>
+        </label>
+        {props.mode && (
+          <label>
+            <input
+              type="checkbox"
+              checked={props.required}
+              name="required"
+              onChange={(e) => {
+                setSelected(undefined);
+                // @ts-expect-error abc
+                setProps({ ...props, required: e.target.checked });
+              }}
+            />
+            Required
+          </label>
+        )}
+        {props.mode === "range" && (
+          <label>
+            <input
+              type="checkbox"
+              checked={props.resetOnSelect}
+              name="resetOnSelect"
+              onChange={(e) => {
+                setProps({ ...props, resetOnSelect: e.target.checked });
+              }}
+            />
+            Reset range on select
+          </label>
+        )}
+        {props.mode === "range" || props.mode === "multiple" ? (
+          <label>
+            Min Selection:
+            <input
+              type="number"
+              min={0}
+              max={12}
+              size={4}
+              name="min"
+              value={props.min ?? ""}
+              onChange={(e) => {
+                setProps({
+                  ...props,
+                  min: Number(e.target.value),
+                });
+              }}
+            />
+          </label>
+        ) : null}
+        {props.mode === "range" || props.mode === "multiple" ? (
+          <label>
+            Max Selection:
+            <input
+              type="number"
+              min={0}
+              max={12}
+              size={4}
+              name="max"
+              value={props.max ?? ""}
+              onChange={(e) => {
+                setProps({
+                  ...props,
+                  max: Number(e.target.value),
+                });
+              }}
+            />
+          </label>
+        ) : null}
+        {props.mode === "range" && (
+          <>
+            <label>
+              Range Background:
+              <input
+                value={backgroundAccentColor ?? ""}
+                type="color"
+                onChange={(e) => setBackgroundAccentColor(e.target.value)}
+              />
+            </label>
+            <label>
+              Range Foreground:
+              <input
+                value={rangeMiddleColor ?? ""}
+                type="color"
+                onChange={(e) => setRangeMiddleColor(e.target.value)}
+              />
+            </label>
+          </>
+        )}
+      </div>
+    </fieldset>
+  );
+}

--- a/website/src/components/PlaygroundV9/index.tsx
+++ b/website/src/components/PlaygroundV9/index.tsx
@@ -39,12 +39,12 @@ import {
 } from "react-day-picker-v9/persian";
 import { BrowserWindow } from "../BrowserWindow";
 import { HighlightWithTheme } from "../HighlightWithTheme";
+import { toJSX } from "../Playground/shared/toJSX";
+import styles from "../Playground/styles.module.css";
 import { CustomizationFieldset } from "./CustomizationFieldset";
 import { LocalizationFieldset } from "./LocalizationFieldset";
 import { NavigationFieldset } from "./NavigationFieldset";
 import { SelectionFieldset } from "./SelectionFieldset";
-import styles from "../Playground/styles.module.css";
-import { toJSX } from "../Playground/shared/toJSX";
 import { useQueryStringSync } from "./useQueryStringSync";
 
 const localeImportsByCalendar = {

--- a/website/src/components/PlaygroundV9/index.tsx
+++ b/website/src/components/PlaygroundV9/index.tsx
@@ -1,49 +1,50 @@
+import dayPickerStyleCss from "!raw-loader!react-day-picker-v9/src/style.css";
 import React from "react";
 import {
   DateLib,
   type DateRange,
   DayPicker,
   isDateRange,
-} from "react-day-picker";
+} from "react-day-picker-v9";
 import {
   DayPicker as DayPickerBuddhist,
   enUS as enUSBuddhist,
   getDateLib as getDateLibBuddhist,
   th as thBuddhist,
-} from "react-day-picker/buddhist";
+} from "react-day-picker-v9/buddhist";
 import {
   amET as amETEthiopic,
   DayPicker as DayPickerEthiopic,
   enUS as enUSEthiopic,
   getDateLib as getDateLibEthiopic,
-} from "react-day-picker/ethiopic";
+} from "react-day-picker-v9/ethiopic";
 import {
   DayPicker as DayPickerHebrew,
   enUS as enUSHebrew,
   getDateLib as getDateLibHebrew,
   he as heHebrew,
-} from "react-day-picker/hebrew";
+} from "react-day-picker-v9/hebrew";
 import {
   arSA as arSAHijri,
   DayPicker as DayPickerHijri,
   enUS as enUSHijri,
   getDateLib as getDateLibHijri,
-} from "react-day-picker/hijri";
-import * as locales from "react-day-picker/locale";
+} from "react-day-picker-v9/hijri";
+import * as locales from "react-day-picker-v9/locale";
 import {
   DayPicker as DayPickerPersian,
   enUS as enUSPersian,
   faIR as faIRpersian,
   getDateLib as getDateLibPersian,
-} from "react-day-picker/persian";
+} from "react-day-picker-v9/persian";
 import { BrowserWindow } from "../BrowserWindow";
 import { HighlightWithTheme } from "../HighlightWithTheme";
 import { CustomizationFieldset } from "./CustomizationFieldset";
 import { LocalizationFieldset } from "./LocalizationFieldset";
 import { NavigationFieldset } from "./NavigationFieldset";
 import { SelectionFieldset } from "./SelectionFieldset";
-import styles from "./styles.module.css";
-import { toJSX } from "./shared/toJSX";
+import styles from "../Playground/styles.module.css";
+import { toJSX } from "../Playground/shared/toJSX";
 import { useQueryStringSync } from "./useQueryStringSync";
 
 const localeImportsByCalendar = {
@@ -210,6 +211,7 @@ export function Playground({ basePath = "/playground" }: PlaygroundProps) {
       </form>
       <div className={styles.browserWindow}>
         <BrowserWindow
+          baseStyleCss={dayPickerStyleCss.toString()}
           url=""
           styleStr={`
           .rdp-root,

--- a/website/src/components/PlaygroundV9/useQueryStringSync.ts
+++ b/website/src/components/PlaygroundV9/useQueryStringSync.ts
@@ -1,11 +1,11 @@
 import { useHistory, useLocation } from "@docusaurus/router";
 import { useEffect, useMemo, useState } from "react";
-import type { DayPickerProps } from "react-day-picker";
-import * as locales from "react-day-picker/locale";
+import type { DayPickerProps } from "react-day-picker-v9";
+import * as locales from "react-day-picker-v9/locale";
 import {
   buildPlaygroundQueryString,
   parsePlaygroundSearch,
-} from "./shared/queryString";
+} from "../Playground/shared/queryString";
 
 export type DayPickerPropsWithCalendar = DayPickerProps & {
   calendar?:

--- a/website/src/components/ShadowDomWrapper.tsx
+++ b/website/src/components/ShadowDomWrapper.tsx
@@ -3,9 +3,11 @@ import { useColorMode } from "@docusaurus/theme-common";
 import root from "react-shadow";
 
 export function ShadowDomWrapper({
+  baseStyleCss,
   children,
   styleStr,
 }: {
+  baseStyleCss?: string;
   children: React.ReactNode;
   styleStr: string | undefined;
 }) {
@@ -13,7 +15,7 @@ export function ShadowDomWrapper({
   return (
     <root.div>
       {children}
-      <style>{style.toString()}</style>
+      <style>{baseStyleCss ?? style.toString()}</style>
       <style>{`
         .rdp-root {
           --rdp-accent-color: var(--ifm-color-primary);

--- a/website/src/pages/playground.tsx
+++ b/website/src/pages/playground.tsx
@@ -1,7 +1,7 @@
 import Head from "@docusaurus/Head";
 import Layout from "@theme/Layout";
 
-import { Playground } from "../components/Playground";
+import { Playground } from "../components/PlaygroundV9";
 
 export default function playground() {
   return (


### PR DESCRIPTION
## Summary
- add a dedicated `PlaygroundV9` implementation for `/playground` while keeping `/next/playground` on the workspace package
- let the browser preview inject version-specific DayPicker CSS so the stable playground renders with v9 styles inside the shadow root
- share the low-risk playground helpers for query-string parsing and JSX formatting under `Playground/shared`

## Why
The docs site had two playground routes, but both were effectively running the workspace package. This split keeps the stable playground aligned with `react-day-picker-v9` without hiding real differences from the next playground.

## Validation
- `pnpm --dir website typecheck`
- `pnpm --dir website build`
