### PR TITLE
build: convert repo utility scripts to typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "typecheck": "pnpm typecheck:root && pnpm typecheck:packages",
     "typecheck:root": "tsc --project ./tsconfig.json --noEmit",
     "typecheck:packages": "pnpm -r --filter \"@daypicker/*\" typecheck && pnpm --filter react-day-picker typecheck",
-    "check:versions": "node ./scripts/check-package-versions.mjs",
-    "pack:dry-run": "node ./scripts/npm-pack-dry-run.mjs",
-    "release:ci": "pnpm exec tsx ./scripts/release-ci.ts",
+    "check:versions": "node --import tsx ./scripts/check-package-versions.ts",
+    "pack:dry-run": "node --import tsx ./scripts/npm-pack-dry-run.ts",
+    "release:ci": "node --import tsx ./scripts/release-ci.ts",
     "typecheck-watch": "tsc --project ./tsconfig.json --noEmit --watch"
   },
   "devDependencies": {

--- a/scripts/check-package-versions.ts
+++ b/scripts/check-package-versions.ts
@@ -10,16 +10,20 @@ const packagePaths = [
   "packages/hebrew/package.json",
   "packages/hijri/package.json",
   "packages/persian/package.json",
-];
+] as const;
 
-function readPackageJson(packagePath) {
+function readPackageJson(packagePath: string): {
+  version: string;
+  peerDependencies?: Record<string, string>;
+} {
   const filePath = new URL(packagePath, repoRoot);
-  return JSON.parse(readFileSync(filePath, "utf8"));
+  return JSON.parse(readFileSync(filePath, "utf8")) as {
+    version: string;
+    peerDependencies?: Record<string, string>;
+  };
 }
 
-const rootVersion = readPackageJson(
-  "packages/react-day-picker/package.json",
-).version;
+const rootVersion = readPackageJson(packagePaths[0]).version;
 
 for (const packagePath of packagePaths.slice(1)) {
   const packageJson = readPackageJson(packagePath);
@@ -28,6 +32,7 @@ for (const packagePath of packagePaths.slice(1)) {
       `Expected ${path.dirname(packagePath)} version ${rootVersion}, got ${packageJson.version}.`,
     );
   }
+
   if (packageJson.peerDependencies?.["react-day-picker"] !== rootVersion) {
     throw new Error(
       `Expected ${path.dirname(packagePath)} peer dependency react-day-picker=${rootVersion}, got ${packageJson.peerDependencies?.["react-day-picker"]}.`,

--- a/scripts/npm-pack-dry-run.ts
+++ b/scripts/npm-pack-dry-run.ts
@@ -7,7 +7,7 @@ const packageDirs = [
   "packages/hebrew",
   "packages/hijri",
   "packages/persian",
-];
+] as const;
 
 for (const packageDir of packageDirs) {
   execFileSync("npm", ["pack", "--dry-run"], {


### PR DESCRIPTION
This finishes the TypeScript migration for the small repo utility scripts that were still living in `.mjs` while the newer release scripts had already moved to TypeScript. The goal here is consistency only: keep the scripts folder on one runtime path without changing what these utilities do.

## What Changed
- converted `scripts/check-package-versions.mjs` to `scripts/check-package-versions.ts`
- converted `scripts/npm-pack-dry-run.mjs` to `scripts/npm-pack-dry-run.ts`
- updated `package.json` to run these scripts, and `release:ci`, through `node --import tsx` instead of the `tsx` CLI

## Review Notes
- behavior should stay the same; this is a script runtime cleanup, not a release-policy change
- I validated the converted commands directly with `pnpm check:versions` and `pnpm pack:dry-run`
- the `pack:dry-run` validation still shows the existing npm config warnings, but it now runs through the TypeScript script successfully