### PR TITLE
fix: keep shadcn smoke app dropdowns clickable

### DIFF
--- a/shadcn-app-v9/src/components/ui/calendar.tsx
+++ b/shadcn-app-v9/src/components/ui/calendar.tsx
@@ -36,17 +36,17 @@ function Calendar({
     ),
     month: cn("flex w-full flex-col gap-4", defaultClassNames.month),
     nav: cn(
-      "absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1",
+      "pointer-events-none absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1",
       defaultClassNames.nav,
     ),
     button_previous: cn(
       buttonVariants({ variant: buttonVariant }),
-      "size-(--cell-size) select-none p-0 aria-disabled:opacity-50",
+      "pointer-events-auto size-(--cell-size) select-none p-0 aria-disabled:opacity-50",
       defaultClassNames.button_previous,
     ),
     button_next: cn(
       buttonVariants({ variant: buttonVariant }),
-      "size-(--cell-size) select-none p-0 aria-disabled:opacity-50",
+      "pointer-events-auto size-(--cell-size) select-none p-0 aria-disabled:opacity-50",
       defaultClassNames.button_next,
     ),
     month_caption: cn(
@@ -119,6 +119,7 @@ function Calendar({
 
   return (
     <DayPicker
+      navLayout="after"
       showOutsideDays={showOutsideDays}
       className={cn(
         "group/calendar bg-background p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",

--- a/shadcn-app-workspace/src/components/ui/calendar.tsx
+++ b/shadcn-app-workspace/src/components/ui/calendar.tsx
@@ -36,17 +36,17 @@ function Calendar({
     ),
     month: cn("flex w-full flex-col gap-4", defaultClassNames.month),
     nav: cn(
-      "absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1",
+      "pointer-events-none absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1",
       defaultClassNames.nav,
     ),
     button_previous: cn(
       buttonVariants({ variant: buttonVariant }),
-      "size-(--cell-size) select-none p-0 aria-disabled:opacity-50",
+      "pointer-events-auto size-(--cell-size) select-none p-0 aria-disabled:opacity-50",
       defaultClassNames.button_previous,
     ),
     button_next: cn(
       buttonVariants({ variant: buttonVariant }),
-      "size-(--cell-size) select-none p-0 aria-disabled:opacity-50",
+      "pointer-events-auto size-(--cell-size) select-none p-0 aria-disabled:opacity-50",
       defaultClassNames.button_next,
     ),
     month_caption: cn(
@@ -119,6 +119,7 @@ function Calendar({
 
   return (
     <DayPicker
+      navLayout="after"
       showOutsideDays={showOutsideDays}
       className={cn(
         "group/calendar bg-background p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",


### PR DESCRIPTION
## Summary
- make the overlaid shadcn nav ignore pointer events except on the actual previous/next buttons
- set `navLayout="after"` in both smoke-test calendar copies so they exercise the v10 navigation layout
- keep the two shadcn smoke apps aligned while fixing the dropdown hit-testing issue

## Why
The smoke-test apps added in #2934 surfaced a compatibility issue with the current shadcn calendar implementation.

In v10, `navLayout="after"` becomes the default. With the current shadcn calendar styling, the navigation is rendered as an absolute full-width overlay. That causes the nav layer to intercept clicks meant for the month/year dropdown selects.

This PR applies the shadcn-side workaround we validated locally:
- the nav container uses `pointer-events-none`
- the previous/next buttons use `pointer-events-auto`

That keeps the buttons clickable while allowing the dropdown selects underneath to keep receiving pointer events.

## Notes
- the fix is applied to both smoke-test apps
- `shadcn-app-workspace` continues to use the workspace package
- `shadcn-app-v9` continues to use `react-day-picker@9.14.0`
- the explicit `navLayout="after"` keeps both apps exercising the layout that v10 will use by default

## Before

The selects cannot be opened on v10:

https://github.com/user-attachments/assets/ea8f5024-a54e-475a-b673-d1d926f7697c

## After

Selects can be opened: 

https://github.com/user-attachments/assets/52c53725-c67f-404a-ab05-ae87d4a4100a

