### PR TITLE
docs: simplify calendar package READMEs

### DIFF
--- a/.changeset/calendar-readmes.md
+++ b/.changeset/calendar-readmes.md
@@ -1,0 +1,9 @@
+---
+"@daypicker/buddhist": patch
+"@daypicker/ethiopic": patch
+"@daypicker/hebrew": patch
+"@daypicker/hijri": patch
+"@daypicker/persian": patch
+---
+
+docs: simplify standalone calendar package READMEs.

--- a/packages/buddhist/README.md
+++ b/packages/buddhist/README.md
@@ -28,19 +28,10 @@ export function BuddhistCalendar() {
 }
 ```
 
-The package also exports the `th` and `enUS` locales, plus `getDateLib` for
-advanced date-library customization.
-
-## Peer Dependencies
-
-`@daypicker/buddhist` is an add-on for `react-day-picker`. Your app must also
-install `react` and `react-day-picker`.
-
 ## Documentation
 
 - [Buddhist calendar guide](https://daypicker.dev/next/localization/buddhist)
 - [React DayPicker v10 docs](https://daypicker.dev/next)
-- [Issues and support](https://github.com/gpbl/react-day-picker/issues)
 
 ## License
 

--- a/packages/ethiopic/README.md
+++ b/packages/ethiopic/README.md
@@ -27,19 +27,10 @@ export function EthiopicCalendar() {
 }
 ```
 
-The package also exports the `amET` and `enUS` locales, plus `getDateLib` for
-advanced date-library customization.
-
-## Peer Dependencies
-
-`@daypicker/ethiopic` is an add-on for `react-day-picker`. Your app must also
-install `react` and `react-day-picker`.
-
 ## Documentation
 
 - [Ethiopic calendar guide](https://daypicker.dev/next/localization/ethiopic)
 - [React DayPicker v10 docs](https://daypicker.dev/next)
-- [Issues and support](https://github.com/gpbl/react-day-picker/issues)
 
 ## License
 

--- a/packages/hebrew/README.md
+++ b/packages/hebrew/README.md
@@ -28,19 +28,10 @@ export function HebrewCalendar() {
 }
 ```
 
-The package also exports the `he` and `enUS` locales, plus `getDateLib` for
-advanced date-library customization.
-
-## Peer Dependencies
-
-`@daypicker/hebrew` is an add-on for `react-day-picker`. Your app must also
-install `react` and `react-day-picker`.
-
 ## Documentation
 
 - [Hebrew calendar guide](https://daypicker.dev/next/localization/hebrew)
 - [React DayPicker v10 docs](https://daypicker.dev/next)
-- [Issues and support](https://github.com/gpbl/react-day-picker/issues)
 
 ## License
 

--- a/packages/hijri/README.md
+++ b/packages/hijri/README.md
@@ -28,19 +28,10 @@ export function HijriCalendar() {
 }
 ```
 
-The package also exports the `arSA` and `enUS` locales, plus `getDateLib` for
-advanced date-library customization.
-
-## Peer Dependencies
-
-`@daypicker/hijri` is an add-on for `react-day-picker`. Your app must also
-install `react` and `react-day-picker`.
-
 ## Documentation
 
 - [Hijri calendar guide](https://daypicker.dev/next/localization/hijri)
 - [React DayPicker v10 docs](https://daypicker.dev/next)
-- [Issues and support](https://github.com/gpbl/react-day-picker/issues)
 
 ## License
 

--- a/packages/persian/README.md
+++ b/packages/persian/README.md
@@ -28,19 +28,10 @@ export function PersianCalendar() {
 }
 ```
 
-The package also exports the `faIR`, `enUS`, `faIRJalali`, and `enUSJalali`
-locales, plus `getDateLib` for advanced date-library customization.
-
-## Peer Dependencies
-
-`@daypicker/persian` is an add-on for `react-day-picker`. Your app must also
-install `react` and `react-day-picker`.
-
 ## Documentation
 
 - [Persian calendar guide](https://daypicker.dev/next/localization/persian)
 - [React DayPicker v10 docs](https://daypicker.dev/next)
-- [Issues and support](https://github.com/gpbl/react-day-picker/issues)
 
 ## License
 


### PR DESCRIPTION
The standalone calendar package READMEs repeated lower-level package details that are already represented elsewhere, making the package pages a little noisier than needed. This trims those package-specific READMEs so they stay focused on installation, usage, and documentation links.

## What Changed

- Removed the advanced export notes from the Buddhist, Ethiopic, Hebrew, Hijri, and Persian package READMEs.
- Removed the repeated Peer Dependencies sections from those standalone package READMEs.
- Removed the Issues and support link from each package README Documentation section.
- Added a patch changeset for the affected standalone calendar packages.

## Review Notes

This is documentation-only. It does not change runtime code, package exports, peer dependency metadata, or the main `react-day-picker` README.