### PR TITLE
fix: alias calendar packages in website

### DIFF
--- a/apps/website/docusaurus.config.ts
+++ b/apps/website/docusaurus.config.ts
@@ -30,6 +30,15 @@ const reactDayPickerStylePath = nodeRequire.resolve(
 const reactDayPickerStyleModulePath = nodeRequire.resolve(
   "../../packages/react-day-picker/src/style.module.css",
 );
+const buddhistPath = nodeRequire.resolve(
+  "../../packages/buddhist/src/index.tsx",
+);
+const ethiopicPath = nodeRequire.resolve(
+  "../../packages/ethiopic/src/index.tsx",
+);
+const hebrewPath = nodeRequire.resolve("../../packages/hebrew/src/index.tsx");
+const hijriPath = nodeRequire.resolve("../../packages/hijri/src/index.tsx");
+const persianPath = nodeRequire.resolve("../../packages/persian/src/index.tsx");
 
 const config: Config = {
   title: "React DayPicker",
@@ -138,6 +147,11 @@ const config: Config = {
                 "react-day-picker/locale$": reactDayPickerLocalePath,
                 "react-day-picker/locale": reactDayPickerLocaleDir,
                 "react-day-picker$": reactDayPickerSrcPath,
+                "@daypicker/buddhist$": buddhistPath,
+                "@daypicker/ethiopic$": ethiopicPath,
+                "@daypicker/hebrew$": hebrewPath,
+                "@daypicker/hijri$": hijriPath,
+                "@daypicker/persian$": persianPath,
               },
             },
           };


### PR DESCRIPTION
## What Changed

Adds Docusaurus webpack aliases for the standalone calendar packages so the website resolves `@daypicker/buddhist`, `@daypicker/ethiopic`, `@daypicker/hebrew`, `@daypicker/hijri`, and `@daypicker/persian` to their workspace source entry points.

This mirrors the source aliases already used by the examples app and keeps the v10 playground/docs app from resolving calendar add-ons through package `dist` output during local website builds.

## Review Notes

This is build configuration only. No Changeset is included.

Validation run locally:

- `pnpm --filter website run build`
- `pnpm --filter website run typecheck`
- `pnpm lint`