### PR TITLE
docs: add addon package readmes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2025 Giampaolo Bellavite <io@gpbl.dev> and contributors
+Copyright (c) 2014-2026 Giampaolo Bellavite <io@gpbl.dev> and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/buddhist/LICENSE
+++ b/packages/buddhist/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2025 Giampaolo Bellavite <io@gpbl.dev> and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/buddhist/LICENSE
+++ b/packages/buddhist/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2025 Giampaolo Bellavite <io@gpbl.dev> and contributors
+Copyright (c) 2014-2026 Giampaolo Bellavite <io@gpbl.dev> and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/buddhist/README.md
+++ b/packages/buddhist/README.md
@@ -1,0 +1,42 @@
+# @daypicker/buddhist
+
+Buddhist calendar support for [React DayPicker](https://daypicker.dev).
+
+This package renders DayPicker with Buddhist Era years. The calendar keeps
+Gregorian months and weeks, displays years as BE (`CE + 543`), and uses Thai
+digits by default.
+
+## Installation
+
+```bash
+npm install react-day-picker @daypicker/buddhist
+```
+
+## Usage
+
+```tsx
+import { DayPicker } from "@daypicker/buddhist";
+import "react-day-picker/style.css";
+
+export function BuddhistCalendar() {
+  return <DayPicker mode="single" />;
+}
+```
+
+The package also exports the `th` and `enUS` locales, plus `getDateLib` for
+advanced date-library customization.
+
+## Peer Dependencies
+
+`@daypicker/buddhist` is an add-on for `react-day-picker`. Your app must also
+install `react` and `react-day-picker`.
+
+## Documentation
+
+- [Buddhist calendar guide](https://daypicker.dev/localization/buddhist)
+- [React DayPicker documentation](https://daypicker.dev)
+- [Issues and support](https://github.com/gpbl/react-day-picker/issues)
+
+## License
+
+MIT. See [LICENSE](./LICENSE).

--- a/packages/ethiopic/LICENSE
+++ b/packages/ethiopic/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2025 Giampaolo Bellavite <io@gpbl.dev> and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/ethiopic/LICENSE
+++ b/packages/ethiopic/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2025 Giampaolo Bellavite <io@gpbl.dev> and contributors
+Copyright (c) 2014-2026 Giampaolo Bellavite <io@gpbl.dev> and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/ethiopic/README.md
+++ b/packages/ethiopic/README.md
@@ -1,0 +1,41 @@
+# @daypicker/ethiopic
+
+Ethiopic calendar support for [React DayPicker](https://daypicker.dev).
+
+This package renders DayPicker with Ethiopic calendar month and year logic. It
+uses the Amharic locale and Ethiopic numerals by default.
+
+## Installation
+
+```bash
+npm install react-day-picker @daypicker/ethiopic
+```
+
+## Usage
+
+```tsx
+import { DayPicker } from "@daypicker/ethiopic";
+import "react-day-picker/style.css";
+
+export function EthiopicCalendar() {
+  return <DayPicker mode="single" />;
+}
+```
+
+The package also exports the `amET` and `enUS` locales, plus `getDateLib` for
+advanced date-library customization.
+
+## Peer Dependencies
+
+`@daypicker/ethiopic` is an add-on for `react-day-picker`. Your app must also
+install `react` and `react-day-picker`.
+
+## Documentation
+
+- [Ethiopic calendar guide](https://daypicker.dev/localization/ethiopic)
+- [React DayPicker documentation](https://daypicker.dev)
+- [Issues and support](https://github.com/gpbl/react-day-picker/issues)
+
+## License
+
+MIT. See [LICENSE](./LICENSE).

--- a/packages/hebrew/LICENSE
+++ b/packages/hebrew/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2025 Giampaolo Bellavite <io@gpbl.dev> and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/hebrew/LICENSE
+++ b/packages/hebrew/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2025 Giampaolo Bellavite <io@gpbl.dev> and contributors
+Copyright (c) 2014-2026 Giampaolo Bellavite <io@gpbl.dev> and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/hebrew/README.md
+++ b/packages/hebrew/README.md
@@ -1,0 +1,42 @@
+# @daypicker/hebrew
+
+Hebrew calendar support for [React DayPicker](https://daypicker.dev).
+
+This package renders DayPicker with Hebrew lunisolar calendar month and year
+logic, including leap years with Adar I and Adar II. It uses the Hebrew locale
+and right-to-left direction by default.
+
+## Installation
+
+```bash
+npm install react-day-picker @daypicker/hebrew
+```
+
+## Usage
+
+```tsx
+import { DayPicker } from "@daypicker/hebrew";
+import "react-day-picker/style.css";
+
+export function HebrewCalendar() {
+  return <DayPicker mode="single" />;
+}
+```
+
+The package also exports the `he` and `enUS` locales, plus `getDateLib` for
+advanced date-library customization.
+
+## Peer Dependencies
+
+`@daypicker/hebrew` is an add-on for `react-day-picker`. Your app must also
+install `react` and `react-day-picker`.
+
+## Documentation
+
+- [Hebrew calendar guide](https://daypicker.dev/localization/hebrew)
+- [React DayPicker documentation](https://daypicker.dev)
+- [Issues and support](https://github.com/gpbl/react-day-picker/issues)
+
+## License
+
+MIT. See [LICENSE](./LICENSE).

--- a/packages/hijri/LICENSE
+++ b/packages/hijri/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2025 Giampaolo Bellavite <io@gpbl.dev> and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/hijri/LICENSE
+++ b/packages/hijri/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2025 Giampaolo Bellavite <io@gpbl.dev> and contributors
+Copyright (c) 2014-2026 Giampaolo Bellavite <io@gpbl.dev> and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/hijri/README.md
+++ b/packages/hijri/README.md
@@ -1,0 +1,42 @@
+# @daypicker/hijri
+
+Hijri calendar support for [React DayPicker](https://daypicker.dev).
+
+This package renders DayPicker with Umm al-Qura Hijri calendar month and year
+logic. It uses the Arabic Saudi Arabia locale, Arabic-Indic numerals, and
+right-to-left direction by default.
+
+## Installation
+
+```bash
+npm install react-day-picker @daypicker/hijri
+```
+
+## Usage
+
+```tsx
+import { DayPicker } from "@daypicker/hijri";
+import "react-day-picker/style.css";
+
+export function HijriCalendar() {
+  return <DayPicker mode="single" />;
+}
+```
+
+The package also exports the `arSA` and `enUS` locales, plus `getDateLib` for
+advanced date-library customization.
+
+## Peer Dependencies
+
+`@daypicker/hijri` is an add-on for `react-day-picker`. Your app must also
+install `react` and `react-day-picker`.
+
+## Documentation
+
+- [Hijri calendar guide](https://daypicker.dev/localization/hijri)
+- [React DayPicker documentation](https://daypicker.dev)
+- [Issues and support](https://github.com/gpbl/react-day-picker/issues)
+
+## License
+
+MIT. See [LICENSE](./LICENSE).

--- a/packages/persian/LICENSE
+++ b/packages/persian/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2025 Giampaolo Bellavite <io@gpbl.dev> and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/persian/LICENSE
+++ b/packages/persian/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2025 Giampaolo Bellavite <io@gpbl.dev> and contributors
+Copyright (c) 2014-2026 Giampaolo Bellavite <io@gpbl.dev> and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/persian/README.md
+++ b/packages/persian/README.md
@@ -1,0 +1,42 @@
+# @daypicker/persian
+
+Persian calendar support for [React DayPicker](https://daypicker.dev).
+
+This package renders DayPicker with Jalali calendar month and year logic. It
+uses the Persian Iran locale, Eastern Arabic-Indic numerals, and right-to-left
+direction by default.
+
+## Installation
+
+```bash
+npm install react-day-picker @daypicker/persian
+```
+
+## Usage
+
+```tsx
+import { DayPicker } from "@daypicker/persian";
+import "react-day-picker/style.css";
+
+export function PersianCalendar() {
+  return <DayPicker mode="single" />;
+}
+```
+
+The package also exports the `faIR`, `enUS`, `faIRJalali`, and `enUSJalali`
+locales, plus `getDateLib` for advanced date-library customization.
+
+## Peer Dependencies
+
+`@daypicker/persian` is an add-on for `react-day-picker`. Your app must also
+install `react` and `react-day-picker`.
+
+## Documentation
+
+- [Persian calendar guide](https://daypicker.dev/localization/persian)
+- [React DayPicker documentation](https://daypicker.dev)
+- [Issues and support](https://github.com/gpbl/react-day-picker/issues)
+
+## License
+
+MIT. See [LICENSE](./LICENSE).

--- a/packages/react-day-picker/LICENSE
+++ b/packages/react-day-picker/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2025 Giampaolo Bellavite <io@gpbl.dev> and contributors
+Copyright (c) 2014-2026 Giampaolo Bellavite <io@gpbl.dev> and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR adds package-local README and LICENSE files for the `@daypicker/*` add-on packages.

The add-ons are separate npm packages now, so their npm pages and tarballs should include the basic context a consumer expects: what the package does, how to install it with `react-day-picker`, a minimal import example, peer dependency notes, docs/support links, and the license text.

There are no runtime, export, dependency, or build-output changes.

## What Changed

- Added `README.md` to the Buddhist, Ethiopic, Hebrew, Hijri, and Persian add-on packages.
- Added a package-local MIT `LICENSE` file to each add-on package.
- Left each package manifest, `files` list, and public entrypoint unchanged.

## Review Notes

This should be package documentation only. Please focus review on:

- The usage examples matching each add-on package export.
- Peer dependency wording staying aligned with the package manifests.
- `npm pack` including `README.md` and `LICENSE` automatically without changing the `files` lists.