### PR TITLE
fix: remove Persian date-fns type imports

### DIFF
--- a/packages/persian/src/noonDateLib.ts
+++ b/packages/persian/src/noonDateLib.ts
@@ -1,6 +1,6 @@
-import type { Locale } from "date-fns";
+import type { DateLibOptions } from "./classes/DateLib.js";
 
 export interface CreateNoonOverridesOptions {
-  weekStartsOn?: number;
-  locale?: Locale;
+  weekStartsOn?: DateLibOptions["weekStartsOn"];
+  locale?: DateLibOptions["locale"];
 }

--- a/packages/persian/src/noonJalaliDateLib.ts
+++ b/packages/persian/src/noonJalaliDateLib.ts
@@ -1,5 +1,4 @@
 import { TZDate } from "@date-fns/tz";
-import type { EndOfWeekOptions, StartOfWeekOptions } from "date-fns";
 import {
   addDays as addDaysJalali,
   addMonths as addMonthsJalali,
@@ -24,6 +23,8 @@ import type { DateLib } from "./classes/DateLib.js";
 import type { CreateNoonOverridesOptions } from "./noonDateLib.js";
 
 type SupportedDate = Date | number | string | TZDate;
+type StartOfWeekOptions = NonNullable<Parameters<DateLib["startOfWeek"]>[1]>;
+type EndOfWeekOptions = NonNullable<Parameters<DateLib["endOfWeek"]>[1]>;
 type WeekStartsOn = NonNullable<StartOfWeekOptions["weekStartsOn"]>;
 
 /**


### PR DESCRIPTION
## What Changed

Removes the direct `date-fns` type imports from `@daypicker/persian` noon-safe helpers.

The Persian package now derives its locale and week option types from the existing `react-day-picker` peer types, while keeping its runtime dependencies limited to `@date-fns/tz` and `date-fns-jalali`.

## Review Notes

This is an internal type cleanup with no runtime behavior change. No Changeset is included.

Validation run locally:

- `pnpm --filter @daypicker/persian run typecheck`
- `pnpm exec jest --selectProjects packages packages/persian/src/index.test.tsx packages/persian/src/locale-jalali.test.ts`
- `pnpm --filter @daypicker/persian run build`
- `pnpm lint`
- `pnpm typecheck`

I also verified no direct `date-fns` imports remain in `packages/persian/src` or the generated `packages/persian/dist` declarations.