### PR TITLE
fix: calendar dateLib overrides

### DIFF
--- a/.changeset/calendar-datelib-overrides.md
+++ b/.changeset/calendar-datelib-overrides.md
@@ -1,0 +1,7 @@
+---
+"@daypicker/buddhist": patch
+"@daypicker/ethiopic": patch
+"@daypicker/hebrew": patch
+---
+
+Respect custom `dateLib` overrides in calendar wrappers.

--- a/packages/buddhist/src/buddhist/index.test.tsx
+++ b/packages/buddhist/src/buddhist/index.test.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { grid } from "@/test/elements";
+import { render } from "@/test/render";
+import { DayPicker } from "./index";
+
+describe("Buddhist DayPicker", () => {
+  test("applies dateLib overrides after Buddhist defaults", () => {
+    render(
+      <DayPicker
+        month={new Date(2024, 11, 1)}
+        dateLib={{ format: () => "custom caption" }}
+      />,
+    );
+
+    expect(grid("custom caption")).toBeInTheDocument();
+  });
+});

--- a/packages/buddhist/src/buddhist/index.tsx
+++ b/packages/buddhist/src/buddhist/index.tsx
@@ -43,18 +43,21 @@ export function DayPicker(
     dateLib?: DayPickerProps["dateLib"];
   },
 ) {
+  const { dateLib: dateLibProp, ...dayPickerProps } = props;
+  const locale = props.locale ?? th;
   const dateLib = getDateLib({
-    locale: props.locale ?? th,
+    locale,
     weekStartsOn: props.broadcastCalendar ? 1 : props.weekStartsOn,
     firstWeekContainsDate: props.firstWeekContainsDate,
     useAdditionalWeekYearTokens: props.useAdditionalWeekYearTokens,
     useAdditionalDayOfYearTokens: props.useAdditionalDayOfYearTokens,
     timeZone: props.timeZone,
+    overrides: dateLibProp,
   });
   return (
     <DayPickerComponent
-      {...props}
-      locale={props.locale ?? th}
+      {...dayPickerProps}
+      locale={locale}
       numerals={props.numerals ?? "thai"}
       dir={props.dir ?? "ltr"}
       dateLib={dateLib}
@@ -63,8 +66,14 @@ export function DayPicker(
 }
 
 /** Returns the date library used in the Buddhist calendar. */
-export const getDateLib = (options?: DateLibOptions) => {
-  return new DateLib(options, {
+export const getDateLib = (
+  options?: DateLibOptions & {
+    overrides?: DayPickerProps["dateLib"];
+  },
+) => {
+  const { overrides, ...dateLibOptions } = options ?? {};
+  return new DateLib(dateLibOptions, {
     format: buddhistFormat,
+    ...(overrides ?? {}),
   });
 };

--- a/packages/ethiopic/src/ethiopic/index.test.tsx
+++ b/packages/ethiopic/src/ethiopic/index.test.tsx
@@ -9,6 +9,17 @@ const today = new Date(2024, 11, 22);
 
 setTestTime(today);
 describe("Ethiopic DayPicker", () => {
+  test("applies dateLib overrides after Ethiopic defaults", () => {
+    render(
+      <DayPicker
+        month={new Date(2024, 8, 10)}
+        dateLib={{ format: () => "custom caption" }}
+      />,
+    );
+
+    expect(grid("custom caption")).toBeInTheDocument();
+  });
+
   test("renders Amharic month with Geez numerals by default", () => {
     render(<DayPicker />);
     // Caption label is also used as grid aria-label

--- a/packages/ethiopic/src/ethiopic/index.tsx
+++ b/packages/ethiopic/src/ethiopic/index.tsx
@@ -47,20 +47,29 @@ export function DayPicker(
     numerals?: DayPickerProps["numerals"];
   },
 ) {
+  const { dateLib: dateLibProp, ...dayPickerProps } = props;
   return (
     <DayPickerComponent
-      {...props}
+      {...dayPickerProps}
       locale={(props.locale as Locale) ?? amET}
       numerals={props.numerals ?? "geez"}
       // Pass overrides, not a DateLib instance
-      dateLib={ethiopicDateLib}
+      dateLib={{ ...ethiopicDateLib, ...(dateLibProp ?? {}) }}
     />
   );
 }
 
 /** Returns the date library used in the calendar. */
-export const getDateLib = (options?: DateLibOptions) => {
-  return new DateLib(options, ethiopicDateLib);
+export const getDateLib = (
+  options?: DateLibOptions & {
+    overrides?: DayPickerProps["dateLib"];
+  },
+) => {
+  const { overrides, ...dateLibOptions } = options ?? {};
+  return new DateLib(dateLibOptions, {
+    ...ethiopicDateLib,
+    ...(overrides ?? {}),
+  });
 };
 
 // Export a minimal Amharic (Ethiopia) date-fns locale that uses Intl

--- a/packages/hebrew/src/hebrew/index.test.tsx
+++ b/packages/hebrew/src/hebrew/index.test.tsx
@@ -9,6 +9,17 @@ const today = new Date(2024, 9, 3);
 
 setTestTime(today);
 describe("Hebrew DayPicker", () => {
+  test("applies dateLib overrides after Hebrew defaults", () => {
+    render(
+      <DayPicker
+        month={new Date(2024, 9, 3)}
+        dateLib={{ format: () => "custom caption" }}
+      />,
+    );
+
+    expect(grid("custom caption")).toBeInTheDocument();
+  });
+
   test("renders Hebrew month caption by default", () => {
     render(<DayPicker />);
     expect(grid("תשרי 5785")).toBeInTheDocument();

--- a/packages/hebrew/src/hebrew/index.tsx
+++ b/packages/hebrew/src/hebrew/index.tsx
@@ -29,18 +29,21 @@ export function DayPicker(
     dateLib?: DayPickerProps["dateLib"];
   },
 ) {
+  const { dateLib: dateLibProp, ...dayPickerProps } = props;
+  const locale = props.locale ?? he;
   const dateLib = getDateLib({
-    locale: props.locale,
+    locale,
     weekStartsOn: props.broadcastCalendar ? 1 : props.weekStartsOn,
     firstWeekContainsDate: props.firstWeekContainsDate,
     useAdditionalWeekYearTokens: props.useAdditionalWeekYearTokens,
     useAdditionalDayOfYearTokens: props.useAdditionalDayOfYearTokens,
     timeZone: props.timeZone,
+    overrides: dateLibProp,
   });
   return (
     <DayPickerComponent
-      {...props}
-      locale={props.locale ?? he}
+      {...dayPickerProps}
+      locale={locale}
       numerals={props.numerals ?? "latn"}
       dir={props.dir ?? "rtl"}
       dateLib={dateLib}
@@ -49,8 +52,16 @@ export function DayPicker(
 }
 
 /** Returns the date library used in the Hebrew calendar. */
-export const getDateLib = (options?: DateLibOptions) => {
-  return new DateLib(options, hebrewDateLib);
+export const getDateLib = (
+  options?: DateLibOptions & {
+    overrides?: DayPickerProps["dateLib"];
+  },
+) => {
+  const { overrides, ...dateLibOptions } = options ?? {};
+  return new DateLib(dateLibOptions, {
+    ...hebrewDateLib,
+    ...(overrides ?? {}),
+  });
 };
 
 export { enUS } from "../locale/en-US.js";

--- a/packages/hijri/src/hijri/index.test.tsx
+++ b/packages/hijri/src/hijri/index.test.tsx
@@ -11,6 +11,17 @@ const gregorianMaxDate = new Date(2077, 10, 16);
 
 setTestTime(today);
 describe("Hijri DayPicker", () => {
+  test("applies dateLib overrides after Hijri defaults", () => {
+    render(
+      <DayPicker
+        month={new Date(2025, 2, 1)}
+        dateLib={{ format: () => "custom caption" }}
+      />,
+    );
+
+    expect(grid("custom caption")).toBeInTheDocument();
+  });
+
   test("renders Hijri month caption by default", () => {
     // Default locale is ar-SA, numerals arab
     // Ramadan 1446 -> رمضان ١٤٤٦

--- a/packages/persian/src/index.test.tsx
+++ b/packages/persian/src/index.test.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { grid } from "@/test/elements";
+import { render } from "@/test/render";
+import { DayPicker } from "./index";
+
+describe("Persian DayPicker", () => {
+  test("applies dateLib overrides after Persian defaults", () => {
+    render(
+      <DayPicker
+        month={new Date(2024, 11, 1)}
+        dateLib={{ format: () => "custom caption" }}
+      />,
+    );
+
+    expect(grid("custom caption")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What Changed

Fixes the Buddhist, Ethiopic, and Hebrew calendar wrappers so consumer-provided `dateLib` overrides are merged after the calendar defaults instead of being dropped.

Adds matching `dateLib` override regression coverage across all five `@daypicker/*` packages, including the already-working Hijri and Persian wrappers, so the add-ons share the same contract.

Adds a patch Changeset for `@daypicker/buddhist`, `@daypicker/ethiopic`, and `@daypicker/hebrew`.

## Review Notes

Root cause: those three wrappers passed their own computed calendar date library into core `DayPicker` after spreading props, so the user `dateLib` prop was overwritten before core could merge it.

Validation run locally:

- `pnpm exec jest --selectProjects packages`
- `pnpm -r --filter "@daypicker/*" typecheck`
- `pnpm lint`
- `pnpm typecheck`