### PR TITLE
test: add calendar package coverage

### DIFF
--- a/packages/buddhist/src/buddhist/index.test.tsx
+++ b/packages/buddhist/src/buddhist/index.test.tsx
@@ -1,9 +1,24 @@
 import React from "react";
 import { grid } from "@/test/elements";
 import { render } from "@/test/render";
-import { DayPicker } from "./index";
+import { DayPicker, enUS, getDateLib } from "./index";
 
 describe("Buddhist DayPicker", () => {
+  test("renders Thai month caption and Buddhist Era year by default", () => {
+    const { container } = render(<DayPicker month={new Date(2024, 11, 1)} />);
+
+    expect(grid("ธันวาคม ๒๕๖๗")).toBeInTheDocument();
+    expect(container.firstElementChild).toHaveAttribute("dir", "ltr");
+  });
+
+  test("renders English month caption with Latin digits when requested", () => {
+    render(
+      <DayPicker locale={enUS} month={new Date(2024, 11, 1)} numerals="latn" />,
+    );
+
+    expect(grid("December 2567")).toBeInTheDocument();
+  });
+
   test("applies dateLib overrides after Buddhist defaults", () => {
     render(
       <DayPicker
@@ -13,5 +28,13 @@ describe("Buddhist DayPicker", () => {
     );
 
     expect(grid("custom caption")).toBeInTheDocument();
+  });
+
+  test("getDateLib formats Buddhist Era years", () => {
+    const dateLib = getDateLib({ locale: enUS, numerals: "latn" });
+
+    expect(dateLib.format(new Date(2024, 11, 1), "yyyy-MM-dd")).toBe(
+      "2567-12-01",
+    );
   });
 });

--- a/packages/hijri/src/hijri/lib/differenceInCalendarMonths.test.ts
+++ b/packages/hijri/src/hijri/lib/differenceInCalendarMonths.test.ts
@@ -1,0 +1,15 @@
+import { differenceInCalendarMonths } from "./differenceInCalendarMonths.js";
+
+describe("differenceInCalendarMonths", () => {
+  test("returns month distance in Hijri calendar", () => {
+    expect(
+      differenceInCalendarMonths(new Date(2025, 2, 8), new Date(2025, 0, 1)),
+    ).toBe(2);
+  });
+
+  test("handles Hijri year boundaries", () => {
+    expect(
+      differenceInCalendarMonths(new Date(2025, 5, 26), new Date(2025, 2, 8)),
+    ).toBe(4);
+  });
+});

--- a/packages/hijri/src/hijri/lib/endOfMonth.test.ts
+++ b/packages/hijri/src/hijri/lib/endOfMonth.test.ts
@@ -1,0 +1,12 @@
+import { toHijriDate } from "../utils/conversion.js";
+import { endOfMonth } from "./endOfMonth.js";
+
+describe("endOfMonth", () => {
+  test("returns the last day of the Hijri month", () => {
+    expect(toHijriDate(endOfMonth(new Date(2025, 2, 8)))).toEqual({
+      year: 1446,
+      monthIndex: 8,
+      day: 29,
+    });
+  });
+});

--- a/packages/hijri/src/hijri/lib/endOfYear.test.ts
+++ b/packages/hijri/src/hijri/lib/endOfYear.test.ts
@@ -1,0 +1,12 @@
+import { toHijriDate } from "../utils/conversion.js";
+import { endOfYear } from "./endOfYear.js";
+
+describe("endOfYear", () => {
+  test("returns the last day of the Hijri year", () => {
+    expect(toHijriDate(endOfYear(new Date(2025, 2, 8)))).toEqual({
+      year: 1446,
+      monthIndex: 11,
+      day: 29,
+    });
+  });
+});

--- a/packages/hijri/src/hijri/lib/getMonth.test.ts
+++ b/packages/hijri/src/hijri/lib/getMonth.test.ts
@@ -1,0 +1,7 @@
+import { getMonth } from "./getMonth.js";
+
+describe("getMonth", () => {
+  test("returns the Hijri month index", () => {
+    expect(getMonth(new Date(2025, 2, 8))).toBe(8);
+  });
+});

--- a/packages/hijri/src/hijri/lib/getYear.test.ts
+++ b/packages/hijri/src/hijri/lib/getYear.test.ts
@@ -1,0 +1,7 @@
+import { getYear } from "./getYear.js";
+
+describe("getYear", () => {
+  test("returns the Hijri year", () => {
+    expect(getYear(new Date(2025, 2, 8))).toBe(1446);
+  });
+});

--- a/packages/hijri/src/hijri/lib/isSameMonth.test.ts
+++ b/packages/hijri/src/hijri/lib/isSameMonth.test.ts
@@ -1,0 +1,13 @@
+import { isSameMonth } from "./isSameMonth.js";
+
+describe("isSameMonth", () => {
+  test("returns true for dates in the same Hijri month", () => {
+    expect(isSameMonth(new Date(2025, 2, 8), new Date(2025, 2, 29))).toBe(true);
+  });
+
+  test("returns false for dates in different Hijri months", () => {
+    expect(isSameMonth(new Date(2025, 2, 8), new Date(2025, 2, 30))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/hijri/src/hijri/lib/isSameYear.test.ts
+++ b/packages/hijri/src/hijri/lib/isSameYear.test.ts
@@ -1,0 +1,11 @@
+import { isSameYear } from "./isSameYear.js";
+
+describe("isSameYear", () => {
+  test("returns true for dates in the same Hijri year", () => {
+    expect(isSameYear(new Date(2025, 0, 1), new Date(2025, 2, 8))).toBe(true);
+  });
+
+  test("returns false for dates in different Hijri years", () => {
+    expect(isSameYear(new Date(2025, 2, 8), new Date(2025, 5, 26))).toBe(false);
+  });
+});

--- a/packages/hijri/src/hijri/lib/newDate.test.ts
+++ b/packages/hijri/src/hijri/lib/newDate.test.ts
@@ -1,0 +1,16 @@
+import { toHijriDate } from "../utils/conversion.js";
+import { newDate } from "./newDate.js";
+
+describe("newDate", () => {
+  test("creates the Gregorian equivalent for a Hijri date", () => {
+    expect(newDate(1446, 8, 8)).toEqual(new Date(2025, 2, 8));
+  });
+
+  test("normalizes invalid Hijri month and day values", () => {
+    expect(toHijriDate(newDate(1446, 14, 60))).toEqual({
+      year: 1447,
+      monthIndex: 2,
+      day: 30,
+    });
+  });
+});

--- a/packages/hijri/src/hijri/lib/startOfMonth.test.ts
+++ b/packages/hijri/src/hijri/lib/startOfMonth.test.ts
@@ -1,0 +1,7 @@
+import { startOfMonth } from "./startOfMonth.js";
+
+describe("startOfMonth", () => {
+  test("returns the first day of the Hijri month", () => {
+    expect(startOfMonth(new Date(2025, 2, 8))).toEqual(new Date(2025, 2, 1));
+  });
+});

--- a/packages/hijri/src/hijri/lib/startOfYear.test.ts
+++ b/packages/hijri/src/hijri/lib/startOfYear.test.ts
@@ -1,0 +1,7 @@
+import { startOfYear } from "./startOfYear.js";
+
+describe("startOfYear", () => {
+  test("returns the first day of the Hijri year", () => {
+    expect(startOfYear(new Date(2025, 2, 8))).toEqual(new Date(2024, 6, 7));
+  });
+});

--- a/packages/persian/src/index.test.tsx
+++ b/packages/persian/src/index.test.tsx
@@ -1,9 +1,30 @@
 import React from "react";
 import { grid } from "@/test/elements";
-import { render } from "@/test/render";
-import { DayPicker } from "./index";
+import { render, screen, within } from "@/test/render";
+import { DayPicker, enUS, faIR, getDateLib } from "./index";
 
 describe("Persian DayPicker", () => {
+  test("renders Persian month caption and RTL direction by default", () => {
+    const { container } = render(<DayPicker month={new Date(2024, 11, 1)} />);
+
+    expect(grid("آذر ۱۴۰۳")).toBeInTheDocument();
+    expect(container.firstElementChild).toHaveAttribute("dir", "rtl");
+  });
+
+  test("renders English month caption with Latin digits when requested", () => {
+    const { container } = render(
+      <DayPicker
+        dir="ltr"
+        locale={enUS}
+        month={new Date(2024, 11, 1)}
+        numerals="latn"
+      />,
+    );
+
+    expect(grid("Azar 1403")).toBeInTheDocument();
+    expect(container.firstElementChild).toHaveAttribute("dir", "ltr");
+  });
+
   test("applies dateLib overrides after Persian defaults", () => {
     render(
       <DayPicker
@@ -13,5 +34,49 @@ describe("Persian DayPicker", () => {
     );
 
     expect(grid("custom caption")).toBeInTheDocument();
+  });
+
+  test("getDateLib formats Jalali dates with configured numerals", () => {
+    const dateLib = getDateLib({ locale: faIR, numerals: "arabext" });
+
+    expect(dateLib.format(new Date(2024, 11, 1), "yyyy-MM-dd")).toBe(
+      "۱۴۰۳-۰۹-۱۱",
+    );
+  });
+
+  test("getDateLib applies consumer overrides after Jalali defaults", () => {
+    const dateLib = getDateLib({
+      locale: enUS,
+      numerals: "latn",
+      overrides: {
+        format: () => "custom format",
+      },
+    });
+
+    expect(dateLib.format(new Date(2024, 11, 1), "yyyy-MM-dd")).toBe(
+      "custom format",
+    );
+  });
+
+  test("noonSafe keeps full weeks in historical time zones", () => {
+    render(
+      <DayPicker
+        defaultMonth={new Date(1900, 11, 1)}
+        fixedWeeks
+        noonSafe
+        showOutsideDays
+        timeZone="Asia/Dubai"
+      />,
+    );
+
+    const rows = within(screen.getByRole("grid")).getAllByRole("row");
+    const dayRows = rows.filter(
+      (row) => within(row).queryAllByRole("gridcell").length > 0,
+    );
+
+    expect(within(dayRows[0]).getAllByRole("gridcell")).toHaveLength(7);
+    expect(
+      within(dayRows[dayRows.length - 1]).getAllByRole("gridcell"),
+    ).toHaveLength(7);
   });
 });


### PR DESCRIPTION
## What Changed

Adds package-local test coverage for standalone calendar packages:

- Buddhist wrapper defaults, English/Latin rendering, and `getDateLib` Buddhist Era formatting.
- Persian wrapper defaults, English/LTR rendering, `getDateLib` Jalali formatting, override precedence, and `noonSafe` historical timezone behavior.
- Hijri date-lib wrapper functions for calendar-month differences, starts/ends, getters, equality helpers, and `newDate`.

## Review Notes

This is test-only. No Changeset is included.

Validation run locally:

- `pnpm exec jest --selectProjects packages`
- `pnpm lint`
- `pnpm typecheck`