### PR TITLE
build: upgrade workflow actions for node 24

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -23,9 +23,9 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -36,9 +36,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -49,9 +49,9 @@ jobs:
     needs: [lint, typecheck]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -62,9 +62,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -81,9 +81,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,16 +33,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org/
-          always-auth: false
       - run: pnpm install --frozen-lockfile
 
       - name: Create release pull request or mark publishable release
@@ -57,16 +56,10 @@ jobs:
           createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EXPECTED_PR_AUTHOR: github-actions[bot]
-          EXPECTED_BASE_BRANCH: main
-          EXPECTED_PR_BRANCH: changesets-release/main
 
       - name: Recover release for a merged release PR commit
         if: github.event_name == 'workflow_dispatch'
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EXPECTED_PR_AUTHOR: github-actions[bot]
-          EXPECTED_BASE_BRANCH: main
-          EXPECTED_PR_BRANCH: changesets-release/main
         run: pnpm release:ci

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -17,9 +17,9 @@ jobs:
   build-react-day-picker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -34,9 +34,9 @@ jobs:
     needs: [build-react-day-picker]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -51,9 +51,9 @@ jobs:
     needs: [build-react-day-picker]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
GitHub is warning that several workflow actions in this repo still run on the deprecated Node 20 JavaScript action runtime. This updates the workflow action majors so the repo is on supported Node 24-compatible releases before GitHub flips the default runtime.

## What Changed
- upgraded `actions/checkout` to `v6`, `actions/setup-node` to `v6`, and `pnpm/action-setup` to `v5` in the main CI workflow
- applied the same action upgrades to the release and website workflows so the repo is consistent
- removed stale `always-auth` and `EXPECTED_*` workflow env configuration from `release.yml` now that the current release scripts do not use it

## Review Notes
- the intent here is workflow-runtime maintenance only; package build, test, and release behavior should stay the same
- `actions/setup-node@v6` removed the deprecated `always-auth` input, so this PR also drops that no-op config from the release workflow
- I could not run `actionlint` locally because it is not installed in this repo, so the main validation for syntax will come from GitHub Actions on the PR