### PR TITLE
test: lock Date behavior before Temporal prep

### DIFF
--- a/packages/react-day-picker/src/DayPicker.test.tsx
+++ b/packages/react-day-picker/src/DayPicker.test.tsx
@@ -11,7 +11,7 @@ import {
 import { act, fireEvent, render, screen } from "@/test/render";
 import { setTestTime } from "@/test/setTestTime";
 import { user } from "@/test/user";
-import { defaultLocale } from "./classes/DateLib";
+import { DateLib, defaultLocale } from "./classes/DateLib";
 import type { MonthProps } from "./components/Month";
 import type { MonthsProps } from "./components/Months";
 import { DayPicker } from "./DayPicker";
@@ -19,6 +19,18 @@ import { ja } from "./locale/ja.js";
 
 const testId = "test";
 const dayPicker = () => screen.getByTestId(testId);
+
+function expectFirstOfMonthDate(
+  value: unknown,
+  year: number,
+  monthIndex: number,
+) {
+  expect(value).toBeInstanceOf(Date);
+  const date = value as Date;
+  expect(date.getFullYear()).toBe(year);
+  expect(date.getMonth()).toBe(monthIndex);
+  expect(date.getDate()).toBe(1);
+}
 
 test("should render a date picker component", () => {
   render(<DayPicker data-testid={testId} />);
@@ -105,6 +117,153 @@ test("use custom components", () => {
   expect(dayPicker()).toHaveTextContent("Custom Months");
   expect(dayPicker()).toHaveTextContent("Custom Month");
   expect(dayPicker()).toHaveTextContent("Custom Footer");
+});
+
+test("passes Date-backed calendar data to custom components", () => {
+  const monthDates: unknown[] = [];
+  const dayDates: unknown[] = [];
+
+  render(
+    <DayPicker
+      month={new Date(2024, 0, 1)}
+      components={{
+        Month: ({ calendarMonth, displayIndex, ...divProps }) => {
+          monthDates.push(calendarMonth.date);
+          return <div {...divProps} data-display-index={displayIndex} />;
+        },
+        DayButton: ({ day, modifiers, ...buttonProps }) => {
+          dayDates.push(day.date);
+          return (
+            <button
+              {...buttonProps}
+              data-has-modifiers={Object.keys(modifiers).length > 0}
+            />
+          );
+        },
+      }}
+      mode="single"
+    />,
+  );
+
+  expect(monthDates.length).toBeGreaterThan(0);
+  expect(monthDates.every((monthDate) => monthDate instanceof Date)).toBe(true);
+  expect(dayDates.length).toBeGreaterThan(0);
+  expect(dayDates.every((dayDate) => dayDate instanceof Date)).toBe(true);
+});
+
+test("calls selection and day event callbacks with Date instances", async () => {
+  const selectedDate = new Date(2024, 0, 15);
+  const handleSelect = jest.fn();
+  const handleDayClick = jest.fn();
+
+  render(
+    <DayPicker
+      defaultMonth={selectedDate}
+      mode="single"
+      onDayClick={handleDayClick}
+      onSelect={handleSelect}
+    />,
+  );
+
+  await user.click(dateButton(selectedDate));
+
+  expect(handleSelect).toHaveBeenCalled();
+  expect(handleSelect.mock.calls[0][0]).toBeInstanceOf(Date);
+  expect(handleSelect.mock.calls[0][1]).toBeInstanceOf(Date);
+  expect(handleDayClick).toHaveBeenCalled();
+  expect(handleDayClick.mock.calls[0][0]).toBeInstanceOf(Date);
+});
+
+test("navigates with first-of-month Date callback values", async () => {
+  const handleMonthChange = jest.fn();
+  const handleNextClick = jest.fn();
+  const handlePrevClick = jest.fn();
+
+  render(
+    <DayPicker
+      defaultMonth={new Date(2024, 0, 15)}
+      onMonthChange={handleMonthChange}
+      onNextClick={handleNextClick}
+      onPrevClick={handlePrevClick}
+    />,
+  );
+
+  await user.click(nextButton());
+
+  expectFirstOfMonthDate(handleNextClick.mock.calls[0][0], 2024, 1);
+  expectFirstOfMonthDate(handleMonthChange.mock.calls[0][0], 2024, 1);
+
+  await user.click(previousButton());
+
+  expectFirstOfMonthDate(handlePrevClick.mock.calls[0][0], 2024, 0);
+  expectFirstOfMonthDate(handleMonthChange.mock.calls[1][0], 2024, 0);
+});
+
+test("passes Date values and DateLib options to custom formatters and labels", () => {
+  const formatterDates: unknown[] = [];
+  const formatterOptions: unknown[] = [];
+  const formatterDateLibs: unknown[] = [];
+  const labelDates: unknown[] = [];
+  const labelOptions: unknown[] = [];
+  const labelDateLibs: unknown[] = [];
+
+  render(
+    <DayPicker
+      month={new Date(2024, 0, 1)}
+      mode="single"
+      formatters={{
+        formatCaption: (date, options, dateLib) => {
+          formatterDates.push(date);
+          formatterOptions.push(options);
+          formatterDateLibs.push(dateLib);
+          return dateLib?.format(date, "LLLL y") ?? "";
+        },
+        formatDay: (date, options, dateLib) => {
+          formatterDates.push(date);
+          formatterOptions.push(options);
+          formatterDateLibs.push(dateLib);
+          return dateLib?.format(date, "d") ?? "";
+        },
+      }}
+      labels={{
+        labelGrid: (date, options, dateLib) => {
+          labelDates.push(date);
+          labelOptions.push(options);
+          labelDateLibs.push(dateLib);
+          return dateLib?.format(date, "LLLL y") ?? "";
+        },
+        labelDayButton: (date, _modifiers, options, dateLib) => {
+          labelDates.push(date);
+          labelOptions.push(options);
+          labelDateLibs.push(dateLib);
+          return dateLib?.format(date, "PPPP") ?? "";
+        },
+      }}
+    />,
+  );
+
+  expect(formatterDates.length).toBeGreaterThan(0);
+  expect(formatterDates.every((date) => date instanceof Date)).toBe(true);
+  expect(
+    formatterOptions.every(
+      (options) =>
+        typeof options === "object" && options !== null && "locale" in options,
+    ),
+  ).toBe(true);
+  expect(formatterDateLibs.every((dateLib) => dateLib instanceof DateLib)).toBe(
+    true,
+  );
+  expect(labelDates.length).toBeGreaterThan(0);
+  expect(labelDates.every((date) => date instanceof Date)).toBe(true);
+  expect(
+    labelOptions.every(
+      (options) =>
+        typeof options === "object" && options !== null && "locale" in options,
+    ),
+  ).toBe(true);
+  expect(labelDateLibs.every((dateLib) => dateLib instanceof DateLib)).toBe(
+    true,
+  );
 });
 
 describe("when the date picker is focused", () => {
@@ -242,6 +401,27 @@ describe("when the `month` is changed programmatically", () => {
     expect(grid("January 2023")).toBeInTheDocument();
     rerender(<DayPicker month={newMonth} mode="single" />);
     expect(grid("February 2023")).toBeInTheDocument();
+  });
+
+  test("normalizes rerendered month values to first-of-month Dates", () => {
+    const monthDates: unknown[] = [];
+    const components = {
+      Month: ({ calendarMonth, displayIndex, ...divProps }: MonthProps) => {
+        monthDates.push(calendarMonth.date);
+        return <div {...divProps} data-display-index={displayIndex} />;
+      },
+    };
+
+    const { rerender } = render(
+      <DayPicker month={new Date(2023, 0, 15)} components={components} />,
+    );
+
+    rerender(
+      <DayPicker month={new Date(2023, 1, 20)} components={components} />,
+    );
+
+    expectFirstOfMonthDate(monthDates[0], 2023, 0);
+    expectFirstOfMonthDate(monthDates[monthDates.length - 1], 2023, 1);
   });
 });
 

--- a/packages/react-day-picker/src/classes/DateLib.test.ts
+++ b/packages/react-day-picker/src/classes/DateLib.test.ts
@@ -32,3 +32,23 @@ describe("DateLib numerals", () => {
     expect(dateLib.formatNumber(123)).toBe(expected);
   });
 });
+
+describe("DateLib overrides", () => {
+  test("returns Date instances supplied by date-producing overrides", () => {
+    const today = new Date(2024, 0, 15);
+    const newDate = new Date(2024, 1, 1);
+    const startOfMonth = new Date(2024, 0, 1);
+    const dateLib = new DateLib(undefined, {
+      today: () => today,
+      newDate: () => newDate,
+      startOfMonth: () => startOfMonth,
+    });
+
+    expect(dateLib.today()).toBe(today);
+    expect(dateLib.today()).toBeInstanceOf(Date);
+    expect(dateLib.newDate(2024, 1, 1)).toBe(newDate);
+    expect(dateLib.newDate(2024, 1, 1)).toBeInstanceOf(Date);
+    expect(dateLib.startOfMonth(today)).toBe(startOfMonth);
+    expect(dateLib.startOfMonth(today)).toBeInstanceOf(Date);
+  });
+});

--- a/packages/react-day-picker/src/types/props.test.tsx
+++ b/packages/react-day-picker/src/types/props.test.tsx
@@ -2,22 +2,104 @@ import React from "react";
 
 import { DayPicker } from "../DayPicker";
 
-import type { DateRange } from "./shared";
+import type { DayPickerProps } from "./props";
+import type { DateRange, Matcher } from "./shared";
+
+type PlainDateLike = {
+  year: number;
+  month: number;
+  day: number;
+  equals(other: unknown): boolean;
+};
+
+type DateLike = {
+  getTime(): number;
+  getFullYear(): number;
+  getMonth(): number;
+  getDate(): number;
+};
+
+const date = new Date(2024, 0, 15);
+const month = new Date(2024, 0, 1);
+const endMonth = new Date(2024, 11, 1);
+const plainDateLike: PlainDateLike = {
+  year: 2024,
+  month: 1,
+  day: 15,
+  equals: () => true,
+};
+const dateLike: DateLike = {
+  getTime: () => date.getTime(),
+  getFullYear: () => date.getFullYear(),
+  getMonth: () => date.getMonth(),
+  getDate: () => date.getDate(),
+};
+
+const expectDate = (_date: Date) => {};
+const expectDateRange = (_range: DateRange) => {};
+const dateMatchers: Matcher[] = [
+  date,
+  [date],
+  { from: date, to: date },
+  { before: date },
+  { after: date },
+  { before: endMonth, after: month },
+  { dayOfWeek: [0, 6] },
+  (matchedDate: Date) => matchedDate.getDay() === 0,
+];
+
+const dateShapedProps: DayPickerProps = {
+  today: date,
+  month,
+  defaultMonth: month,
+  startMonth: month,
+  endMonth,
+  disabled: dateMatchers,
+  hidden: dateMatchers,
+  modifiers: {
+    selected: date,
+    booked: [date],
+    range: { from: month, to: endMonth },
+    before: { before: date },
+    after: { after: date },
+    interval: { before: endMonth, after: month },
+    weekend: { dayOfWeek: [0, 6] },
+  },
+  onDayClick: (clickedDate) => {
+    expectDate(clickedDate);
+  },
+  onMonthChange: (changedMonth) => {
+    expectDate(changedMonth);
+  },
+  onNextClick: (nextMonth) => {
+    expectDate(nextMonth);
+  },
+  onPrevClick: (previousMonth) => {
+    expectDate(previousMonth);
+  },
+};
 
 const Test = () => {
   return (
     <>
       <DayPicker />
+      <DayPicker {...dateShapedProps} />
       <DayPicker mode="single" />
       <DayPicker
         mode="single"
         selected={undefined}
-        onSelect={(_date: Date | undefined) => {}}
+        onSelect={(selectedDate, triggerDate) => {
+          if (selectedDate) expectDate(selectedDate);
+          expectDate(triggerDate);
+        }}
       />
       <DayPicker
         mode="single"
         selected={new Date()}
-        onSelect={(_date: Date | undefined) => {}}
+        onSelect={(selectedDate, triggerDate) => {
+          if (selectedDate) expectDate(selectedDate);
+          expectDate(triggerDate);
+        }}
       />
       {/* @ts-expect-error Missing `selected` */}
       <DayPicker
@@ -31,13 +113,19 @@ const Test = () => {
         mode="multiple"
         required
         selected={undefined}
-        onSelect={(_selected: Date[], _date: Date, _modifiers) => {}}
+        onSelect={(selectedDates, triggerDate) => {
+          selectedDates.forEach(expectDate);
+          expectDate(triggerDate);
+        }}
       />
       <DayPicker
         mode="range"
         required
         selected={undefined}
-        onSelect={(_selected: DateRange, _date: Date, _modifiers) => {}}
+        onSelect={(selectedRange, triggerDate) => {
+          expectDateRange(selectedRange);
+          expectDate(triggerDate);
+        }}
       />
       <DayPicker
         mode="multiple"
@@ -56,6 +144,15 @@ const Test = () => {
         onSelect={(_date: Date[]) => {}}
       />
       <DayPicker mode="single" selected={new Date()} />
+      <DayPicker
+        mode="range"
+        selected={{ from: month, to: endMonth }}
+        onSelect={(selectedRange, triggerDate) => {
+          if (selectedRange?.from) expectDate(selectedRange.from);
+          if (selectedRange?.to) expectDate(selectedRange.to);
+          expectDate(triggerDate);
+        }}
+      />
       <DayPicker modifiers={{ selected: new Date() }} onDayClick={() => {}} />
       <DayPicker
         onSelect={() => {}}
@@ -70,6 +167,53 @@ const Test = () => {
       <DayPicker initialFocus />
       {/* @ts-expect-error Removed in v10: use custom `WeekNumber` component */}
       <DayPicker showWeekNumber onWeekNumberClick={() => {}} />
+      {/* @ts-expect-error `today` must be a Date, not a PlainDate-like object */}
+      <DayPicker today={plainDateLike} />
+      {/* @ts-expect-error `month` must be a Date, not a Date-like object */}
+      <DayPicker month={dateLike} />
+      {/* @ts-expect-error `defaultMonth` must be a Date */}
+      <DayPicker defaultMonth={plainDateLike} />
+      {/* @ts-expect-error `startMonth` must be a Date */}
+      <DayPicker startMonth={plainDateLike} />
+      {/* @ts-expect-error `endMonth` must be a Date */}
+      <DayPicker endMonth={plainDateLike} />
+      {/* @ts-expect-error single selection is Date-shaped */}
+      <DayPicker mode="single" selected={plainDateLike} />
+      {/* @ts-expect-error multiple selection contains Date values */}
+      <DayPicker mode="multiple" selected={[plainDateLike]} />
+      {/* @ts-expect-error range endpoints must be Date values */}
+      <DayPicker mode="range" selected={{ from: plainDateLike }} />
+      {/* @ts-expect-error matchers must use Date values */}
+      <DayPicker disabled={plainDateLike} />
+      {/* @ts-expect-error matcher arrays must use Date values */}
+      <DayPicker hidden={[plainDateLike]} />
+      {/* @ts-expect-error modifier matchers must use Date values */}
+      <DayPicker modifiers={{ selected: plainDateLike }} />
+      <DayPicker
+        // @ts-expect-error matcher callbacks receive Date values
+        disabled={(_matchedDate: PlainDateLike) => true}
+      />
+      <DayPicker
+        // @ts-expect-error onDayClick receives a Date
+        onDayClick={(_clickedDate: PlainDateLike) => {}}
+      />
+      <DayPicker
+        // @ts-expect-error onMonthChange receives a Date
+        onMonthChange={(_changedMonth: PlainDateLike) => {}}
+      />
+      <DayPicker
+        // @ts-expect-error onNextClick receives a Date
+        onNextClick={(_nextMonth: PlainDateLike) => {}}
+      />
+      <DayPicker
+        // @ts-expect-error onPrevClick receives a Date
+        onPrevClick={(_previousMonth: PlainDateLike) => {}}
+      />
+      <DayPicker
+        mode="single"
+        // @ts-expect-error onSelect receives Date-shaped selection values
+        onSelect={(_selectedDate: PlainDateLike) => {}}
+      />
     </>
   );
 };

--- a/packages/react-day-picker/src/useDayPicker.test.tsx
+++ b/packages/react-day-picker/src/useDayPicker.test.tsx
@@ -12,16 +12,21 @@ import {
 } from "./useDayPicker";
 
 describe("useDayPicker", () => {
+  const displayedMonth = new Date(2024, 0, 1);
+  const previousMonth = new Date(2023, 11, 1);
+  const nextMonth = new Date(2024, 1, 1);
+  const selectedDate = new Date(2024, 0, 15);
+
   const mockContextValue: DayPickerContext<{
     required: false;
     mode: "single";
   }> = {
-    months: [new CalendarMonth(new Date(), [])],
-    nextMonth: new Date(),
-    previousMonth: new Date(),
+    months: [new CalendarMonth(displayedMonth, [])],
+    nextMonth,
+    previousMonth,
     goToMonth: jest.fn(),
     getModifiers: jest.fn((_day: CalendarDay) => ({}) as Modifiers),
-    selected: undefined,
+    selected: selectedDate,
     select: jest.fn(),
     isSelected: jest.fn((_date: Date) => false),
     components: {
@@ -123,6 +128,10 @@ describe("useDayPicker", () => {
     } as DayPickerProps,
   };
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("should return the context value when used within a DayPicker provider", () => {
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <dayPickerContext.Provider value={mockContextValue}>
@@ -132,5 +141,32 @@ describe("useDayPicker", () => {
 
     const { result } = renderHook(() => useDayPicker(), { wrapper });
     expect(result.current).toEqual(mockContextValue);
+  });
+
+  it("keeps public calendar context values Date-shaped", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <dayPickerContext.Provider value={mockContextValue}>
+        {children}
+      </dayPickerContext.Provider>
+    );
+
+    const { result } = renderHook(() => useDayPicker(), { wrapper });
+    const context = result.current;
+    const targetMonth = new Date(2024, 2, 1);
+
+    expect(context.months[0].date).toBe(displayedMonth);
+    expect(context.months[0].date).toBeInstanceOf(Date);
+    expect(context.nextMonth).toBe(nextMonth);
+    expect(context.nextMonth).toBeInstanceOf(Date);
+    expect(context.previousMonth).toBe(previousMonth);
+    expect(context.previousMonth).toBeInstanceOf(Date);
+    expect(context.selected).toBe(selectedDate);
+    expect(context.selected).toBeInstanceOf(Date);
+
+    context.goToMonth(targetMonth);
+    expect(mockContextValue.goToMonth).toHaveBeenCalledWith(targetMonth);
+
+    context.isSelected?.(selectedDate);
+    expect(mockContextValue.isSelected).toHaveBeenCalledWith(selectedDate);
   });
 });

--- a/packages/react-day-picker/src/utils/addToRange.test.ts
+++ b/packages/react-day-picker/src/utils/addToRange.test.ts
@@ -45,6 +45,17 @@ describe("addToRange", () => {
     expect(range).toEqual({ from: from, to: date });
   });
 
+  test("preserves Date endpoint instances when completing a range", () => {
+    const from = new Date(2022, 0, 1);
+    const date = new Date(2022, 0, 2);
+    const range = addToRange(date, { from, to: undefined });
+
+    expect(range?.from).toBe(from);
+    expect(range?.from).toBeInstanceOf(Date);
+    expect(range?.to).toBe(date);
+    expect(range?.to).toBeInstanceOf(Date);
+  });
+
   test("add a date to a complete range with same start and end date", () => {
     const date = new Date(2022, 0, 1);
     const from = date;

--- a/packages/react-day-picker/src/utils/convertMatchersToTimeZone.test.ts
+++ b/packages/react-day-picker/src/utils/convertMatchersToTimeZone.test.ts
@@ -26,6 +26,23 @@ describe("convertMatchersToTimeZone", () => {
     });
   });
 
+  describe("when argument is a date array matcher", () => {
+    const dates = [
+      new Date("2024-09-24T00:00:00.000Z"),
+      new Date("2024-09-26T00:00:00.000Z"),
+    ];
+    let convertedDates: Date[];
+
+    beforeEach(() => {
+      convertedDates = convertMatchersToTimeZone(dates, timeZone) as Date[];
+    });
+
+    test("converts each date entry to a TZDate instance", () => {
+      expect(convertedDates).toHaveLength(dates.length);
+      expect(convertedDates.every((date) => date instanceof TZDate)).toBe(true);
+    });
+  });
+
   describe("when argument is a date range", () => {
     const range: DateRange = {
       from: new Date("2024-09-24T00:00:00.000Z"),

--- a/packages/react-day-picker/src/utils/toTimeZone.test.ts
+++ b/packages/react-day-picker/src/utils/toTimeZone.test.ts
@@ -16,6 +16,10 @@ describe("toTimeZone", () => {
     test("returns the original instance", () => {
       expect(result).toBe(tzDate);
     });
+
+    test("preserves Date behavior", () => {
+      expect(result).toBeInstanceOf(Date);
+    });
   });
 
   describe("when argument is a TZDate in a different zone", () => {
@@ -33,6 +37,10 @@ describe("toTimeZone", () => {
     test("adopts the requested time zone", () => {
       expect(result.timeZone).toBe(timeZone);
     });
+
+    test("preserves Date behavior", () => {
+      expect(result).toBeInstanceOf(Date);
+    });
   });
 
   describe("when argument is a native Date", () => {
@@ -45,6 +53,10 @@ describe("toTimeZone", () => {
 
     test("wraps the value as TZDate", () => {
       expect(result).toBeInstanceOf(TZDate);
+    });
+
+    test("preserves Date behavior", () => {
+      expect(result).toBeInstanceOf(Date);
     });
 
     test("matches the TZDate ISO output", () => {


### PR DESCRIPTION
## What Changed
- Added TSX type assertions that current DayPicker props, matchers, navigation callbacks, day events, and selection callbacks remain Date-shaped.
- Added runtime regressions for selection/day event callbacks, navigation callbacks, custom component calendar data, useDayPicker context, formatter/label inputs, DateLib overrides, range endpoints, and timezone conversion.
- Kept this as a test-only preparatory change with no new Temporal package, dependency, public API, or runtime code.

## Review Notes
- Branch is based on main.
- Validation: `pnpm --filter react-day-picker typecheck`, `pnpm exec jest --selectProjects src`, `pnpm lint`.