### PR TITLE
feat: add scoped react package alias

### DIFF
--- a/.changeset/scoped-react-alias.md
+++ b/.changeset/scoped-react-alias.md
@@ -8,4 +8,4 @@
 "@daypicker/persian": patch
 ---
 
-Add `@daypicker/react` as a public scoped alias for `react-day-picker` and update calendar packages to consume it.
+Add `@daypicker/react` as the React package for DayPicker and update calendar packages to consume it.

--- a/.changeset/scoped-react-alias.md
+++ b/.changeset/scoped-react-alias.md
@@ -1,0 +1,11 @@
+---
+"react-day-picker": patch
+"@daypicker/react": patch
+"@daypicker/buddhist": patch
+"@daypicker/ethiopic": patch
+"@daypicker/hebrew": patch
+"@daypicker/hijri": patch
+"@daypicker/persian": patch
+---
+
+Add `@daypicker/react` as a public scoped alias for `react-day-picker` and update calendar packages to consume it.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,15 +57,11 @@ jobs:
           createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Optional fallback for first-publishing a new npm package before
-          # its trusted publisher can be configured on npmjs.com.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Recover release for a merged release PR commit
         if: github.event_name == 'workflow_dispatch'
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_COMMIT_SHA: ${{ github.event.inputs.ref }}
         run: pnpm release:ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,11 +57,15 @@ jobs:
           createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Optional fallback for first-publishing a new npm package before
+          # its trusted publisher can be configured on npmjs.com.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Recover release for a merged release PR commit
         if: github.event_name == 'workflow_dispatch'
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_COMMIT_SHA: ${{ github.event.inputs.ref }}
         run: pnpm release:ci

--- a/apps/website/versioned_docs/version-next/localization/buddhist.mdx
+++ b/apps/website/versioned_docs/version-next/localization/buddhist.mdx
@@ -4,7 +4,7 @@ title: Buddhist (Thai) Calendar
 
 DayPicker supports the Buddhist (Thai) calendar via a dedicated build. Months and weeks remain Gregorian, while years render in Buddhist Era (BE = CE + 543) and Thai numerals by default.
 
-Install the scoped React package and the Buddhist calendar package:
+Install the React package and the Buddhist calendar package:
 
 ```bash npm2yarn
 npm install @daypicker/react@next @daypicker/buddhist@next

--- a/apps/website/versioned_docs/version-next/localization/buddhist.mdx
+++ b/apps/website/versioned_docs/version-next/localization/buddhist.mdx
@@ -4,10 +4,10 @@ title: Buddhist (Thai) Calendar
 
 DayPicker supports the Buddhist (Thai) calendar via a dedicated build. Months and weeks remain Gregorian, while years render in Buddhist Era (BE = CE + 543) and Thai numerals by default.
 
-Install the core package and the Buddhist calendar package:
+Install the scoped React package and the Buddhist calendar package:
 
 ```bash npm2yarn
-npm install react-day-picker@next @daypicker/buddhist@next
+npm install @daypicker/react@next @daypicker/buddhist@next
 ```
 
 Import `DayPicker` from `@daypicker/buddhist` to render Buddhist years while keeping the usual DayPicker API.

--- a/apps/website/versioned_docs/version-next/localization/ethiopic.mdx
+++ b/apps/website/versioned_docs/version-next/localization/ethiopic.mdx
@@ -4,7 +4,7 @@ title: Ethiopic Calendar
 
 DayPicker supports the [Ethiopic calendar](https://en.wikipedia.org/wiki/Ethiopian_calendar) via a dedicated build.
 
-Install the scoped React package and the Ethiopic calendar package:
+Install the React package and the Ethiopic calendar package:
 
 ```bash npm2yarn
 npm install @daypicker/react@next @daypicker/ethiopic@next

--- a/apps/website/versioned_docs/version-next/localization/ethiopic.mdx
+++ b/apps/website/versioned_docs/version-next/localization/ethiopic.mdx
@@ -4,10 +4,10 @@ title: Ethiopic Calendar
 
 DayPicker supports the [Ethiopic calendar](https://en.wikipedia.org/wiki/Ethiopian_calendar) via a dedicated build.
 
-Install the core package and the Ethiopic calendar package:
+Install the scoped React package and the Ethiopic calendar package:
 
 ```bash npm2yarn
-npm install react-day-picker@next @daypicker/ethiopic@next
+npm install @daypicker/react@next @daypicker/ethiopic@next
 ```
 
 Import `DayPicker` from `@daypicker/ethiopic` to display Ethiopic months, weekdays, and numerals while keeping the usual DayPicker API.

--- a/apps/website/versioned_docs/version-next/localization/hebrew.mdx
+++ b/apps/website/versioned_docs/version-next/localization/hebrew.mdx
@@ -4,10 +4,10 @@ title: Hebrew Calendar
 
 DayPicker supports the [Hebrew calendar](https://en.wikipedia.org/wiki/Hebrew_calendar) via a dedicated build.
 
-Install the core package and the Hebrew calendar package:
+Install the scoped React package and the Hebrew calendar package:
 
 ```bash npm2yarn
-npm install react-day-picker@next @daypicker/hebrew@next
+npm install @daypicker/react@next @daypicker/hebrew@next
 ```
 
 Import `DayPicker` from `@daypicker/hebrew` to render Hebrew months (including Adar I/II in leap years) with RTL layout by default.

--- a/apps/website/versioned_docs/version-next/localization/hebrew.mdx
+++ b/apps/website/versioned_docs/version-next/localization/hebrew.mdx
@@ -4,7 +4,7 @@ title: Hebrew Calendar
 
 DayPicker supports the [Hebrew calendar](https://en.wikipedia.org/wiki/Hebrew_calendar) via a dedicated build.
 
-Install the scoped React package and the Hebrew calendar package:
+Install the React package and the Hebrew calendar package:
 
 ```bash npm2yarn
 npm install @daypicker/react@next @daypicker/hebrew@next

--- a/apps/website/versioned_docs/version-next/localization/hijri.mdx
+++ b/apps/website/versioned_docs/version-next/localization/hijri.mdx
@@ -4,10 +4,10 @@ title: Hijri Calendar
 
 DayPicker supports the [Hijri (Umm al-Qura) calendar](https://en.wikipedia.org/wiki/Islamic_calendar) via a dedicated build.
 
-Install the core package and the Hijri calendar package:
+Install the scoped React package and the Hijri calendar package:
 
 ```bash npm2yarn
-npm install react-day-picker@next @daypicker/hijri@next
+npm install @daypicker/react@next @daypicker/hijri@next
 ```
 
 Import `DayPicker` from `@daypicker/hijri` to render Hijri months and weekdays while keeping the usual DayPicker API.

--- a/apps/website/versioned_docs/version-next/localization/hijri.mdx
+++ b/apps/website/versioned_docs/version-next/localization/hijri.mdx
@@ -4,7 +4,7 @@ title: Hijri Calendar
 
 DayPicker supports the [Hijri (Umm al-Qura) calendar](https://en.wikipedia.org/wiki/Islamic_calendar) via a dedicated build.
 
-Install the scoped React package and the Hijri calendar package:
+Install the React package and the Hijri calendar package:
 
 ```bash npm2yarn
 npm install @daypicker/react@next @daypicker/hijri@next

--- a/apps/website/versioned_docs/version-next/localization/persian.mdx
+++ b/apps/website/versioned_docs/version-next/localization/persian.mdx
@@ -4,10 +4,10 @@ title: Persian Calendar
 
 DayPicker supports the Persian [Solar Hijri](<https://en.wikipedia.org/wiki/Iranian_calendars#Modern_calendar:_Solar_Hijri_(SH)>) calendar via a dedicated build.
 
-Install the core package and the Persian calendar package:
+Install the scoped React package and the Persian calendar package:
 
 ```bash npm2yarn
-npm install react-day-picker@next @daypicker/persian@next
+npm install @daypicker/react@next @daypicker/persian@next
 ```
 
 Import `DayPicker` from `@daypicker/persian` to render Persian months and weekdays while keeping the usual DayPicker API.

--- a/apps/website/versioned_docs/version-next/localization/persian.mdx
+++ b/apps/website/versioned_docs/version-next/localization/persian.mdx
@@ -4,7 +4,7 @@ title: Persian Calendar
 
 DayPicker supports the Persian [Solar Hijri](<https://en.wikipedia.org/wiki/Iranian_calendars#Modern_calendar:_Solar_Hijri_(SH)>) calendar via a dedicated build.
 
-Install the scoped React package and the Persian calendar package:
+Install the React package and the Persian calendar package:
 
 ```bash npm2yarn
 npm install @daypicker/react@next @daypicker/persian@next

--- a/apps/website/versioned_docs/version-next/upgrading.mdx
+++ b/apps/website/versioned_docs/version-next/upgrading.mdx
@@ -148,12 +148,12 @@ These imports were removed in v10:
   `@daypicker/persian`
 - Deprecated aliases from `types/deprecated`
 
-The calendar packages are now published separately from `react-day-picker`.
-Install the add-on package you use alongside `react-day-picker@next`. For
+The calendar packages are now published separately from the main React package.
+Install the add-on package you use alongside `@daypicker/react@next`. For
 example:
 
 ```bash npm2yarn
-npm install react-day-picker@next @daypicker/persian@next
+npm install @daypicker/react@next @daypicker/persian@next
 ```
 
 ## 8. Review the new `navLayout` default

--- a/examples/ScopedReactAlias.test.tsx
+++ b/examples/ScopedReactAlias.test.tsx
@@ -30,7 +30,7 @@ function CoInstalledMonthCaption(props: MonthCaptionProps) {
   );
 }
 
-test("the scoped React package mirrors the DayPicker public surface", () => {
+test("the React package mirrors the DayPicker public surface", () => {
   const requiredPackage = requirePackage(
     "@daypicker/react",
   ) as typeof import("@daypicker/react");
@@ -63,7 +63,7 @@ test("same-version scoped and legacy imports share the DayPicker implementation"
   );
 });
 
-test("calendar packages render through the scoped React package boundary", () => {
+test("calendar packages render through the React package boundary", () => {
   const calendar = render(
     <BuddhistDayPicker month={new Date(2024, 0, 1)} mode="single" />,
   );

--- a/examples/ScopedReactAlias.test.tsx
+++ b/examples/ScopedReactAlias.test.tsx
@@ -1,14 +1,34 @@
 import { createRequire } from "node:module";
 import { DayPicker as BuddhistDayPicker } from "@daypicker/buddhist";
-import { DayPicker } from "@daypicker/react";
+import {
+  DayPicker,
+  type MonthCaptionProps,
+  useDayPicker as useScopedDayPicker,
+} from "@daypicker/react";
 import { es } from "@daypicker/react/locale";
 import { es as esSubpath } from "@daypicker/react/locale/es";
 import classNames from "@daypicker/react/style.module.css";
 import React from "react";
+import {
+  DayPicker as LegacyDayPicker,
+  useDayPicker as useLegacyDayPicker,
+} from "react-day-picker";
 import { render } from "@/test/render";
 import "@daypicker/react/style.css";
 
 const requirePackage = createRequire(__filename);
+
+function CoInstalledMonthCaption(props: MonthCaptionProps) {
+  const scopedContext = useScopedDayPicker();
+  const legacyContext = useLegacyDayPicker();
+
+  return (
+    <span data-testid="co-installed-caption">
+      {props.calendarMonth.date.getFullYear()}-{scopedContext.months.length}-
+      {legacyContext.months.length}
+    </span>
+  );
+}
 
 test("the scoped React package mirrors the DayPicker public surface", () => {
   const requiredPackage = requirePackage(
@@ -26,6 +46,21 @@ test("the scoped React package mirrors the DayPicker public surface", () => {
   expect(
     scopedCalendar.container.querySelector(".rdp-root"),
   ).toBeInTheDocument();
+});
+
+test("same-version scoped and legacy imports share the DayPicker implementation", () => {
+  expect(DayPicker).toBe(LegacyDayPicker);
+
+  const calendar = render(
+    <DayPicker
+      month={new Date(2024, 0, 1)}
+      components={{ MonthCaption: CoInstalledMonthCaption }}
+    />,
+  );
+
+  expect(calendar.getByTestId("co-installed-caption")).toHaveTextContent(
+    "2024-1-1",
+  );
 });
 
 test("calendar packages render through the scoped React package boundary", () => {

--- a/examples/ScopedReactAlias.test.tsx
+++ b/examples/ScopedReactAlias.test.tsx
@@ -1,0 +1,37 @@
+import { createRequire } from "node:module";
+import { DayPicker as BuddhistDayPicker } from "@daypicker/buddhist";
+import { DayPicker } from "@daypicker/react";
+import { es } from "@daypicker/react/locale";
+import { es as esSubpath } from "@daypicker/react/locale/es";
+import classNames from "@daypicker/react/style.module.css";
+import React from "react";
+import { render } from "@/test/render";
+import "@daypicker/react/style.css";
+
+const requirePackage = createRequire(__filename);
+
+test("the scoped React package mirrors the DayPicker public surface", () => {
+  const requiredPackage = requirePackage(
+    "@daypicker/react",
+  ) as typeof import("@daypicker/react");
+
+  expect(requiredPackage.DayPicker).toBeDefined();
+  expect(DayPicker).toBeDefined();
+  expect(esSubpath).toBe(es);
+  expect(classNames).toBeDefined();
+
+  const scopedCalendar = render(
+    <DayPicker month={new Date(2024, 0, 1)} mode="single" />,
+  );
+  expect(
+    scopedCalendar.container.querySelector(".rdp-root"),
+  ).toBeInTheDocument();
+});
+
+test("calendar packages render through the scoped React package boundary", () => {
+  const calendar = render(
+    <BuddhistDayPicker month={new Date(2024, 0, 1)} mode="single" />,
+  );
+
+  expect(calendar.container.querySelector(".rdp-root")).toBeInTheDocument();
+});

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -25,6 +25,20 @@ const config: Config.InitialOptions = {
       roots: ["<rootDir>/packages/react-day-picker/src"],
       moduleNameMapper: {
         "@/test/(.*)": ["<rootDir>/test/$1"],
+        "@daypicker/react/locale/(.*)\\.js": [
+          "<rootDir>/packages/react-day-picker/src/locale/$1.ts",
+        ],
+        "@daypicker/react/locale/(.*)": [
+          "<rootDir>/packages/react-day-picker/src/locale/$1",
+        ],
+        "@daypicker/react/locale": ["<rootDir>/packages/react/src/locale.ts"],
+        "@daypicker/react/style.module.css": [
+          "<rootDir>/packages/react-day-picker/src/style.module.css",
+        ],
+        "@daypicker/react/style.css": [
+          "<rootDir>/packages/react-day-picker/src/style.css",
+        ],
+        "@daypicker/react": ["<rootDir>/packages/react/src/index.ts"],
         "react-day-picker/locale/(.*)\\.js": [
           "<rootDir>/packages/react-day-picker/src/locale/$1.ts",
         ],
@@ -52,6 +66,20 @@ const config: Config.InitialOptions = {
         "@daypicker/hebrew": ["<rootDir>/packages/hebrew/src/index.tsx"],
         "@daypicker/hijri": ["<rootDir>/packages/hijri/src/index.tsx"],
         "@daypicker/persian": ["<rootDir>/packages/persian/src/index.tsx"],
+        "@daypicker/react/locale/(.*)\\.js": [
+          "<rootDir>/packages/react-day-picker/src/locale/$1.ts",
+        ],
+        "@daypicker/react/locale/(.*)": [
+          "<rootDir>/packages/react-day-picker/src/locale/$1",
+        ],
+        "@daypicker/react/locale": ["<rootDir>/packages/react/src/locale.ts"],
+        "@daypicker/react/style.module.css": [
+          "<rootDir>/packages/react-day-picker/src/style.module.css",
+        ],
+        "@daypicker/react/style.css": [
+          "<rootDir>/packages/react-day-picker/src/style.css",
+        ],
+        "@daypicker/react": ["<rootDir>/packages/react/src/index.ts"],
         "react-day-picker/locale/(.*)\\.js": [
           "<rootDir>/packages/react-day-picker/src/locale/$1.ts",
         ],
@@ -76,6 +104,7 @@ const config: Config.InitialOptions = {
         "<rootDir>/packages/hebrew",
         "<rootDir>/packages/hijri",
         "<rootDir>/packages/persian",
+        "<rootDir>/packages/react",
       ],
       moduleNameMapper: {
         "@/test/(.*)": ["<rootDir>/test/$1"],
@@ -84,6 +113,20 @@ const config: Config.InitialOptions = {
         "@daypicker/hebrew": ["<rootDir>/packages/hebrew/src/index.tsx"],
         "@daypicker/hijri": ["<rootDir>/packages/hijri/src/index.tsx"],
         "@daypicker/persian": ["<rootDir>/packages/persian/src/index.tsx"],
+        "@daypicker/react/locale/(.*)\\.js": [
+          "<rootDir>/packages/react-day-picker/src/locale/$1.ts",
+        ],
+        "@daypicker/react/locale/(.*)": [
+          "<rootDir>/packages/react-day-picker/src/locale/$1",
+        ],
+        "@daypicker/react/locale": ["<rootDir>/packages/react/src/locale.ts"],
+        "@daypicker/react/style.module.css": [
+          "<rootDir>/packages/react-day-picker/src/style.module.css",
+        ],
+        "@daypicker/react/style.css": [
+          "<rootDir>/packages/react-day-picker/src/style.css",
+        ],
+        "@daypicker/react": ["<rootDir>/packages/react/src/index.ts"],
         "react-day-picker/locale/(.*)\\.js": [
           "<rootDir>/packages/react-day-picker/src/locale/$1.ts",
         ],
@@ -107,6 +150,20 @@ const config: Config.InitialOptions = {
       fakeTimers: { enableGlobally: false }, // disable fake timers for timezone tests because they interfere with Intl API
       moduleNameMapper: {
         "@/test/(.*)": ["<rootDir>/test/$1"],
+        "@daypicker/react/locale/(.*)\\.js": [
+          "<rootDir>/packages/react-day-picker/src/locale/$1.ts",
+        ],
+        "@daypicker/react/locale/(.*)": [
+          "<rootDir>/packages/react-day-picker/src/locale/$1",
+        ],
+        "@daypicker/react/locale": ["<rootDir>/packages/react/src/locale.ts"],
+        "@daypicker/react/style.module.css": [
+          "<rootDir>/packages/react-day-picker/src/style.module.css",
+        ],
+        "@daypicker/react/style.css": [
+          "<rootDir>/packages/react-day-picker/src/style.css",
+        ],
+        "@daypicker/react": ["<rootDir>/packages/react/src/index.ts"],
         "react-day-picker/locale/(.*)\\.js": [
           "<rootDir>/packages/react-day-picker/src/locale/$1.ts",
         ],
@@ -148,6 +205,22 @@ const config: Config.InitialOptions = {
         "@daypicker/hebrew": ["<rootDir>/packages/hebrew/dist/cjs/index.js"],
         "@daypicker/hijri": ["<rootDir>/packages/hijri/dist/cjs/index.js"],
         "@daypicker/persian": ["<rootDir>/packages/persian/dist/cjs/index.js"],
+        "@daypicker/react/locale/(.*)\\.js": [
+          "<rootDir>/packages/react/dist/cjs/locale/$1.js",
+        ],
+        "@daypicker/react/locale/(.*)": [
+          "<rootDir>/packages/react/dist/cjs/locale/$1",
+        ],
+        "@daypicker/react/locale": [
+          "<rootDir>/packages/react/dist/cjs/locale.js",
+        ],
+        "@daypicker/react/style.module.css": [
+          "<rootDir>/packages/react/dist/style.module.css",
+        ],
+        "@daypicker/react/style.css": [
+          "<rootDir>/packages/react/dist/style.css",
+        ],
+        "@daypicker/react": ["<rootDir>/packages/react/dist/cjs/index.js"],
         "react-day-picker/locale/(.*)\\.js": [
           "<rootDir>/packages/react-day-picker/dist/cjs/locale/$1.js",
         ],

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "scripts": {
     "build": "pnpm clean:dist && pnpm build:react-day-picker && pnpm build:packages",
     "build:react-day-picker": "pnpm --filter react-day-picker build",
-    "build:packages": "pnpm -r --filter \"@daypicker/*\" build",
+    "build:packages": "pnpm build:daypicker-react && pnpm build:calendar-packages",
+    "build:daypicker-react": "pnpm --filter @daypicker/react build",
+    "build:calendar-packages": "pnpm -r --filter \"@daypicker/*\" --filter \"!@daypicker/react\" build",
     "clean:dist": "rm -rf packages/*/dist",
     "format": "prettier -w \"**/*.{md,mdx,ts,tsx}\"",
     "lint": "biome check",
@@ -30,6 +32,7 @@
     "@changesets/cli": "^2.31.0",
     "@changesets/changelog-github": "^0.5.2",
     "@date-fns/tz": "^1.4.1",
+    "@daypicker/react": "workspace:*",
     "@jest/types": "^30.3.0",
     "@radix-ui/react-select": "^2.2.6",
     "@swc/core": "^1.15.26",
@@ -61,6 +64,8 @@
   },
   "pnpm": {
     "overrides": {
+      "@daypicker/react": "link:packages/react",
+      "@daypicker/react>react-day-picker": "link:packages/react-day-picker",
       "@babel/runtime": "7.28.4",
       "ajv@6": "6.15.0",
       "diff": "4.0.4",

--- a/packages/buddhist/README.md
+++ b/packages/buddhist/README.md
@@ -10,8 +10,8 @@ digits by default.
 
 ## Installation
 
-Install the v10 prerelease of the React DayPicker package together with the
-Buddhist calendar package:
+Install the v10 prerelease of the React DayPicker package with the Buddhist
+calendar addon:
 
 ```bash
 npm install @daypicker/react@next @daypicker/buddhist@next

--- a/packages/buddhist/README.md
+++ b/packages/buddhist/README.md
@@ -10,18 +10,18 @@ digits by default.
 
 ## Installation
 
-Install the v10 prerelease of React DayPicker together with the Buddhist
-calendar package:
+Install the v10 prerelease of the scoped React DayPicker package together with
+the Buddhist calendar package:
 
 ```bash
-npm install react-day-picker@next @daypicker/buddhist@next
+npm install @daypicker/react@next @daypicker/buddhist@next
 ```
 
 ## Usage
 
 ```tsx
 import { DayPicker } from "@daypicker/buddhist";
-import "react-day-picker/style.css";
+import "@daypicker/react/style.css";
 
 export function BuddhistCalendar() {
   return <DayPicker mode="single" />;

--- a/packages/buddhist/README.md
+++ b/packages/buddhist/README.md
@@ -10,8 +10,8 @@ digits by default.
 
 ## Installation
 
-Install the v10 prerelease of the scoped React DayPicker package together with
-the Buddhist calendar package:
+Install the v10 prerelease of the React DayPicker package together with the
+Buddhist calendar package:
 
 ```bash
 npm install @daypicker/react@next @daypicker/buddhist@next

--- a/packages/buddhist/package.json
+++ b/packages/buddhist/package.json
@@ -44,13 +44,10 @@
     "typecheck": "tsc --project ./tsconfig.json --noEmit"
   },
   "peerDependencies": {
-    "react": ">=16.8.0",
-    "react-day-picker": "10.0.0-next.5"
+    "react": ">=16.8.0"
   },
   "dependencies": {
+    "@daypicker/react": "10.0.0-next.5",
     "date-fns": "^4.1.0"
-  },
-  "devDependencies": {
-    "react-day-picker": "workspace:*"
   }
 }

--- a/packages/buddhist/src/buddhist/index.tsx
+++ b/packages/buddhist/src/buddhist/index.tsx
@@ -1,10 +1,10 @@
-import type { Locale } from "date-fns";
-import React from "react";
 import {
   DateLib,
   type DateLibOptions,
   DayPicker as DayPickerComponent,
-} from "react-day-picker";
+} from "@daypicker/react";
+import type { Locale } from "date-fns";
+import React from "react";
 import { enUS as enUSLocale } from "../locale/en-US.js";
 import { th as thLocale } from "../locale/th.js";
 import type { DayPickerProps } from "../types/props.js";

--- a/packages/buddhist/src/classes/DateLib.ts
+++ b/packages/buddhist/src/classes/DateLib.ts
@@ -1,2 +1,2 @@
-export type { DateLibOptions } from "react-day-picker";
-export { DateLib } from "react-day-picker";
+export type { DateLibOptions } from "@daypicker/react";
+export { DateLib } from "@daypicker/react";

--- a/packages/buddhist/src/locale/en-US.ts
+++ b/packages/buddhist/src/locale/en-US.ts
@@ -1,1 +1,1 @@
-export { enUS } from "react-day-picker/locale";
+export { enUS } from "@daypicker/react/locale";

--- a/packages/buddhist/src/locale/th.ts
+++ b/packages/buddhist/src/locale/th.ts
@@ -1,1 +1,1 @@
-export { th } from "react-day-picker/locale";
+export { th } from "@daypicker/react/locale";

--- a/packages/buddhist/src/types/props.ts
+++ b/packages/buddhist/src/types/props.ts
@@ -1,1 +1,1 @@
-export type { DayPickerProps } from "react-day-picker";
+export type { DayPickerProps } from "@daypicker/react";

--- a/packages/ethiopic/README.md
+++ b/packages/ethiopic/README.md
@@ -9,8 +9,8 @@ uses the Amharic locale and Ethiopic numerals by default.
 
 ## Installation
 
-Install the v10 prerelease of the React DayPicker package together with the
-Ethiopic calendar package:
+Install the v10 prerelease of the React DayPicker package with the Ethiopic
+calendar addon:
 
 ```bash
 npm install @daypicker/react@next @daypicker/ethiopic@next

--- a/packages/ethiopic/README.md
+++ b/packages/ethiopic/README.md
@@ -9,18 +9,18 @@ uses the Amharic locale and Ethiopic numerals by default.
 
 ## Installation
 
-Install the v10 prerelease of React DayPicker together with the Ethiopic
-calendar package:
+Install the v10 prerelease of the scoped React DayPicker package together with
+the Ethiopic calendar package:
 
 ```bash
-npm install react-day-picker@next @daypicker/ethiopic@next
+npm install @daypicker/react@next @daypicker/ethiopic@next
 ```
 
 ## Usage
 
 ```tsx
 import { DayPicker } from "@daypicker/ethiopic";
-import "react-day-picker/style.css";
+import "@daypicker/react/style.css";
 
 export function EthiopicCalendar() {
   return <DayPicker mode="single" />;

--- a/packages/ethiopic/README.md
+++ b/packages/ethiopic/README.md
@@ -9,8 +9,8 @@ uses the Amharic locale and Ethiopic numerals by default.
 
 ## Installation
 
-Install the v10 prerelease of the scoped React DayPicker package together with
-the Ethiopic calendar package:
+Install the v10 prerelease of the React DayPicker package together with the
+Ethiopic calendar package:
 
 ```bash
 npm install @daypicker/react@next @daypicker/ethiopic@next

--- a/packages/ethiopic/package.json
+++ b/packages/ethiopic/package.json
@@ -44,13 +44,10 @@
     "typecheck": "tsc --project ./tsconfig.json --noEmit"
   },
   "peerDependencies": {
-    "react": ">=16.8.0",
-    "react-day-picker": "10.0.0-next.5"
+    "react": ">=16.8.0"
   },
   "dependencies": {
+    "@daypicker/react": "10.0.0-next.5",
     "date-fns": "^4.1.0"
-  },
-  "devDependencies": {
-    "react-day-picker": "workspace:*"
   }
 }

--- a/packages/ethiopic/src/classes/DateLib.ts
+++ b/packages/ethiopic/src/classes/DateLib.ts
@@ -1,2 +1,2 @@
-export type { DateLibOptions } from "react-day-picker";
-export { DateLib } from "react-day-picker";
+export type { DateLibOptions } from "@daypicker/react";
+export { DateLib } from "@daypicker/react";

--- a/packages/ethiopic/src/ethiopic/index.tsx
+++ b/packages/ethiopic/src/ethiopic/index.tsx
@@ -1,10 +1,10 @@
-import type { Locale } from "date-fns";
-import React from "react";
 import {
   DateLib,
   type DateLibOptions,
   DayPicker as DayPickerComponent,
-} from "react-day-picker";
+} from "@daypicker/react";
+import type { Locale } from "date-fns";
+import React from "react";
 import amET from "../locale/am-ET.js";
 import type { DayPickerProps } from "../types/props.js";
 import * as ethiopicDateLib from "./lib/index.js";

--- a/packages/ethiopic/src/locale/am-ET.ts
+++ b/packages/ethiopic/src/locale/am-ET.ts
@@ -1,15 +1,15 @@
+import {
+  DateLib,
+  type DateLibOptions,
+  type DayPickerLocale,
+  type Modifiers,
+} from "@daypicker/react";
 import type {
   LocaleDayPeriod,
   LocaleOptions,
   LocaleWidth,
   Localize,
 } from "date-fns/locale";
-import {
-  DateLib,
-  type DateLibOptions,
-  type DayPickerLocale,
-  type Modifiers,
-} from "react-day-picker";
 import { enUS } from "./en-US.js";
 
 /**

--- a/packages/ethiopic/src/locale/en-US.ts
+++ b/packages/ethiopic/src/locale/en-US.ts
@@ -1,1 +1,1 @@
-export { enUS } from "react-day-picker/locale";
+export { enUS } from "@daypicker/react/locale";

--- a/packages/ethiopic/src/types/props.ts
+++ b/packages/ethiopic/src/types/props.ts
@@ -1,1 +1,1 @@
-export type { DayPickerProps } from "react-day-picker";
+export type { DayPickerProps } from "@daypicker/react";

--- a/packages/hebrew/README.md
+++ b/packages/hebrew/README.md
@@ -10,18 +10,18 @@ and right-to-left direction by default.
 
 ## Installation
 
-Install the v10 prerelease of React DayPicker together with the Hebrew calendar
-package:
+Install the v10 prerelease of the scoped React DayPicker package together with
+the Hebrew calendar package:
 
 ```bash
-npm install react-day-picker@next @daypicker/hebrew@next
+npm install @daypicker/react@next @daypicker/hebrew@next
 ```
 
 ## Usage
 
 ```tsx
 import { DayPicker } from "@daypicker/hebrew";
-import "react-day-picker/style.css";
+import "@daypicker/react/style.css";
 
 export function HebrewCalendar() {
   return <DayPicker mode="single" />;

--- a/packages/hebrew/README.md
+++ b/packages/hebrew/README.md
@@ -10,8 +10,8 @@ and right-to-left direction by default.
 
 ## Installation
 
-Install the v10 prerelease of the scoped React DayPicker package together with
-the Hebrew calendar package:
+Install the v10 prerelease of the React DayPicker package together with the
+Hebrew calendar package:
 
 ```bash
 npm install @daypicker/react@next @daypicker/hebrew@next

--- a/packages/hebrew/README.md
+++ b/packages/hebrew/README.md
@@ -10,8 +10,8 @@ and right-to-left direction by default.
 
 ## Installation
 
-Install the v10 prerelease of the React DayPicker package together with the
-Hebrew calendar package:
+Install the v10 prerelease of the React DayPicker package with the Hebrew
+calendar addon:
 
 ```bash
 npm install @daypicker/react@next @daypicker/hebrew@next

--- a/packages/hebrew/package.json
+++ b/packages/hebrew/package.json
@@ -44,13 +44,10 @@
     "typecheck": "tsc --project ./tsconfig.json --noEmit"
   },
   "peerDependencies": {
-    "react": ">=16.8.0",
-    "react-day-picker": "10.0.0-next.5"
+    "react": ">=16.8.0"
   },
   "dependencies": {
+    "@daypicker/react": "10.0.0-next.5",
     "date-fns": "^4.1.0"
-  },
-  "devDependencies": {
-    "react-day-picker": "workspace:*"
   }
 }

--- a/packages/hebrew/src/classes/DateLib.ts
+++ b/packages/hebrew/src/classes/DateLib.ts
@@ -1,2 +1,2 @@
-export type { DateLibOptions } from "react-day-picker";
-export { DateLib } from "react-day-picker";
+export type { DateLibOptions } from "@daypicker/react";
+export { DateLib } from "@daypicker/react";

--- a/packages/hebrew/src/hebrew/index.tsx
+++ b/packages/hebrew/src/hebrew/index.tsx
@@ -1,10 +1,10 @@
-import type { Locale } from "date-fns";
-import React from "react";
 import {
   DateLib,
   type DateLibOptions,
   DayPicker as DayPickerComponent,
-} from "react-day-picker";
+} from "@daypicker/react";
+import type { Locale } from "date-fns";
+import React from "react";
 import { he } from "../locale/he.js";
 import type { DayPickerProps } from "../types/props.js";
 import * as hebrewDateLib from "./lib/index.js";

--- a/packages/hebrew/src/locale/en-US.ts
+++ b/packages/hebrew/src/locale/en-US.ts
@@ -1,1 +1,1 @@
-export { enUS } from "react-day-picker/locale";
+export { enUS } from "@daypicker/react/locale";

--- a/packages/hebrew/src/locale/he.ts
+++ b/packages/hebrew/src/locale/he.ts
@@ -1,1 +1,1 @@
-export { he } from "react-day-picker/locale";
+export { he } from "@daypicker/react/locale";

--- a/packages/hebrew/src/types/props.ts
+++ b/packages/hebrew/src/types/props.ts
@@ -1,1 +1,1 @@
-export type { DayPickerProps } from "react-day-picker";
+export type { DayPickerProps } from "@daypicker/react";

--- a/packages/hijri/README.md
+++ b/packages/hijri/README.md
@@ -10,18 +10,18 @@ right-to-left direction by default.
 
 ## Installation
 
-Install the v10 prerelease of React DayPicker together with the Hijri calendar
-package:
+Install the v10 prerelease of the scoped React DayPicker package together with
+the Hijri calendar package:
 
 ```bash
-npm install react-day-picker@next @daypicker/hijri@next
+npm install @daypicker/react@next @daypicker/hijri@next
 ```
 
 ## Usage
 
 ```tsx
 import { DayPicker } from "@daypicker/hijri";
-import "react-day-picker/style.css";
+import "@daypicker/react/style.css";
 
 export function HijriCalendar() {
   return <DayPicker mode="single" />;

--- a/packages/hijri/README.md
+++ b/packages/hijri/README.md
@@ -10,8 +10,8 @@ right-to-left direction by default.
 
 ## Installation
 
-Install the v10 prerelease of the React DayPicker package together with the
-Hijri calendar package:
+Install the v10 prerelease of the React DayPicker package with the Hijri
+calendar addon:
 
 ```bash
 npm install @daypicker/react@next @daypicker/hijri@next

--- a/packages/hijri/README.md
+++ b/packages/hijri/README.md
@@ -10,8 +10,8 @@ right-to-left direction by default.
 
 ## Installation
 
-Install the v10 prerelease of the scoped React DayPicker package together with
-the Hijri calendar package:
+Install the v10 prerelease of the React DayPicker package together with the
+Hijri calendar package:
 
 ```bash
 npm install @daypicker/react@next @daypicker/hijri@next

--- a/packages/hijri/package.json
+++ b/packages/hijri/package.json
@@ -44,14 +44,11 @@
     "typecheck": "tsc --project ./tsconfig.json --noEmit"
   },
   "peerDependencies": {
-    "react": ">=16.8.0",
-    "react-day-picker": "10.0.0-next.5"
+    "react": ">=16.8.0"
   },
   "dependencies": {
+    "@daypicker/react": "10.0.0-next.5",
     "@tabby_ai/hijri-converter": "1.0.5",
     "date-fns": "^4.1.0"
-  },
-  "devDependencies": {
-    "react-day-picker": "workspace:*"
   }
 }

--- a/packages/hijri/src/classes/DateLib.ts
+++ b/packages/hijri/src/classes/DateLib.ts
@@ -1,2 +1,2 @@
-export type { DateLibOptions } from "react-day-picker";
-export { DateLib } from "react-day-picker";
+export type { DateLibOptions } from "@daypicker/react";
+export { DateLib } from "@daypicker/react";

--- a/packages/hijri/src/hijri/index.tsx
+++ b/packages/hijri/src/hijri/index.tsx
@@ -1,10 +1,10 @@
-import type { Locale } from "date-fns";
-import React from "react";
 import {
   DateLib,
   type DateLibOptions,
   DayPicker as DayPickerComponent,
-} from "react-day-picker";
+} from "@daypicker/react";
+import type { Locale } from "date-fns";
+import React from "react";
 import { arSA } from "../locale/ar-SA.js";
 import type { DayPickerProps } from "../types/props.js";
 import * as hijriDateLib from "./lib/index.js";

--- a/packages/hijri/src/locale/ar-SA.ts
+++ b/packages/hijri/src/locale/ar-SA.ts
@@ -1,1 +1,1 @@
-export { arSA } from "react-day-picker/locale";
+export { arSA } from "@daypicker/react/locale";

--- a/packages/hijri/src/locale/en-US.ts
+++ b/packages/hijri/src/locale/en-US.ts
@@ -1,1 +1,1 @@
-export { enUS } from "react-day-picker/locale";
+export { enUS } from "@daypicker/react/locale";

--- a/packages/hijri/src/types/props.ts
+++ b/packages/hijri/src/types/props.ts
@@ -1,1 +1,1 @@
-export type { DayPickerProps } from "react-day-picker";
+export type { DayPickerProps } from "@daypicker/react";

--- a/packages/persian/README.md
+++ b/packages/persian/README.md
@@ -10,18 +10,18 @@ direction by default.
 
 ## Installation
 
-Install the v10 prerelease of React DayPicker together with the Persian
-calendar package:
+Install the v10 prerelease of the scoped React DayPicker package together with
+the Persian calendar package:
 
 ```bash
-npm install react-day-picker@next @daypicker/persian@next
+npm install @daypicker/react@next @daypicker/persian@next
 ```
 
 ## Usage
 
 ```tsx
 import { DayPicker } from "@daypicker/persian";
-import "react-day-picker/style.css";
+import "@daypicker/react/style.css";
 
 export function PersianCalendar() {
   return <DayPicker mode="single" />;

--- a/packages/persian/README.md
+++ b/packages/persian/README.md
@@ -10,8 +10,8 @@ direction by default.
 
 ## Installation
 
-Install the v10 prerelease of the scoped React DayPicker package together with
-the Persian calendar package:
+Install the v10 prerelease of the React DayPicker package together with the
+Persian calendar package:
 
 ```bash
 npm install @daypicker/react@next @daypicker/persian@next

--- a/packages/persian/README.md
+++ b/packages/persian/README.md
@@ -10,8 +10,8 @@ direction by default.
 
 ## Installation
 
-Install the v10 prerelease of the React DayPicker package together with the
-Persian calendar package:
+Install the v10 prerelease of the React DayPicker package with the Persian
+calendar addon:
 
 ```bash
 npm install @daypicker/react@next @daypicker/persian@next

--- a/packages/persian/package.json
+++ b/packages/persian/package.json
@@ -44,14 +44,11 @@
     "typecheck": "tsc --project ./tsconfig.json --noEmit"
   },
   "peerDependencies": {
-    "react": ">=16.8.0",
-    "react-day-picker": "10.0.0-next.5"
+    "react": ">=16.8.0"
   },
   "dependencies": {
+    "@daypicker/react": "10.0.0-next.5",
     "@date-fns/tz": "^1.4.1",
     "date-fns-jalali": "4.1.0-0"
-  },
-  "devDependencies": {
-    "react-day-picker": "workspace:*"
   }
 }

--- a/packages/persian/src/classes/DateLib.ts
+++ b/packages/persian/src/classes/DateLib.ts
@@ -4,5 +4,5 @@ export type {
   DayPickerLocaleLabels,
   Locale,
   MonthYearOrder,
-} from "react-day-picker";
-export { DateLib } from "react-day-picker";
+} from "@daypicker/react";
+export { DateLib } from "@daypicker/react";

--- a/packages/persian/src/index.tsx
+++ b/packages/persian/src/index.tsx
@@ -1,12 +1,12 @@
-import * as dateFnsJalali from "date-fns-jalali";
-import React from "react";
 import {
   DateLib,
   type DateLibOptions,
   DayPicker as DayPickerComponent,
   type DayPickerLocale,
   type DayPickerProps,
-} from "react-day-picker";
+} from "@daypicker/react";
+import * as dateFnsJalali from "date-fns-jalali";
+import React from "react";
 import { enUSJalali } from "./locale/en-US-jalali.js";
 import { faIRJalali } from "./locale/fa-IR-jalali.js";
 import { createJalaliNoonOverrides } from "./noonJalaliDateLib.js";

--- a/packages/persian/src/types/index.ts
+++ b/packages/persian/src/types/index.ts
@@ -1,1 +1,1 @@
-export type { Modifiers } from "react-day-picker";
+export type { Modifiers } from "@daypicker/react";

--- a/packages/persian/src/types/props.ts
+++ b/packages/persian/src/types/props.ts
@@ -1,1 +1,1 @@
-export type { DayPickerProps } from "react-day-picker";
+export type { DayPickerProps } from "@daypicker/react";

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @daypicker/react

--- a/packages/react/LICENSE
+++ b/packages/react/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2026 Giampaolo Bellavite <io@gpbl.dev> and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,27 @@
+# @daypicker/react
+
+Scoped package alias for [React DayPicker](https://daypicker.dev).
+
+This package re-exports the public API from `react-day-picker` while the
+DayPicker packages move toward the `@daypicker/*` namespace.
+
+## Installation
+
+```bash
+npm install @daypicker/react@next
+```
+
+## Usage
+
+```tsx
+import { DayPicker } from "@daypicker/react";
+import "@daypicker/react/style.css";
+
+export function Calendar() {
+  return <DayPicker mode="single" />;
+}
+```
+
+## License
+
+MIT. See [LICENSE](./LICENSE).

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,9 +1,9 @@
 # @daypicker/react
 
-Scoped package alias for [React DayPicker](https://daypicker.dev).
+React package for [DayPicker](https://daypicker.dev).
 
-This package re-exports the public API from `react-day-picker` while the
-DayPicker packages move toward the `@daypicker/*` namespace.
+This package re-exports the public API from `react-day-picker` for the
+`@daypicker/*` namespace.
 
 ## Installation
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,6 +25,9 @@
   "sideEffects": [
     "**/*.css"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@daypicker/react",
   "version": "10.0.0-next.5",
-  "description": "Scoped alias for react-day-picker",
+  "description": "React package for DayPicker",
   "author": "Giampaolo Bellavite <io@gpbl.dev>",
   "homepage": "https://daypicker.dev",
   "packageManager": "pnpm@10.24.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,170 @@
+{
+  "name": "@daypicker/react",
+  "version": "10.0.0-next.5",
+  "description": "Scoped alias for react-day-picker",
+  "author": "Giampaolo Bellavite <io@gpbl.dev>",
+  "homepage": "https://daypicker.dev",
+  "packageManager": "pnpm@10.24.0",
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gpbl/react-day-picker.git",
+    "directory": "packages/react"
+  },
+  "bugs": {
+    "url": "https://github.com/gpbl/react-day-picker/issues"
+  },
+  "main": "./dist/cjs/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "module": "./dist/esm/index.js",
+  "style": "./dist/style.css",
+  "type": "module",
+  "sideEffects": [
+    "**/*.css"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    },
+    "./style": {
+      "sass": "./dist/style.css"
+    },
+    "./style.css": {
+      "style": {
+        "default": "./dist/style.css"
+      },
+      "import": {
+        "types": "./dist/style.css.d.ts",
+        "default": "./dist/style.css"
+      },
+      "require": {
+        "types": "./dist/style.css.d.ts",
+        "default": "./dist/style.css"
+      }
+    },
+    "./style.module": {
+      "sass": "./dist/style.module.css"
+    },
+    "./style.module.css": {
+      "style": {
+        "default": "./dist/style.module.css"
+      },
+      "import": {
+        "types": "./dist/style.module.css.d.ts",
+        "default": "./dist/style.module.css"
+      },
+      "require": {
+        "types": "./dist/style.module.css.d.ts",
+        "default": "./dist/style.module.css"
+      }
+    },
+    "./src/style.css": {
+      "style": {
+        "default": "./dist/style.css"
+      },
+      "import": {
+        "types": "./dist/style.css.d.ts",
+        "default": "./dist/style.css"
+      },
+      "require": {
+        "types": "./dist/style.css.d.ts",
+        "default": "./dist/style.css"
+      }
+    },
+    "./src/style.module.css": {
+      "style": {
+        "default": "./dist/style.module.css"
+      },
+      "import": {
+        "types": "./dist/style.module.css.d.ts",
+        "default": "./dist/style.module.css"
+      },
+      "require": {
+        "types": "./dist/style.module.css.d.ts",
+        "default": "./dist/style.module.css"
+      }
+    },
+    "./dist/style.css": {
+      "style": {
+        "default": "./dist/style.css"
+      },
+      "import": {
+        "types": "./dist/style.css.d.ts",
+        "default": "./dist/style.css"
+      },
+      "require": {
+        "types": "./dist/style.css.d.ts",
+        "default": "./dist/style.css"
+      }
+    },
+    "./dist/style.module.css": {
+      "style": {
+        "default": "./dist/style.module.css"
+      },
+      "import": {
+        "types": "./dist/style.module.css.d.ts",
+        "default": "./dist/style.module.css"
+      },
+      "require": {
+        "types": "./dist/style.module.css.d.ts",
+        "default": "./dist/style.module.css"
+      }
+    },
+    "./package.json": {
+      "import": "./package.json",
+      "require": "./package.json",
+      "default": "./package.json"
+    },
+    "./locale": {
+      "import": {
+        "types": "./dist/esm/locale.d.ts",
+        "default": "./dist/esm/locale.js"
+      },
+      "require": {
+        "types": "./dist/cjs/locale.d.ts",
+        "default": "./dist/cjs/locale.js"
+      }
+    },
+    "./locale/*": {
+      "import": {
+        "types": "./dist/esm/locale/*.d.ts",
+        "default": "./dist/esm/locale/*.js"
+      },
+      "require": {
+        "types": "./dist/cjs/locale/*.d.ts",
+        "default": "./dist/cjs/locale/*.js"
+      }
+    }
+  },
+  "scripts": {
+    "prepublish": "pnpm build",
+    "build": "rm -rf dist && pnpm build:cjs && pnpm build:esm && pnpm build:assets",
+    "build:cjs": "tsc --project tsconfig-cjs.json && echo '{ \"type\": \"commonjs\" }' > dist/cjs/package.json",
+    "build:esm": "tsc --project tsconfig-esm.json",
+    "build:assets": "node ./scripts/build-assets.mjs",
+    "typecheck": "tsc --project ./tsconfig.json --noEmit"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "react-day-picker": "10.0.0-next.5"
+  },
+  "peerDependencies": {
+    "react": ">=16.8.0"
+  },
+  "funding": {
+    "type": "individual",
+    "url": "https://github.com/sponsors/gpbl"
+  }
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,9 +25,6 @@
   "sideEffects": [
     "**/*.css"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react/scripts/build-assets.mjs
+++ b/packages/react/scripts/build-assets.mjs
@@ -1,0 +1,51 @@
+import { cp, mkdir, readdir, writeFile } from "node:fs/promises";
+
+const packageRoot = new URL("../", import.meta.url);
+const reactDayPickerSrc = new URL("../react-day-picker/src/", packageRoot);
+const localeSrc = new URL("locale/", reactDayPickerSrc);
+const distRoot = new URL("dist/", packageRoot);
+const esmLocaleDist = new URL("esm/locale/", distRoot);
+const cjsLocaleDist = new URL("cjs/locale/", distRoot);
+
+await Promise.all([
+  mkdir(esmLocaleDist, { recursive: true }),
+  mkdir(cjsLocaleDist, { recursive: true }),
+]);
+
+await Promise.all(
+  [
+    "style.css",
+    "style.css.d.ts",
+    "style.module.css",
+    "style.module.css.d.ts",
+  ].map((fileName) =>
+    cp(new URL(fileName, reactDayPickerSrc), new URL(fileName, distRoot)),
+  ),
+);
+
+const localeFiles = (await readdir(localeSrc, { withFileTypes: true }))
+  .filter((entry) => entry.isFile() && entry.name.endsWith(".ts"))
+  .map((entry) => entry.name.slice(0, -".ts".length))
+  .sort();
+
+for (const localeName of localeFiles) {
+  const specifier = `react-day-picker/locale/${localeName}`;
+  await Promise.all([
+    writeFile(
+      new URL(`${localeName}.js`, esmLocaleDist),
+      `export * from ${JSON.stringify(specifier)};\n`,
+    ),
+    writeFile(
+      new URL(`${localeName}.d.ts`, esmLocaleDist),
+      `export * from ${JSON.stringify(specifier)};\n`,
+    ),
+    writeFile(
+      new URL(`${localeName}.js`, cjsLocaleDist),
+      `"use strict";\nmodule.exports = require(${JSON.stringify(specifier)});\n`,
+    ),
+    writeFile(
+      new URL(`${localeName}.d.ts`, cjsLocaleDist),
+      `export * from ${JSON.stringify(specifier)};\n`,
+    ),
+  ]);
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,0 +1,1 @@
+export * from "react-day-picker";

--- a/packages/react/src/locale.ts
+++ b/packages/react/src/locale.ts
@@ -1,0 +1,1 @@
+export * from "react-day-picker/locale";

--- a/packages/react/tsconfig-cjs.json
+++ b/packages/react/tsconfig-cjs.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig-base.json",
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "rootDir": "./src",
+    "module": "CommonJS",
+    "sourceMap": false
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.*"]
+}

--- a/packages/react/tsconfig-esm.json
+++ b/packages/react/tsconfig-esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig-base.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+    "rootDir": "./src",
+    "module": "ES2020",
+    "sourceMap": false
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.*"]
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig-workspace-base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "../..",
+    "types": ["node", "jest", "@testing-library/jest-dom", "@types/jest"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@daypicker/react': link:packages/react
+  '@daypicker/react>react-day-picker': link:packages/react-day-picker
   '@babel/runtime': 7.28.4
   ajv@6: 6.15.0
   diff: 4.0.4
@@ -26,6 +28,9 @@ importers:
       '@date-fns/tz':
         specifier: ^1.4.1
         version: 1.4.1
+      '@daypicker/react':
+        specifier: link:packages/react
+        version: link:packages/react
       '@jest/types':
         specifier: ^30.3.0
         version: 30.3.0
@@ -372,45 +377,45 @@ importers:
 
   packages/buddhist:
     dependencies:
+      '@daypicker/react':
+        specifier: link:../react
+        version: link:../react
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
       react:
         specifier: '>=16.8.0'
         version: 19.2.5
-    devDependencies:
-      react-day-picker:
-        specifier: workspace:*
-        version: link:../react-day-picker
 
   packages/ethiopic:
     dependencies:
+      '@daypicker/react':
+        specifier: link:../react
+        version: link:../react
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
       react:
         specifier: '>=16.8.0'
         version: 19.2.5
-    devDependencies:
-      react-day-picker:
-        specifier: workspace:*
-        version: link:../react-day-picker
 
   packages/hebrew:
     dependencies:
+      '@daypicker/react':
+        specifier: link:../react
+        version: link:../react
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
       react:
         specifier: '>=16.8.0'
         version: 19.2.5
-    devDependencies:
-      react-day-picker:
-        specifier: workspace:*
-        version: link:../react-day-picker
 
   packages/hijri:
     dependencies:
+      '@daypicker/react':
+        specifier: link:../react
+        version: link:../react
       '@tabby_ai/hijri-converter':
         specifier: 1.0.5
         version: 1.0.5
@@ -420,25 +425,29 @@ importers:
       react:
         specifier: '>=16.8.0'
         version: 19.2.5
-    devDependencies:
-      react-day-picker:
-        specifier: workspace:*
-        version: link:../react-day-picker
 
   packages/persian:
     dependencies:
       '@date-fns/tz':
         specifier: ^1.4.1
         version: 1.4.1
+      '@daypicker/react':
+        specifier: link:../react
+        version: link:../react
       date-fns-jalali:
         specifier: 4.1.0-0
         version: 4.1.0-0
       react:
         specifier: '>=16.8.0'
         version: 19.2.5
-    devDependencies:
+
+  packages/react:
+    dependencies:
+      react:
+        specifier: '>=16.8.0'
+        version: 19.2.5
       react-day-picker:
-        specifier: workspace:*
+        specifier: link:../react-day-picker
         version: link:../react-day-picker
 
   packages/react-day-picker:

--- a/scripts/check-package-versions.ts
+++ b/scripts/check-package-versions.ts
@@ -5,6 +5,7 @@ const repoRoot = new URL("../", import.meta.url);
 
 const packagePaths = [
   "packages/react-day-picker/package.json",
+  "packages/react/package.json",
   "packages/buddhist/package.json",
   "packages/ethiopic/package.json",
   "packages/hebrew/package.json",
@@ -14,18 +15,33 @@ const packagePaths = [
 
 function readPackageJson(packagePath: string): {
   version: string;
+  dependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
 } {
   const filePath = new URL(packagePath, repoRoot);
   return JSON.parse(readFileSync(filePath, "utf8")) as {
     version: string;
+    dependencies?: Record<string, string>;
     peerDependencies?: Record<string, string>;
   };
 }
 
 const rootVersion = readPackageJson(packagePaths[0]).version;
+const reactPackageJson = readPackageJson(packagePaths[1]);
 
-for (const packagePath of packagePaths.slice(1)) {
+if (reactPackageJson.version !== rootVersion) {
+  throw new Error(
+    `Expected packages/react version ${rootVersion}, got ${reactPackageJson.version}.`,
+  );
+}
+
+if (reactPackageJson.dependencies?.["react-day-picker"] !== rootVersion) {
+  throw new Error(
+    `Expected packages/react dependency react-day-picker=${rootVersion}, got ${reactPackageJson.dependencies?.["react-day-picker"]}.`,
+  );
+}
+
+for (const packagePath of packagePaths.slice(2)) {
   const packageJson = readPackageJson(packagePath);
   if (packageJson.version !== rootVersion) {
     throw new Error(
@@ -33,9 +49,15 @@ for (const packagePath of packagePaths.slice(1)) {
     );
   }
 
-  if (packageJson.peerDependencies?.["react-day-picker"] !== rootVersion) {
+  if (packageJson.dependencies?.["@daypicker/react"] !== rootVersion) {
     throw new Error(
-      `Expected ${path.dirname(packagePath)} peer dependency react-day-picker=${rootVersion}, got ${packageJson.peerDependencies?.["react-day-picker"]}.`,
+      `Expected ${path.dirname(packagePath)} dependency @daypicker/react=${rootVersion}, got ${packageJson.dependencies?.["@daypicker/react"]}.`,
+    );
+  }
+
+  if (packageJson.peerDependencies?.["react-day-picker"]) {
+    throw new Error(
+      `Expected ${path.dirname(packagePath)} to depend on @daypicker/react instead of peering on react-day-picker.`,
     );
   }
 }

--- a/scripts/create-github-release.test.ts
+++ b/scripts/create-github-release.test.ts
@@ -8,6 +8,10 @@ const releasePackageInfoByDir: Record<
     name: "react-day-picker",
     version: "10.0.0-next.1",
   },
+  "packages/react": {
+    name: "@daypicker/react",
+    version: "10.0.0-next.1",
+  },
   "packages/buddhist": {
     name: "@daypicker/buddhist",
     version: "10.0.0-next.1",

--- a/scripts/npm-pack-dry-run.ts
+++ b/scripts/npm-pack-dry-run.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 
 const packageDirs = [
   "packages/react-day-picker",
+  "packages/react",
   "packages/buddhist",
   "packages/ethiopic",
   "packages/hebrew",

--- a/scripts/publish-packages.test.ts
+++ b/scripts/publish-packages.test.ts
@@ -11,6 +11,10 @@ const packageInfoByDir: Record<string, { name: string; version: string }> = {
     name: "react-day-picker",
     version: "10.0.0-next.1",
   },
+  "packages/react": {
+    name: "@daypicker/react",
+    version: "10.0.0-next.1",
+  },
   "packages/buddhist": {
     name: "@daypicker/buddhist",
     version: "10.0.0-next.1",
@@ -109,7 +113,7 @@ describe("publishPackages", function describePublishPackages() {
           return "";
         }
 
-        if (args[1] === "@daypicker/buddhist@10.0.0-next.1") {
+        if (args[1] === "@daypicker/react@10.0.0-next.1") {
           throw createNpmError("npm ERR! code E404\nnpm ERR! 404 Not Found");
         }
 
@@ -119,9 +123,9 @@ describe("publishPackages", function describePublishPackages() {
 
     expect(getUnpublishedPackages()).toEqual([
       {
-        packageDir: "packages/buddhist",
+        packageDir: "packages/react",
         packageInfo: {
-          name: "@daypicker/buddhist",
+          name: "@daypicker/react",
           version: "10.0.0-next.1",
         },
       },
@@ -142,7 +146,7 @@ describe("publishPackages", function describePublishPackages() {
         }
 
         if (args[0] === "view") {
-          if (args[1] === "@daypicker/buddhist@10.0.0-next.1") {
+          if (args[1] === "@daypicker/react@10.0.0-next.1") {
             throw createNpmError("npm ERR! code E404");
           }
           return "10.0.0-next.1\n";
@@ -156,8 +160,9 @@ describe("publishPackages", function describePublishPackages() {
 
     expect(execCalls.map((call) => call.args)).toEqual([
       ["view", "react-day-picker@10.0.0-next.1", "version"],
-      ["view", "@daypicker/buddhist@10.0.0-next.1", "version"],
+      ["view", "@daypicker/react@10.0.0-next.1", "version"],
       ["publish", "--provenance", "--tag", "next", "--access", "public"],
+      ["view", "@daypicker/buddhist@10.0.0-next.1", "version"],
       ["view", "@daypicker/ethiopic@10.0.0-next.1", "version"],
       ["view", "@daypicker/hebrew@10.0.0-next.1", "version"],
       ["view", "@daypicker/hijri@10.0.0-next.1", "version"],
@@ -167,7 +172,7 @@ describe("publishPackages", function describePublishPackages() {
       | { cwd?: URL; stdio?: string }
       | undefined;
     expect(publishOptions?.stdio).toBe("inherit");
-    expect(publishOptions?.cwd?.href).toContain("packages/buddhist");
+    expect(publishOptions?.cwd?.href).toContain("packages/react");
     expect(consoleLogSpy).toHaveBeenCalledWith(
       "Skipping react-day-picker@10.0.0-next.1; already published.",
     );

--- a/scripts/publish-packages.ts
+++ b/scripts/publish-packages.ts
@@ -7,6 +7,7 @@ const repoRoot = new URL("../", import.meta.url);
 
 export const publishablePackageDirs = [
   "packages/react-day-picker",
+  "packages/react",
   "packages/buddhist",
   "packages/ethiopic",
   "packages/hebrew",

--- a/scripts/release-notes.test.ts
+++ b/scripts/release-notes.test.ts
@@ -8,6 +8,10 @@ const releaseNotesPackageInfoByDir: Record<
     name: "react-day-picker",
     version: "10.0.0-next.4",
   },
+  "packages/react": {
+    name: "@daypicker/react",
+    version: "10.0.0-next.4",
+  },
   "packages/buddhist": {
     name: "@daypicker/buddhist",
     version: "10.0.0-next.4",

--- a/tsconfig-workspace-base.json
+++ b/tsconfig-workspace-base.json
@@ -6,6 +6,15 @@
     "paths": {
       "@/test": ["./test"],
       "@/test/*": ["./test/*"],
+      "@daypicker/react": ["./packages/react/src/index.ts"],
+      "@daypicker/react/locale": ["./packages/react/src/locale.ts"],
+      "@daypicker/react/locale/*": ["./packages/react-day-picker/src/locale/*"],
+      "@daypicker/react/style.css": [
+        "./packages/react-day-picker/src/style.css"
+      ],
+      "@daypicker/react/style.module.css": [
+        "./packages/react-day-picker/src/style.module.css"
+      ],
       "react-day-picker": ["./packages/react-day-picker/src/index.ts"],
       "react-day-picker/*": ["./packages/react-day-picker/src/*"],
       "@daypicker/buddhist": ["./packages/buddhist/src/index.tsx"],


### PR DESCRIPTION
## What Changed

- Added `@daypicker/react` as a wrapper package over `react-day-picker`, including the root entry, locale entry, locale subpaths, CSS, CSS modules, and package metadata exports.
- Updated calendar packages to consume `@daypicker/react` and documented installing the scoped React package alongside each `@daypicker/*` calendar package.
- Wired workspace resolution, Jest/TypeScript aliases, build order, dry-run packaging, version checks, release fixtures, and smoke coverage for the scoped alias.

## Review Notes

- `@daypicker/react` keeps `react-day-picker` as the implementation dependency for this prerelease.
- `@daypicker/react@10.0.0-next.5` has been manually seeded on npm so the next Changesets release can publish the bumped version through the normal trusted publishing workflow.
- Root `pnpm` overrides link exact publishable dependencies to local workspace packages so the alias and calendar packages can be tested against local builds.

## Validation

- `pnpm check:versions`
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm pack:dry-run`
- `npm pack --dry-run --json` in `packages/react`
- `pnpm exec jest --selectProjects scripts --runTestsByPath scripts/publish-packages.test.ts scripts/release-ci.test.ts`
- Node ESM/CJS resolver checks for `@daypicker/react`, locale subpaths, and CSS exports