### PR TITLE
build: rename ci workflow file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: react-day-picker
+name: ci
 
 # How this workflow works:
 # - Pull requests and branch pushes run typecheck, lint, test, and build jobs.
@@ -77,7 +77,7 @@ jobs:
           name: rdp-dist
           path: packages/*/dist
 
-  test-build:
+  test-built-packages:
     runs-on: ubuntu-latest
     needs: [build]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,14 @@
 name: ci
 
 # How this workflow works:
-# - Pull requests and branch pushes run typecheck, lint, test, and build jobs.
+# - Pull requests run typecheck, lint, test, and build jobs.
+# - Pushes to `main` rerun the same validation suite after merge.
 # - The build job verifies publish-sensitive invariants like matching versions,
 #   npm pack contents, and the built-package smoke test.
 #
 # How to use it:
-# - Open a pull request or push a branch to run the main validation suite.
+# - Open a pull request to run the main validation suite.
+# - Merges to `main` rerun the same checks without duplicating branch push runs.
 # - Package publishing is handled separately by `.github/workflows/release.yml`.
 on:
   pull_request:
@@ -14,7 +16,7 @@ on:
       - "**"
   push:
     branches:
-      - "**"
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release
+name: changesets release
 
 # How this workflow works:
 # - Every push to `main` updates or opens the Changesets release PR when there


### PR DESCRIPTION
This is a small workflow naming and trigger cleanup so the main validation workflow reads more clearly in the repo and avoids duplicate check runs on PR branches.

## What Changed
- renamed `.github/workflows/package.yml` to `.github/workflows/ci.yml`
- renamed the workflow from `react-day-picker` to `ci`
- renamed the built-package smoke-test job from `test-build` to `test-built-packages`
- renamed the release workflow from `release` to `changesets release`
- narrowed the CI workflow `push` trigger to `main` so PR branches do not run duplicate `push` and `pull_request` checks for the same commit

## Review Notes
- this is workflow naming and trigger cleanup only; no package build or release behavior should change
- after this change, pull requests still get the full CI suite, and merges to `main` still rerun the same validation checks
- I did not run `actionlint` locally because it is not installed in this repo, so GitHub Actions on the PR will be the syntax validator
