### PR TITLE
test: standardize Jest test lifecycle patterns

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -38,6 +38,42 @@
       }
     }
   },
+  "overrides": [
+    {
+      "includes": ["**/*.test.ts", "**/*.test.tsx"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noDoneCallback": "error",
+            "noRestrictedGlobals": {
+              "level": "error",
+              "options": {
+                "deniedGlobals": {
+                  "it": "Use test() instead of it() for test declaration consistency."
+                }
+              }
+            },
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "@testing-library/react": "Use @/test/render so tests share the repo test helpers.",
+                  "@testing-library/user-event": "Use @/test/user so user-event setup is consistent."
+                }
+              }
+            }
+          },
+          "suspicious": {
+            "noDuplicateTestHooks": "error",
+            "noExportsInTest": "error",
+            "noFocusedTests": "error",
+            "noMisplacedAssertion": "error",
+            "noSkippedTests": "error"
+          }
+        }
+      }
+    }
+  ],
   "javascript": {
     "jsxRuntime": "reactClassic",
     "formatter": {

--- a/examples/ControlledSelection.test.tsx
+++ b/examples/ControlledSelection.test.tsx
@@ -7,67 +7,104 @@ import { user } from "@/test/user";
 import { ControlledSelection } from "./ControlledSelection";
 
 const today = new Date(2024, 8, 17);
+const rangeStart = new Date(2024, 8, 1);
+const rangeMiddle = new Date(2024, 8, 2);
+const rangeEndBeforeReset = new Date(2024, 8, 3);
+const rangeEnd = new Date(2024, 8, 4);
+const resetDay = new Date(2024, 8, 5);
+const unselectedDay = new Date(2024, 8, 6);
+
 setTestTime(today);
-beforeEach(async () => {});
 
-test("a range is selected after clicking two dates", async () => {
-  render(<ControlledSelection />);
-  await user.click(dateButton(new Date(2024, 8, 1)));
-  await user.click(dateButton(new Date(2024, 8, 4)));
+describe("when a range is selected", () => {
+  beforeEach(async () => {
+    render(<ControlledSelection />);
+    await user.click(dateButton(rangeStart));
+    await user.click(dateButton(rangeEnd));
+  });
 
-  expect(gridcell(new Date(2024, 8, 1), true)).toHaveAttribute(
-    "aria-selected",
-    "true",
-  );
-  expect(gridcell(new Date(2024, 8, 2), true)).toHaveAttribute(
-    "aria-selected",
-    "true",
-  );
-  expect(gridcell(new Date(2024, 8, 3), true)).toHaveAttribute(
-    "aria-selected",
-    "true",
-  );
-  expect(gridcell(new Date(2024, 8, 4), true)).toHaveAttribute(
-    "aria-selected",
-    "true",
-  );
-  expect(gridcell(new Date(2024, 8, 5), true)).not.toHaveAttribute(
-    "aria-selected",
-    "true",
-  );
+  test("the first day appears selected", () => {
+    expect(gridcell(rangeStart, true)).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("a middle day appears selected", () => {
+    expect(gridcell(rangeMiddle, true)).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("the day before the range end appears selected", () => {
+    expect(gridcell(rangeEndBeforeReset, true)).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  test("the last day appears selected", () => {
+    expect(gridcell(rangeEnd, true)).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("the following day does not appear selected", () => {
+    expect(gridcell(resetDay, true)).not.toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
 });
 
-test("a range is reset after clicking a third date", async () => {
-  const consoleSpy = jest.spyOn(console, "log");
-  render(<ControlledSelection />);
-  await user.click(dateButton(new Date(2024, 8, 1)));
-  await user.click(dateButton(new Date(2024, 8, 4)));
-  await user.click(dateButton(new Date(2024, 8, 5)));
-  expect(console.log).toHaveBeenCalledWith("reset range");
-  expect(gridcell(new Date(2024, 8, 1), true)).not.toHaveAttribute(
-    "aria-selected",
-    "true",
-  );
-  expect(gridcell(new Date(2024, 8, 2), true)).not.toHaveAttribute(
-    "aria-selected",
-    "true",
-  );
-  expect(gridcell(new Date(2024, 8, 3), true)).not.toHaveAttribute(
-    "aria-selected",
-    "true",
-  );
-  expect(gridcell(new Date(2024, 8, 4), true)).not.toHaveAttribute(
-    "aria-selected",
-    "true",
-  );
-  expect(gridcell(new Date(2024, 8, 5), true)).toHaveAttribute(
-    "aria-selected",
-    "true",
-  );
-  expect(gridcell(new Date(2024, 8, 6), true)).not.toHaveAttribute(
-    "aria-selected",
-    "true",
-  );
+describe("when a third date is clicked", () => {
+  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
 
-  consoleSpy.mockRestore();
+  beforeEach(async () => {
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    render(<ControlledSelection />);
+    await user.click(dateButton(rangeStart));
+    await user.click(dateButton(rangeEnd));
+    await user.click(dateButton(resetDay));
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  test("logs the reset", () => {
+    expect(consoleLogSpy).toHaveBeenCalledWith("reset range");
+  });
+
+  test("the original first day does not appear selected", () => {
+    expect(gridcell(rangeStart, true)).not.toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  test("the original middle day does not appear selected", () => {
+    expect(gridcell(rangeMiddle, true)).not.toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  test("the day before the original range end does not appear selected", () => {
+    expect(gridcell(rangeEndBeforeReset, true)).not.toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  test("the original last day does not appear selected", () => {
+    expect(gridcell(rangeEnd, true)).not.toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  test("the reset day appears selected", () => {
+    expect(gridcell(resetDay, true)).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("the following day does not appear selected", () => {
+    expect(gridcell(unselectedDay, true)).not.toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
 });

--- a/examples/ControlledSelection.test.tsx
+++ b/examples/ControlledSelection.test.tsx
@@ -28,7 +28,10 @@ describe("when a range is selected", () => {
   });
 
   test("a middle day appears selected", () => {
-    expect(gridcell(rangeMiddle, true)).toHaveAttribute("aria-selected", "true");
+    expect(gridcell(rangeMiddle, true)).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
   });
 
   test("the day before the range end appears selected", () => {

--- a/examples/CustomDropdown/CustomDropdown.test.tsx
+++ b/examples/CustomDropdown/CustomDropdown.test.tsx
@@ -1,7 +1,6 @@
-import { render, screen } from "@/test/render";
 import React from "react";
-
 import { grid, monthDropdown, yearDropdown } from "@/test/elements";
+import { render, screen } from "@/test/render";
 import { setTestTime } from "@/test/setTestTime";
 import { user } from "@/test/user";
 import { CustomDropdown } from "./CustomDropdown";

--- a/examples/CustomDropdown/CustomDropdown.test.tsx
+++ b/examples/CustomDropdown/CustomDropdown.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen } from "@/test/render";
 import React from "react";
 
 import { grid, monthDropdown, yearDropdown } from "@/test/elements";

--- a/examples/CustomDropdown/CustomDropdown.test.tsx
+++ b/examples/CustomDropdown/CustomDropdown.test.tsx
@@ -6,16 +6,33 @@ import { setTestTime } from "@/test/setTestTime";
 import { user } from "@/test/user";
 import { CustomDropdown } from "./CustomDropdown";
 
-// Mocks for Radix UI
-window.PointerEvent =
-  class PointerEvent extends Event {} as unknown as typeof window.PointerEvent;
-window.HTMLElement.prototype.scrollIntoView = jest.fn();
-window.HTMLElement.prototype.hasPointerCapture = jest.fn();
-window.HTMLElement.prototype.releasePointerCapture = jest.fn();
+const originalPointerEvent = window.PointerEvent;
+const originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView;
+const originalHasPointerCapture =
+  window.HTMLElement.prototype.hasPointerCapture;
+const originalReleasePointerCapture =
+  window.HTMLElement.prototype.releasePointerCapture;
 
 const today = new Date(2015, 6, 1);
 
 setTestTime(today);
+
+beforeAll(() => {
+  window.PointerEvent =
+    class PointerEvent extends Event {} as unknown as typeof window.PointerEvent;
+  window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  window.HTMLElement.prototype.hasPointerCapture = jest.fn();
+  window.HTMLElement.prototype.releasePointerCapture = jest.fn();
+});
+
+afterAll(() => {
+  window.PointerEvent = originalPointerEvent;
+  window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+  window.HTMLElement.prototype.hasPointerCapture = originalHasPointerCapture;
+  window.HTMLElement.prototype.releasePointerCapture =
+    originalReleasePointerCapture;
+});
+
 beforeEach(() => {
   render(<CustomDropdown />);
 });

--- a/examples/DisabledSelectedDate.test.tsx
+++ b/examples/DisabledSelectedDate.test.tsx
@@ -5,41 +5,42 @@ import { render } from "@/test/render";
 
 import { DisabledSelectedDate } from "./DisabledSelectedDate";
 
-test("selected days should render with 'selected' modifier when disabled", () => {
+const selectedStyle = "background-color: rgb(255, 0, 0)";
+const dayBeforeRangeStart = new Date(2025, 2, 7);
+const selectedDays = [
+  new Date(2025, 2, 8),
+  new Date(2025, 2, 9),
+  new Date(2025, 2, 10),
+  new Date(2025, 2, 11),
+];
+const dayAfterRangeEnd = new Date(2025, 2, 12);
+
+beforeEach(() => {
   render(<DisabledSelectedDate />);
+});
 
-  const dayBeforeRangeStart = new Date(2025, 2, 7);
-  expect(gridcell(dayBeforeRangeStart, true)).not.toHaveClass("rdp-selected");
-  expect(gridcell(dayBeforeRangeStart, true)).not.toHaveStyle(
-    "background-color: rgb(255, 0, 0)",
-  );
-  const rangeStart = new Date(2025, 2, 8);
-  expect(gridcell(rangeStart, true)).toHaveClass("rdp-selected");
-  expect(gridcell(rangeStart, true)).toHaveStyle(
-    "background-color: rgb(255, 0, 0)",
-  );
+describe("selected disabled days", () => {
+  test.each(selectedDays)("renders %s with the selected modifier", (day) => {
+    expect(gridcell(day, true)).toHaveClass("rdp-selected");
+  });
 
-  rangeStart.setDate(rangeStart.getDate() + 1);
-  expect(gridcell(rangeStart, true)).toHaveClass("rdp-selected");
-  expect(gridcell(rangeStart, true)).toHaveStyle(
-    "background-color: rgb(255, 0, 0)",
-  );
+  test.each(selectedDays)("renders %s with the selected style", (day) => {
+    expect(gridcell(day, true)).toHaveStyle(selectedStyle);
+  });
+});
 
-  rangeStart.setDate(rangeStart.getDate() + 1);
-  expect(gridcell(rangeStart, true)).toHaveClass("rdp-selected");
-  expect(gridcell(rangeStart, true)).toHaveStyle(
-    "background-color: rgb(255, 0, 0)",
+describe("unselected disabled days", () => {
+  test.each([dayBeforeRangeStart, dayAfterRangeEnd])(
+    "does not render %s with the selected modifier",
+    (day) => {
+      expect(gridcell(day, true)).not.toHaveClass("rdp-selected");
+    },
   );
 
-  rangeStart.setDate(rangeStart.getDate() + 1);
-  expect(gridcell(rangeStart, true)).toHaveClass("rdp-selected");
-  expect(gridcell(rangeStart, true)).toHaveStyle(
-    "background-color: rgb(255, 0, 0)",
-  );
-
-  rangeStart.setDate(rangeStart.getDate() + 1);
-  expect(gridcell(rangeStart, true)).not.toHaveClass("rdp-selected");
-  expect(gridcell(dayBeforeRangeStart, true)).not.toHaveStyle(
-    "background-color: rgb(255, 0, 0)",
+  test.each([dayBeforeRangeStart, dayAfterRangeEnd])(
+    "does not render %s with the selected style",
+    (day) => {
+      expect(gridcell(day, true)).not.toHaveStyle(selectedStyle);
+    },
   );
 });

--- a/examples/DisabledSelectedDate.test.tsx
+++ b/examples/DisabledSelectedDate.test.tsx
@@ -30,17 +30,17 @@ describe("selected disabled days", () => {
 });
 
 describe("unselected disabled days", () => {
-  test.each([dayBeforeRangeStart, dayAfterRangeEnd])(
-    "does not render %s with the selected modifier",
-    (day) => {
-      expect(gridcell(day, true)).not.toHaveClass("rdp-selected");
-    },
-  );
+  test.each([
+    dayBeforeRangeStart,
+    dayAfterRangeEnd,
+  ])("does not render %s with the selected modifier", (day) => {
+    expect(gridcell(day, true)).not.toHaveClass("rdp-selected");
+  });
 
-  test.each([dayBeforeRangeStart, dayAfterRangeEnd])(
-    "does not render %s with the selected style",
-    (day) => {
-      expect(gridcell(day, true)).not.toHaveStyle(selectedStyle);
-    },
-  );
+  test.each([
+    dayBeforeRangeStart,
+    dayAfterRangeEnd,
+  ])("does not render %s with the selected style", (day) => {
+    expect(gridcell(day, true)).not.toHaveStyle(selectedStyle);
+  });
 });

--- a/examples/FocusedDisabledNav.test.tsx
+++ b/examples/FocusedDisabledNav.test.tsx
@@ -2,32 +2,67 @@ import React from "react";
 
 import { dateButton, nextButton, previousButton } from "@/test/elements";
 import { render } from "@/test/render";
+import { setTestTime } from "@/test/setTestTime";
 import { user } from "@/test/user";
 
 import { FocusedDisabledNav } from "./FocusedDisabledNav";
 
-const today = new Date();
+const today = new Date(2025, 2, 8);
+
+setTestTime(today);
 
 describe("FocusedDisabledNav", () => {
-  test("should not focus the aria-disabled navigation button", async () => {
+  beforeEach(() => {
     render(<FocusedDisabledNav />);
-    await user.tab();
-    expect(previousButton()).toHaveFocus();
-    await user.tab();
-    expect(nextButton()).not.toHaveFocus();
-    expect(dateButton(today)).toHaveFocus(); // should ignore next button and focus today's date
   });
-  test("should keep focus on the disabled navigation button", async () => {
-    render(<FocusedDisabledNav />);
-    await user.tab();
-    await user.keyboard("{enter}");
-    expect(previousButton()).toHaveFocus();
-    await user.tab();
-    expect(nextButton()).toHaveFocus();
-    await user.keyboard("{enter}");
-    expect(nextButton()).toHaveFocus();
-    expect(nextButton()).toHaveAttribute("aria-disabled", "true");
-    expect(nextButton()).not.toBeDisabled();
-    expect(dateButton(today)).not.toHaveFocus();
+
+  describe("when navigation receives focus", () => {
+    beforeEach(async () => {
+      await user.tab();
+    });
+
+    test("focuses the previous button", () => {
+      expect(previousButton()).toHaveFocus();
+    });
+  });
+
+  describe("when tabbing through navigation", () => {
+    beforeEach(async () => {
+      await user.tab();
+      await user.tab();
+    });
+
+    test("does not focus the aria-disabled navigation button", () => {
+      expect(nextButton()).not.toHaveFocus();
+    });
+
+    test("focuses today's date after the previous button", () => {
+      expect(dateButton(today)).toHaveFocus();
+    });
+  });
+
+  describe("when pressing the disabled navigation button", () => {
+    beforeEach(async () => {
+      await user.tab();
+      await user.keyboard("{enter}");
+      await user.tab();
+      await user.keyboard("{enter}");
+    });
+
+    test("keeps focus on the disabled navigation button", () => {
+      expect(nextButton()).toHaveFocus();
+    });
+
+    test("marks the disabled navigation button as aria-disabled", () => {
+      expect(nextButton()).toHaveAttribute("aria-disabled", "true");
+    });
+
+    test("does not disable the navigation button element", () => {
+      expect(nextButton()).not.toBeDisabled();
+    });
+
+    test("does not focus today's date", () => {
+      expect(dateButton(today)).not.toHaveFocus();
+    });
   });
 });

--- a/examples/Hebrew.test.tsx
+++ b/examples/Hebrew.test.tsx
@@ -1,8 +1,7 @@
-import { within } from "@testing-library/react";
 import React from "react";
 
 import { grid } from "@/test/elements";
-import { render } from "@/test/render";
+import { render, within } from "@/test/render";
 import { setTestTime } from "@/test/setTestTime";
 import { Hebrew } from "./Hebrew";
 

--- a/examples/Keyboard.test.tsx
+++ b/examples/Keyboard.test.tsx
@@ -166,28 +166,28 @@ describe.each(["ltr", "rtl"])("when text direction is %s", (dir: string) => {
       beforeEach(() => {
         return user.type(activeElement(), "{pageup}");
       });
-      it("should display the previous month", () => {
+      test("should display the previous month", () => {
         expect(grid("May 2022")).toBeInTheDocument();
       });
-      it("should focus the day in the previous month", () => {
+      test("should focus the day in the previous month", () => {
         expect(dateButton(prevMonth)).toHaveFocus();
       });
     });
     describe("when Page Down is pressed", () => {
       beforeEach(() => user.type(activeElement(), "{pagedown}"));
-      it("should display the next month", () => {
+      test("should display the next month", () => {
         expect(grid("July 2022")).toBeInTheDocument();
       });
-      it("should focus the day in the next month", () => {
+      test("should focus the day in the next month", () => {
         expect(dateButton(nextMonth)).toHaveFocus();
       });
     });
     describe("when Shift + Page Up is pressed", () => {
       beforeEach(() => user.type(activeElement(), "{shift>}{pageup}"));
-      it("should display the previous year", () => {
+      test("should display the previous year", () => {
         expect(grid("June 2021")).toBeInTheDocument();
       });
-      it("should focus the day in the previous year", () => {
+      test("should focus the day in the previous year", () => {
         expect(dateButton(prevYear)).toHaveFocus();
       });
     });
@@ -195,22 +195,22 @@ describe.each(["ltr", "rtl"])("when text direction is %s", (dir: string) => {
       beforeEach(() => {
         return user.type(activeElement(), "{shift>}{pagedown}");
       });
-      it("should display the next year", () => {
+      test("should display the next year", () => {
         expect(grid("June 2023")).toBeInTheDocument();
       });
-      it("should focus the day in the next yeaer", () => {
+      test("should focus the day in the next yeaer", () => {
         expect(dateButton(nextYear)).toHaveFocus();
       });
     });
     describe("when Home is pressed", () => {
       beforeEach(() => user.type(activeElement(), "{home}"));
-      it("should focus the start of the week", () => {
+      test("should focus the start of the week", () => {
         expect(dateButton(startOfWeekDay)).toHaveFocus();
       });
     });
     describe("when End is pressed", () => {
       beforeEach(() => user.type(activeElement(), "{end}"));
-      it("should focus the end of the week", () => {
+      test("should focus the end of the week", () => {
         expect(dateButton(endOfWeekDay)).toHaveFocus();
       });
     });
@@ -294,13 +294,13 @@ describe("when week is set to start on a Monday", () => {
 
   describe("when Home is pressed", () => {
     beforeEach(() => user.type(activeElement(), "{home}"));
-    it("should focus the start of the week being Monday", () => {
+    test("should focus the start of the week being Monday", () => {
       expect(dateButton(startOfWeekDay)).toHaveFocus();
     });
   });
   describe("when End is pressed", () => {
     beforeEach(() => user.type(activeElement(), "{end}"));
-    it("should focus the end of the week being Sunday", () => {
+    test("should focus the end of the week being Sunday", () => {
       expect(dateButton(endOfWeekDay)).toHaveFocus();
     });
   });

--- a/examples/Numerals.test.tsx
+++ b/examples/Numerals.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render } from "@/test/render";
 import React from "react";
 
 import { grid } from "@/test/elements";

--- a/examples/Numerals.test.tsx
+++ b/examples/Numerals.test.tsx
@@ -1,7 +1,6 @@
-import { render } from "@/test/render";
 import React from "react";
-
 import { grid } from "@/test/elements";
+import { render } from "@/test/render";
 import { setTestTime } from "@/test/setTestTime";
 import { Numerals } from "./Numerals";
 

--- a/examples/RangeResetSelection.test.tsx
+++ b/examples/RangeResetSelection.test.tsx
@@ -14,26 +14,73 @@ beforeEach(() => render(<RangeResetSelection />));
 const getFrom = () => screen.getByTestId("from");
 const getTo = () => screen.getByTestId("to");
 
-test("select same day range", async () => {
-  await user.click(dateButton(today));
-  expect(getFrom()).toHaveTextContent("2022-09-12");
-  expect(getTo()).toHaveTextContent("");
-  await user.click(dateButton(today));
-  expect(getFrom()).toHaveTextContent("2022-09-12");
-  expect(getTo()).toHaveTextContent("—2022-09-12");
+describe("when selecting the same day range", () => {
+  beforeEach(async () => {
+    await user.click(dateButton(today));
+  });
+
+  test("sets the from date", () => {
+    expect(getFrom()).toHaveTextContent("2022-09-12");
+  });
+
+  test("leaves the to date empty", () => {
+    expect(getTo()).toHaveTextContent("");
+  });
+
+  describe("when clicking the day again", () => {
+    beforeEach(async () => {
+      await user.click(dateButton(today));
+    });
+
+    test("keeps the from date", () => {
+      expect(getFrom()).toHaveTextContent("2022-09-12");
+    });
+
+    test("sets the to date", () => {
+      expect(getTo()).toHaveTextContent("—2022-09-12");
+    });
+  });
 });
 
-test("start range after click on day with range selected", async () => {
-  await user.click(dateButton(today));
-  expect(getFrom()).toHaveTextContent("2022-09-12");
-  expect(getTo()).toHaveTextContent("");
-  await user.click(dateButton(addDays(today, 1)));
-  expect(getFrom()).toHaveTextContent("2022-09-12");
-  expect(getTo()).toHaveTextContent("—2022-09-13");
-  await user.click(dateButton(addDays(today, 4)));
-  expect(getFrom()).toHaveTextContent("2022-09-16");
-  expect(getTo()).toHaveTextContent("");
-  await user.click(dateButton(today));
-  expect(getFrom()).toHaveTextContent("2022-09-12");
-  expect(getTo()).toHaveTextContent("—2022-09-16");
+describe("when starting a range from an existing range", () => {
+  beforeEach(async () => {
+    await user.click(dateButton(today));
+    await user.click(dateButton(addDays(today, 1)));
+  });
+
+  test("keeps the first selected day as the from date", () => {
+    expect(getFrom()).toHaveTextContent("2022-09-12");
+  });
+
+  test("sets the second selected day as the to date", () => {
+    expect(getTo()).toHaveTextContent("—2022-09-13");
+  });
+
+  describe("when clicking a later day", () => {
+    beforeEach(async () => {
+      await user.click(dateButton(addDays(today, 4)));
+    });
+
+    test("starts a new range from the later day", () => {
+      expect(getFrom()).toHaveTextContent("2022-09-16");
+    });
+
+    test("clears the to date", () => {
+      expect(getTo()).toHaveTextContent("");
+    });
+
+    describe("when clicking the original first day", () => {
+      beforeEach(async () => {
+        await user.click(dateButton(today));
+      });
+
+      test("sets the original first day as the from date", () => {
+        expect(getFrom()).toHaveTextContent("2022-09-12");
+      });
+
+      test("sets the later day as the to date", () => {
+        expect(getTo()).toHaveTextContent("—2022-09-16");
+      });
+    });
+  });
 });

--- a/examples/RangeResetSelection.test.tsx
+++ b/examples/RangeResetSelection.test.tsx
@@ -1,8 +1,7 @@
-import { screen } from "@testing-library/react";
 import { addDays } from "date-fns";
 import React from "react";
 import { dateButton } from "@/test/elements";
-import { render } from "@/test/render";
+import { render, screen } from "@/test/render";
 import { setTestTime } from "@/test/setTestTime";
 import { user } from "@/test/user";
 import { RangeResetSelection } from "./RangeResetSelection";

--- a/examples/Single.test.tsx
+++ b/examples/Single.test.tsx
@@ -1,7 +1,6 @@
-import { render } from "@/test/render";
 import React from "react";
-
 import { dateButton, gridcell } from "@/test/elements";
+import { render } from "@/test/render";
 import { setTestTime } from "@/test/setTestTime";
 import { user } from "@/test/user";
 import { Single } from "./Single";

--- a/examples/Single.test.tsx
+++ b/examples/Single.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render } from "@/test/render";
 import React from "react";
 
 import { dateButton, gridcell } from "@/test/elements";

--- a/examples/SingleControlled.test.tsx
+++ b/examples/SingleControlled.test.tsx
@@ -1,7 +1,7 @@
-import { render } from "@testing-library/react";
 import React from "react";
 
 import { dateButton, gridcell } from "@/test/elements";
+import { render } from "@/test/render";
 import { setTestTime } from "@/test/setTestTime";
 import { user } from "@/test/user";
 import { SingleControlled } from "./SingleControlled";

--- a/examples/SingleMockDate.test.tsx
+++ b/examples/SingleMockDate.test.tsx
@@ -1,6 +1,6 @@
 /* This test uses mockdate to ensure date mocking works as it should. */
 
-import { render } from "@testing-library/react";
+import { render } from "@/test/render";
 import MockDate from "mockdate";
 import React from "react";
 

--- a/examples/SingleMockDate.test.tsx
+++ b/examples/SingleMockDate.test.tsx
@@ -1,10 +1,9 @@
 /* This test uses mockdate to ensure date mocking works as it should. */
 
-import { render } from "@/test/render";
 import MockDate from "mockdate";
 import React from "react";
-
 import { dateButton, gridcell } from "@/test/elements";
+import { render } from "@/test/render";
 import { user } from "@/test/user";
 
 import { Single } from "./Single";

--- a/examples/TestCase2585.test.tsx
+++ b/examples/TestCase2585.test.tsx
@@ -4,7 +4,9 @@ import { render, screen } from "@/test/render";
 
 import { TestCase2585 } from "./TestCase2585";
 
-render(<TestCase2585 />);
+beforeEach(() => {
+  render(<TestCase2585 />);
+});
 
 test("should render 42*12 days", () => {
   expect(screen.getAllByRole("gridcell", { hidden: true })).toHaveLength(

--- a/examples/TimeZoneNoonSafe.test.tsx
+++ b/examples/TimeZoneNoonSafe.test.tsx
@@ -5,14 +5,27 @@ import { render, screen, within } from "@/test/render";
 import { user } from "@/test/user";
 import { TimeZoneNoonSafe } from "./TimeZoneNoonSafe";
 
+const getPrimaryGridDayRows = () => {
+  const [primaryGrid] = screen.getAllByRole("grid");
+  return within(primaryGrid)
+    .getAllByRole("row")
+    .filter((row) => {
+      return within(row).queryAllByRole("gridcell").length > 0;
+    });
+};
+
+const getFirstDayRowCells = () => {
+  return within(getPrimaryGridDayRows()[0]).getAllByRole("gridcell");
+};
+
+const getLastDayRowCells = () => {
+  const dayRows = getPrimaryGridDayRows();
+  return within(dayRows[dayRows.length - 1]).getAllByRole("gridcell");
+};
+
 test("the first row should display 7 days", () => {
   render(<TimeZoneNoonSafe />);
-  const grid = screen.getByRole("grid");
-  const rows = within(grid).getAllByRole("row");
-  const firstDayRow = rows.find((row) =>
-    row.querySelector("[role='gridcell']"),
-  );
-  expect(firstDayRow?.querySelectorAll("[role='gridcell']")).toHaveLength(7);
+  expect(getFirstDayRowCells()).toHaveLength(7);
 });
 
 test("week numbers remain valid when using noonSafe", () => {
@@ -31,43 +44,48 @@ test("week numbers remain valid when using noonSafe", () => {
 
 test("the last row should display 7 days", () => {
   render(<TimeZoneNoonSafe />);
-  const grid = screen.getByRole("grid");
-  const rows = within(grid).getAllByRole("row");
-  const lastDayRow = [...rows]
-    .reverse()
-    .find((row) => row.querySelector("[role='gridcell']"));
-  expect(lastDayRow?.querySelectorAll("[role='gridcell']")).toHaveLength(7);
+  expect(getLastDayRowCells()).toHaveLength(7);
 });
 
 describe("TimeZoneNoonSafe navigation", () => {
-  test("previous and next month buttons render full weeks", async () => {
+  beforeEach(() => {
     render(<TimeZoneNoonSafe />);
+  });
 
-    const assertFirstAndLastRowHave7Cells = () => {
-      const [grid] = screen.getAllByRole("grid");
-      const rows = within(grid).getAllByRole("row");
-      const dayRows = rows.filter(
-        (row) => within(row).queryAllByRole("gridcell").length > 0,
-      );
-      const firstCells = within(dayRows[0]).getAllByRole("gridcell");
-      const lastCells = within(dayRows[dayRows.length - 1]).getAllByRole(
-        "gridcell",
-      );
-      expect(firstCells.length).toBe(7);
-      expect(lastCells.length).toBe(7);
-    };
+  test("the current month renders a full first week", () => {
+    expect(getFirstDayRowCells()).toHaveLength(7);
+  });
 
-    // Current month
-    assertFirstAndLastRowHave7Cells();
+  test("the current month renders a full last week", () => {
+    expect(getLastDayRowCells()).toHaveLength(7);
+  });
 
-    // Move to previous month
-    await user.click(screen.getByRole("button", { name: /previous month/i }));
-    assertFirstAndLastRowHave7Cells();
+  describe("when navigating to the previous month", () => {
+    beforeEach(async () => {
+      await user.click(screen.getByRole("button", { name: /previous month/i }));
+    });
 
-    // Move to next month twice (back to original and forward one)
-    await user.click(screen.getByRole("button", { name: /next month/i }));
-    await user.click(screen.getByRole("button", { name: /next month/i }));
-    assertFirstAndLastRowHave7Cells();
+    test("renders a full first week", () => {
+      expect(getFirstDayRowCells()).toHaveLength(7);
+    });
+
+    test("renders a full last week", () => {
+      expect(getLastDayRowCells()).toHaveLength(7);
+    });
+  });
+
+  describe("when navigating to the next month", () => {
+    beforeEach(async () => {
+      await user.click(screen.getByRole("button", { name: /next month/i }));
+    });
+
+    test("renders a full first week", () => {
+      expect(getFirstDayRowCells()).toHaveLength(7);
+    });
+
+    test("renders a full last week", () => {
+      expect(getLastDayRowCells()).toHaveLength(7);
+    });
   });
 });
 

--- a/examples/TimeZoneNoonSafe.test.tsx
+++ b/examples/TimeZoneNoonSafe.test.tsx
@@ -1,8 +1,8 @@
-import userEvent from "@testing-library/user-event";
 import React from "react";
 import { DayPicker } from "react-day-picker";
 import { dateButton, grid } from "@/test/elements";
 import { render, screen, within } from "@/test/render";
+import { user } from "@/test/user";
 import { TimeZoneNoonSafe } from "./TimeZoneNoonSafe";
 
 test("the first row should display 7 days", () => {
@@ -42,7 +42,6 @@ test("the last row should display 7 days", () => {
 describe("TimeZoneNoonSafe navigation", () => {
   test("previous and next month buttons render full weeks", async () => {
     render(<TimeZoneNoonSafe />);
-    const user = userEvent.setup();
 
     const assertFirstAndLastRowHave7Cells = () => {
       const [grid] = screen.getAllByRole("grid");

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,6 +5,7 @@ if (process.env.TZ) {
 import type { Config } from "@jest/types";
 
 const sharedConfig: Config.InitialOptions = {
+  clearMocks: true,
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["<rootDir>/test/setup.ts"],
   transform: {

--- a/packages/ethiopic/src/ethiopic/lib/formatNumber.test.ts
+++ b/packages/ethiopic/src/ethiopic/lib/formatNumber.test.ts
@@ -1,47 +1,44 @@
 import { formatNumber } from "./formatNumber";
 
 describe("formatNumber", () => {
-  test("should format numbers using Ethiopian numerals", () => {
-    expect(formatNumber(1, "geez")).toBe("፩");
-    expect(formatNumber(10, "geez")).toBe("፲");
-    expect(formatNumber(12, "geez")).toBe("፲፪");
-    expect(formatNumber(21, "geez")).toBe("፳፩");
-    expect(formatNumber(100, "geez")).toBe("፻");
-    expect(formatNumber(1000, "geez")).toBe("፲፻");
-    expect(formatNumber(10000, "geez")).toBe("፼");
-
-    // years
-    expect(formatNumber(1998, "geez")).toBe("፲፱፻፺፰");
-    expect(formatNumber(2000, "geez")).toBe("፳፻");
-    expect(formatNumber(2002, "geez")).toBe("፳፻፪");
-
-    // Complex numbers
-    expect(formatNumber(140000, "geez")).toBe("፲፬፼");
-    expect(formatNumber(123, "geez")).toBe("፻፳፫");
-    expect(formatNumber(1234, "geez")).toBe("፲፪፻፴፬");
-    expect(formatNumber(38965, "geez")).toBe("፫፼፹፱፻፷፭");
+  test.each([
+    [1, "፩"],
+    [10, "፲"],
+    [12, "፲፪"],
+    [21, "፳፩"],
+    [100, "፻"],
+    [1000, "፲፻"],
+    [10000, "፼"],
+    [1998, "፲፱፻፺፰"],
+    [2000, "፳፻"],
+    [2002, "፳፻፪"],
+    [140000, "፲፬፼"],
+    [123, "፻፳፫"],
+    [1234, "፲፪፻፴፬"],
+    [38965, "፫፼፹፱፻፷፭"],
+  ])("formats %i using Ethiopian numerals", (value, expected) => {
+    expect(formatNumber(value, "geez")).toBe(expected);
   });
 
-  test("should format numbers using latin numerals by default", () => {
-    expect(formatNumber(123)).toBe("123");
-    expect(formatNumber(1234)).toBe("1,234");
-    expect(formatNumber(12345)).toBe("12,345");
-
-    // Explicit latin format
-    expect(formatNumber(123, "latn")).toBe("123");
-    expect(formatNumber(1234, "latn")).toBe("1,234");
-    expect(formatNumber(12345, "latn")).toBe("12,345");
+  test.each([
+    [123, undefined, "123"],
+    [1234, undefined, "1,234"],
+    [12345, undefined, "12,345"],
+    [123, "latn" as const, "123"],
+    [1234, "latn" as const, "1,234"],
+    [12345, "latn" as const, "12,345"],
+  ])("formats %i using latin numerals", (value, numerals, expected) => {
+    expect(formatNumber(value, numerals)).toBe(expected);
   });
 
-  test("should handle zero and negative numbers correctly", () => {
-    // Zero
-    expect(formatNumber(0, "geez")).toBe("-"); // Special case in Geez
-    expect(formatNumber(0, "latn")).toBe("0");
-
-    // Negative numbers
-    expect(formatNumber(-123, "geez")).toBe("-፻፳፫");
-    expect(formatNumber(-1234, "geez")).toBe("-፲፪፻፴፬");
-    expect(formatNumber(-123, "latn")).toBe("-123");
-    expect(formatNumber(-1234, "latn")).toBe("-1,234");
+  test.each([
+    [0, "geez" as const, "-"],
+    [0, "latn" as const, "0"],
+    [-123, "geez" as const, "-፻፳፫"],
+    [-1234, "geez" as const, "-፲፪፻፴፬"],
+    [-123, "latn" as const, "-123"],
+    [-1234, "latn" as const, "-1,234"],
+  ])("formats %i using %s numerals", (value, numerals, expected) => {
+    expect(formatNumber(value, numerals)).toBe(expected);
   });
 });

--- a/packages/react-day-picker/src/DayPicker.test.tsx
+++ b/packages/react-day-picker/src/DayPicker.test.tsx
@@ -20,18 +20,6 @@ import { ja } from "./locale/ja.js";
 const testId = "test";
 const dayPicker = () => screen.getByTestId(testId);
 
-function expectFirstOfMonthDate(
-  value: unknown,
-  year: number,
-  monthIndex: number,
-) {
-  expect(value).toBeInstanceOf(Date);
-  const date = value as Date;
-  expect(date.getFullYear()).toBe(year);
-  expect(date.getMonth()).toBe(monthIndex);
-  expect(date.getDate()).toBe(1);
-}
-
 test("should render a date picker component", () => {
   render(<DayPicker data-testid={testId} />);
   expect(dayPicker()).toBeInTheDocument();
@@ -174,29 +162,45 @@ test("calls selection and day event callbacks with Date instances", async () => 
   expect(handleDayClick.mock.calls[0][0]).toBeInstanceOf(Date);
 });
 
-test("navigates with first-of-month Date callback values", async () => {
+describe("when navigating with month callbacks", () => {
   const handleMonthChange = jest.fn();
   const handleNextClick = jest.fn();
   const handlePrevClick = jest.fn();
 
-  render(
-    <DayPicker
-      defaultMonth={new Date(2024, 0, 15)}
-      onMonthChange={handleMonthChange}
-      onNextClick={handleNextClick}
-      onPrevClick={handlePrevClick}
-    />,
-  );
+  beforeEach(async () => {
+    render(
+      <DayPicker
+        defaultMonth={new Date(2024, 0, 15)}
+        onMonthChange={handleMonthChange}
+        onNextClick={handleNextClick}
+        onPrevClick={handlePrevClick}
+      />,
+    );
 
-  await user.click(nextButton());
+    await user.click(nextButton());
+  });
 
-  expectFirstOfMonthDate(handleNextClick.mock.calls[0][0], 2024, 1);
-  expectFirstOfMonthDate(handleMonthChange.mock.calls[0][0], 2024, 1);
+  test("calls onNextClick with the first day of the next month", () => {
+    expect(handleNextClick.mock.calls[0][0]).toEqual(new Date(2024, 1, 1));
+  });
 
-  await user.click(previousButton());
+  test("calls onMonthChange with the first day of the next month", () => {
+    expect(handleMonthChange.mock.calls[0][0]).toEqual(new Date(2024, 1, 1));
+  });
 
-  expectFirstOfMonthDate(handlePrevClick.mock.calls[0][0], 2024, 0);
-  expectFirstOfMonthDate(handleMonthChange.mock.calls[1][0], 2024, 0);
+  describe("when navigating back", () => {
+    beforeEach(async () => {
+      await user.click(previousButton());
+    });
+
+    test("calls onPrevClick with the first day of the previous month", () => {
+      expect(handlePrevClick.mock.calls[0][0]).toEqual(new Date(2024, 0, 1));
+    });
+
+    test("calls onMonthChange with the first day of the previous month", () => {
+      expect(handleMonthChange.mock.calls[1][0]).toEqual(new Date(2024, 0, 1));
+    });
+  });
 });
 
 test("passes Date values and DateLib options to custom formatters and labels", () => {
@@ -403,7 +407,7 @@ describe("when the `month` is changed programmatically", () => {
     expect(grid("February 2023")).toBeInTheDocument();
   });
 
-  test("normalizes rerendered month values to first-of-month Dates", () => {
+  describe("when the month prop is rerendered with non-first-of-month dates", () => {
     const monthDates: unknown[] = [];
     const components = {
       Month: ({ calendarMonth, displayIndex, ...divProps }: MonthProps) => {
@@ -412,16 +416,25 @@ describe("when the `month` is changed programmatically", () => {
       },
     };
 
-    const { rerender } = render(
-      <DayPicker month={new Date(2023, 0, 15)} components={components} />,
-    );
+    beforeEach(() => {
+      monthDates.length = 0;
 
-    rerender(
-      <DayPicker month={new Date(2023, 1, 20)} components={components} />,
-    );
+      const { rerender } = render(
+        <DayPicker month={new Date(2023, 0, 15)} components={components} />,
+      );
 
-    expectFirstOfMonthDate(monthDates[0], 2023, 0);
-    expectFirstOfMonthDate(monthDates[monthDates.length - 1], 2023, 1);
+      rerender(
+        <DayPicker month={new Date(2023, 1, 20)} components={components} />,
+      );
+    });
+
+    test("normalizes the initial month to the first day", () => {
+      expect(monthDates[0]).toEqual(new Date(2023, 0, 1));
+    });
+
+    test("normalizes the rerendered month to the first day", () => {
+      expect(monthDates[monthDates.length - 1]).toEqual(new Date(2023, 1, 1));
+    });
   });
 });
 

--- a/packages/react-day-picker/src/classes/CalendarDay.test.ts
+++ b/packages/react-day-picker/src/classes/CalendarDay.test.ts
@@ -1,6 +1,6 @@
 import { CalendarDay } from "./CalendarDay";
 
-it("should set `displayMonth` to undefined when date and `displayMonth` are in the same month", () => {
+test("should set `displayMonth` to undefined when date and `displayMonth` are in the same month", () => {
   const date = new Date(2020, 0, 1);
   const displayMonth = new Date(2020, 0, 15);
   const day = new CalendarDay(date, displayMonth);
@@ -8,7 +8,7 @@ it("should set `displayMonth` to undefined when date and `displayMonth` are in t
   expect(day.outside).toEqual(false);
 });
 
-it("should set `displayMonth` to the given `displayMonth` when date and `displayMonth` are not in the same month", () => {
+test("should set `displayMonth` to the given `displayMonth` when date and `displayMonth` are not in the same month", () => {
   const date = new Date(2020, 0, 1);
   const displayMonth = new Date(2020, 1, 15);
   const day = new CalendarDay(date, displayMonth);

--- a/packages/react-day-picker/src/classes/CalendarMonth.test.ts
+++ b/packages/react-day-picker/src/classes/CalendarMonth.test.ts
@@ -19,10 +19,10 @@ beforeEach(() => {
   month = new CalendarMonth(date, weeks);
 });
 
-it("should have a date property", () => {
+test("should have a date property", () => {
   expect(month.date).toEqual(date);
 });
 
-it("should have a weeks property", () => {
+test("should have a weeks property", () => {
   expect(month.weeks).toEqual(weeks);
 });

--- a/packages/react-day-picker/src/classes/CalendarWeek.test.ts
+++ b/packages/react-day-picker/src/classes/CalendarWeek.test.ts
@@ -11,11 +11,11 @@ beforeEach(() => {
   week = new CalendarWeek(1, days);
 });
 
-it("should have a weekNumber", () => {
+test("should have a weekNumber", () => {
   expect(week.weekNumber).toEqual(1);
 });
 
-it("should have an array of days", () => {
+test("should have an array of days", () => {
   expect(week.days).toBe(days);
   expect(week.days[0]).toBeInstanceOf(CalendarDay);
 });

--- a/packages/react-day-picker/src/helpers/calculateFocusTarget.test.ts
+++ b/packages/react-day-picker/src/helpers/calculateFocusTarget.test.ts
@@ -64,7 +64,7 @@ function getModifiersFactory(
 
 describe("calculateFocusTarget", () => {
   describe("when determining the focus target based on priority", () => {
-    it("should prioritize the day with the 'focused' modifier", () => {
+    test("should prioritize the day with the 'focused' modifier", () => {
       const getModifiers = getModifiersFactory([
         [day1, outsideModifiers],
         [dayToday, todayModifiers],
@@ -84,7 +84,7 @@ describe("calculateFocusTarget", () => {
       expect(focusTarget).toBe(dayFocusedModifier);
     });
 
-    it("should fall back to the last focused day if no day has the 'focused' modifier", () => {
+    test("should fall back to the last focused day if no day has the 'focused' modifier", () => {
       const getModifiers = getModifiersFactory([
         [day1, outsideModifiers],
         [dayToday, todayModifiers],
@@ -104,7 +104,7 @@ describe("calculateFocusTarget", () => {
       expect(focusTarget).toBe(dayLastFocused);
     });
 
-    it("should prioritize the selected day if no day is focused or last focused", () => {
+    test("should prioritize the selected day if no day is focused or last focused", () => {
       const getModifiers = getModifiersFactory([
         [day1, outsideModifiers],
         [dayToday, todayModifiers],
@@ -124,7 +124,7 @@ describe("calculateFocusTarget", () => {
       expect(focusTarget).toBe(daySelected);
     });
 
-    it("should prioritize today if no day is focused, last focused, or selected", () => {
+    test("should prioritize today if no day is focused, last focused, or selected", () => {
       const getModifiers = getModifiersFactory([
         [day1, outsideModifiers],
         [dayToday, todayModifiers],
@@ -144,7 +144,7 @@ describe("calculateFocusTarget", () => {
       expect(focusTarget).toBe(dayToday);
     });
 
-    it("should fall back to the first focusable day if no other priority is met", () => {
+    test("should fall back to the first focusable day if no other priority is met", () => {
       const getModifiers = getModifiersFactory([
         [day1, outsideModifiers],
         [dayToday, todayHiddenModifiers],

--- a/packages/react-day-picker/src/helpers/getDates.test.ts
+++ b/packages/react-day-picker/src/helpers/getDates.test.ts
@@ -6,7 +6,7 @@ describe("when the first month and the last month are the same", () => {
   describe("when the month has 6 weeks", () => {
     const month = new Date(2023, 11, 1);
     describe("when not using fixed weeks", () => {
-      it("should return 42 dates", () => {
+      test("should return 42 dates", () => {
         const dates = getDates(
           [month],
           undefined,
@@ -21,7 +21,7 @@ describe("when the first month and the last month are the same", () => {
       });
     });
     describe("when using fixed weeks", () => {
-      it("should return 42 dates", () => {
+      test("should return 42 dates", () => {
         const dates = getDates(
           [month],
           undefined,
@@ -39,7 +39,7 @@ describe("when the first month and the last month are the same", () => {
   describe("when the month has 5 weeks", () => {
     const month = new Date(2023, 4, 1);
     describe("when not using fixed weeks", () => {
-      it("should return 35 dates", () => {
+      test("should return 35 dates", () => {
         const dates = getDates(
           [month],
           undefined,
@@ -54,7 +54,7 @@ describe("when the first month and the last month are the same", () => {
       });
     });
     describe("when using fixed weeks", () => {
-      it("should return 42 dates", () => {
+      test("should return 42 dates", () => {
         const dates = getDates(
           [month],
           undefined,
@@ -71,7 +71,7 @@ describe("when the first month and the last month are the same", () => {
   describe("when the month has 4 weeks", () => {
     const month = new Date(2026, 1); // February 2026
     describe("when not using fixed weeks", () => {
-      it("should return 28 dates", () => {
+      test("should return 28 dates", () => {
         const dates = getDates(
           [month],
           undefined,
@@ -84,7 +84,7 @@ describe("when the first month and the last month are the same", () => {
       });
     });
     describe("when using fixed weeks", () => {
-      it("should return 42 dates", () => {
+      test("should return 42 dates", () => {
         const dates = getDates(
           [month],
           undefined,
@@ -98,7 +98,7 @@ describe("when the first month and the last month are the same", () => {
 
   describe("when using Monday as first day of the week", () => {
     const month = new Date(2023, 4, 1);
-    it("the first day should be Monday", () => {
+    test("the first day should be Monday", () => {
       const dates = getDates(
         [month],
         undefined,
@@ -121,7 +121,7 @@ describe("when the first month and the last month are the same", () => {
         dateLib.startOfWeek(month),
       ) + 1;
 
-    it("the last day should be the end of that week", () => {
+    test("the last day should be the end of that week", () => {
       const dates = getDates([month], maxDate, {}, dateLib);
       expect(dates).toHaveLength(expectedLength);
       expect(dates[dates.length - 1]).toEqual(expectedLastDay);
@@ -129,7 +129,7 @@ describe("when the first month and the last month are the same", () => {
   });
   describe("when using ISO weeks", () => {
     const month = new Date(2023, 4, 1);
-    it("the first day should be Monday", () => {
+    test("the first day should be Monday", () => {
       const dates = getDates(
         [month],
         undefined,
@@ -154,7 +154,7 @@ describe("when the first month and the last month are the same", () => {
         dateLib.startOfWeek(month),
       ) + 1;
 
-    it("clamps to the end of the custom week", () => {
+    test("clamps to the end of the custom week", () => {
       const dates = getDates([month], maxDate, {}, dateLib);
       expect(dates[dates.length - 1]).toEqual(expectedLastDay);
       expect(dates).toHaveLength(expectedLength);
@@ -174,7 +174,7 @@ describe("when the first month and the last month are the same", () => {
         defaultDateLib.startOfISOWeek(month),
       ) + 1;
 
-    it("clamps to the end of the ISO week", () => {
+    test("clamps to the end of the ISO week", () => {
       const dates = getDates(
         [month],
         maxDate,
@@ -191,7 +191,7 @@ describe("when the first month and the last month are different", () => {
   const firstMonth = new Date(2023, 4, 1);
   const lastMonth = new Date(2023, 11, 1);
   describe("when not using fixed weeks", () => {
-    it("should return an array of dates", () => {
+    test("should return an array of dates", () => {
       const dates = getDates(
         [firstMonth, lastMonth],
         undefined,
@@ -215,7 +215,7 @@ describe("when the first month and the last month are different", () => {
         dateLib.startOfWeek(firstMonth),
       ) + 1;
 
-    it("the last day should be the end of that week", () => {
+    test("the last day should be the end of that week", () => {
       const dates = getDates([firstMonth, lastMonth], maxDate, {}, dateLib);
       expect(dates).toHaveLength(expectedLength);
       expect(dates[dates.length - 1]).toEqual(expectedLastDay);
@@ -223,7 +223,7 @@ describe("when the first month and the last month are different", () => {
   });
   describe("when using ISO weeks", () => {
     const month = new Date(2023, 4, 1);
-    it("the first day should be Monday", () => {
+    test("the first day should be Monday", () => {
       const dates = getDates(
         [month],
         undefined,

--- a/packages/react-day-picker/src/helpers/getDays.test.ts
+++ b/packages/react-day-picker/src/helpers/getDays.test.ts
@@ -25,6 +25,6 @@ const months = [
   new CalendarMonth(days1[0].date, weeks2),
 ];
 
-it("should return all the days belonging to the calendar by merging the days in the weeks for each month", () => {
+test("should return all the days belonging to the calendar by merging the days in the weeks for each month", () => {
   expect(getDays(months)).toEqual([...days1, ...days2, ...days3, ...days4]);
 });

--- a/packages/react-day-picker/src/helpers/getDisplayMonths.test.ts
+++ b/packages/react-day-picker/src/helpers/getDisplayMonths.test.ts
@@ -3,14 +3,14 @@ import { defaultDateLib } from "../classes/DateLib";
 import { getDisplayMonths } from "./getDisplayMonths";
 
 describe("getDisplayMonths", () => {
-  it("should return the months to display in the calendar", () => {
+  test("should return the months to display in the calendar", () => {
     const firstMonth = new Date(2020, 0);
     const expectedResult = [new Date(2020, 0)];
     const result = getDisplayMonths(firstMonth, undefined, {}, defaultDateLib);
     expect(result).toEqual(expectedResult);
   });
 
-  it("should return the months to display in the calendar when the number of months is greater than 1", () => {
+  test("should return the months to display in the calendar when the number of months is greater than 1", () => {
     const firstMonth = new Date(2020, 0);
     const expectedResult = [
       new Date(2020, 0),
@@ -28,7 +28,7 @@ describe("getDisplayMonths", () => {
     expect(result).toEqual(expectedResult);
   });
 
-  it("should return the months to display in the calendar when passing a max date", () => {
+  test("should return the months to display in the calendar when passing a max date", () => {
     const firstMonth = new Date(2020, 0);
     const expectedResult = [new Date(2020, 0), new Date(2020, 1)];
     const result = getDisplayMonths(

--- a/packages/react-day-picker/src/helpers/getInitialMonth.test.ts
+++ b/packages/react-day-picker/src/helpers/getInitialMonth.test.ts
@@ -4,7 +4,7 @@ import { defaultDateLib } from "../classes/DateLib";
 
 import { getInitialMonth } from "./getInitialMonth";
 
-it("return start of month", () => {
+test("return start of month", () => {
   const month = new Date(2010, 11, 12);
   const initialMonth = getInitialMonth(
     { month },
@@ -20,7 +20,7 @@ describe("when no startMonth or endMonth is given", () => {
   const defaultMonth = new Date(2011, 11, 12);
   const today = new Date(2012, 11, 12);
   describe("when month is in context", () => {
-    it("return that month", () => {
+    test("return that month", () => {
       const initialMonth = getInitialMonth(
         { month, defaultMonth, today },
         undefined,
@@ -31,7 +31,7 @@ describe("when no startMonth or endMonth is given", () => {
     });
   });
   describe("when defaultMonth is in context and no month is given", () => {
-    it("return that month", () => {
+    test("return that month", () => {
       const initialMonth = getInitialMonth(
         { defaultMonth, today },
         undefined,
@@ -42,7 +42,7 @@ describe("when no startMonth or endMonth is given", () => {
     });
   });
   describe("when no month or defaultMonth", () => {
-    it("return the today month", () => {
+    test("return the today month", () => {
       const initialMonth = getInitialMonth(
         { today },
         undefined,
@@ -55,7 +55,7 @@ describe("when no startMonth or endMonth is given", () => {
 });
 
 describe("when startMonth is given and is after the default initial month", () => {
-  it("return the startMonth", () => {
+  test("return the startMonth", () => {
     const month = new Date(2010, 11, 12);
     const startMonth = addMonths(month, 1);
     const initialMonth = getInitialMonth(
@@ -73,7 +73,7 @@ describe("when endMonth is given", () => {
     const month = new Date(2010, 11, 12);
     const endMonth = addMonths(month, -2);
     describe("when the number of month is 1", () => {
-      it("returns the endMonth as the initial month so the last displayed month does not exceed endMonth", () => {
+      test("returns the endMonth as the initial month so the last displayed month does not exceed endMonth", () => {
         const initialMonth = getInitialMonth(
           { month },
           undefined,
@@ -84,7 +84,7 @@ describe("when endMonth is given", () => {
       });
     });
     describe("when the number of month is 3", () => {
-      it("returns the initial month so that initialMonth + 2 months = endMonth (last displayed month is endMonth)", () => {
+      test("returns the initial month so that initialMonth + 2 months = endMonth (last displayed month is endMonth)", () => {
         const initialMonth = getInitialMonth(
           { month, numberOfMonths: 3 },
           undefined,

--- a/packages/react-day-picker/src/helpers/getMonths.test.ts
+++ b/packages/react-day-picker/src/helpers/getMonths.test.ts
@@ -28,7 +28,7 @@ const dateLib = new DateLib({
   firstWeekContainsDate: 1,
 });
 
-it("should return the correct months without ISO weeks and reverse months", () => {
+test("should return the correct months without ISO weeks and reverse months", () => {
   const displayMonths = [new Date(2023, 5, 1)]; // June 2023
 
   const result = getMonths(displayMonths, mockDates, mockProps, dateLib);
@@ -38,7 +38,7 @@ it("should return the correct months without ISO weeks and reverse months", () =
   expect(result[0].weeks).toHaveLength(5); // June 2023 has 5 weeks
 });
 
-it("should handle ISO weeks", () => {
+test("should handle ISO weeks", () => {
   const displayMonths = [new Date(2023, 5, 1)]; // June 2023
 
   const isoProps = { ...mockProps, ISOWeek: true };
@@ -50,7 +50,7 @@ it("should handle ISO weeks", () => {
   expect(result[0].weeks).toHaveLength(5); // June 2023 has 5 ISO weeks
 });
 
-it("should handle reverse months", () => {
+test("should handle reverse months", () => {
   const displayMonths = [
     new Date(2023, 4, 1), // May 2023
     new Date(2023, 5, 1), // June 2023
@@ -65,7 +65,7 @@ it("should handle reverse months", () => {
   expect(result[1].date).toEqual(new Date(2023, 4, 1)); // May 2023
 });
 
-it("should handle fixed weeks", () => {
+test("should handle fixed weeks", () => {
   const displayMonths = [new Date(2023, 5, 1)]; // June 2023
 
   const fixedWeeksProps = { ...mockProps, fixedWeeks: true };
@@ -77,7 +77,7 @@ it("should handle fixed weeks", () => {
   expect(result[0].weeks).toHaveLength(6); // Fixed weeks should ensure 6 weeks in the month view
 });
 
-it("should handle months with no dates", () => {
+test("should handle months with no dates", () => {
   const displayMonths = [new Date(2023, 5, 1)]; // June 2023
 
   const result = getMonths(displayMonths, [], mockProps, dateLib);

--- a/packages/react-day-picker/src/helpers/getNextFocus.test.tsx
+++ b/packages/react-day-picker/src/helpers/getNextFocus.test.tsx
@@ -12,7 +12,7 @@ const props: Pick<
   hidden: [],
 };
 
-it("should return `undefined` if `attempt` exceeds 365", () => {
+test("should return `undefined` if `attempt` exceeds 365", () => {
   const focusedDay = new CalendarDay(
     new Date(2020, 0, 1),
     new Date(2020, 0, 1),
@@ -33,7 +33,7 @@ it("should return `undefined` if `attempt` exceeds 365", () => {
   expect(result).toBeUndefined();
 });
 
-it("should return the focus date if it is not disabled or hidden", () => {
+test("should return the focus date if it is not disabled or hidden", () => {
   const focusedDay = new CalendarDay(
     new Date(2020, 0, 1),
     new Date(2020, 0, 1),
@@ -52,7 +52,7 @@ it("should return the focus date if it is not disabled or hidden", () => {
   expect(result?.date).toEqual(expectedDate);
 });
 
-it("should return the next focus date if it is disabled", () => {
+test("should return the next focus date if it is disabled", () => {
   const focusedDay = new CalendarDay(
     new Date(2020, 0, 1),
     new Date(2020, 0, 1),
@@ -75,7 +75,7 @@ it("should return the next focus date if it is disabled", () => {
   expect(result?.date).toEqual(expectedDate);
 });
 
-it("should return the next focus date if it is hidden", () => {
+test("should return the next focus date if it is hidden", () => {
   const focusedDay = new CalendarDay(
     new Date(2020, 0, 1),
     new Date(2020, 0, 1),

--- a/packages/react-day-picker/src/helpers/getNextMonth.test.ts
+++ b/packages/react-day-picker/src/helpers/getNextMonth.test.ts
@@ -8,7 +8,7 @@ const startingMonth = new Date(2020, 4, 31);
 
 describe("when number of months is 1", () => {
   describe("when the navigation is disabled", () => {
-    it("the next month is undefined", () => {
+    test("the next month is undefined", () => {
       const result = getNextMonth(
         startingMonth,
         undefined,
@@ -22,7 +22,7 @@ describe("when number of months is 1", () => {
   });
   describe("when in the navigable range", () => {
     const endMonth = addMonths(startingMonth, 3);
-    it("the next month is not undefined", () => {
+    test("the next month is not undefined", () => {
       const result = getNextMonth(startingMonth, endMonth, {}, defaultDateLib);
       const expectedNextMonth = addMonths(startingMonth, 1);
       expect(result && isSameMonth(result, expectedNextMonth)).toBeTruthy();
@@ -30,7 +30,7 @@ describe("when number of months is 1", () => {
   });
   describe("when not in the navigable range", () => {
     const endMonth = startingMonth;
-    it("the next month is undefined", () => {
+    test("the next month is undefined", () => {
       const result = getNextMonth(startingMonth, endMonth, {}, defaultDateLib);
       expect(result).toBe(undefined);
     });
@@ -40,7 +40,7 @@ describe("when displaying 3 months", () => {
   const numberOfMonths = 3;
   describe("when the navigation is paged", () => {
     const pagedNavigation = true;
-    it("the next month is 3 months ahead", () => {
+    test("the next month is 3 months ahead", () => {
       const result = getNextMonth(
         startingMonth,
         undefined,
@@ -54,7 +54,7 @@ describe("when displaying 3 months", () => {
       expect(result && isSameMonth(result, expectedNextMonth)).toBeTruthy();
     });
     describe("when the to-date is ahead less than 3 months", () => {
-      it("the next month is undefined", () => {
+      test("the next month is undefined", () => {
         const result = getNextMonth(
           startingMonth,
           addMonths(startingMonth, 1),
@@ -70,7 +70,7 @@ describe("when displaying 3 months", () => {
   });
   describe("when the navigation is not paged", () => {
     const pagedNavigation = false;
-    it("the next month is 1 months ahead", () => {
+    test("the next month is 1 months ahead", () => {
       const result = getNextMonth(
         startingMonth,
         undefined,
@@ -84,7 +84,7 @@ describe("when displaying 3 months", () => {
       expect(result && isSameMonth(result, expectedNextMonth)).toBeTruthy();
     });
     describe("when the to-date is ahead less than 3 months", () => {
-      it("the next month is undefined", () => {
+      test("the next month is undefined", () => {
         const result = getNextMonth(
           startingMonth,
           addMonths(startingMonth, 2),

--- a/packages/react-day-picker/src/helpers/getPreviousMonth.test.ts
+++ b/packages/react-day-picker/src/helpers/getPreviousMonth.test.ts
@@ -2,7 +2,7 @@ import { defaultDateLib } from "../classes/DateLib";
 
 import { getPreviousMonth } from "./getPreviousMonth";
 
-it("should return undefined if navigation is disabled", () => {
+test("should return undefined if navigation is disabled", () => {
   const firstDisplayedMonth = new Date(2022, 0, 1); // January 2022
   const calendarStartMonth = new Date(2022, 0, 1); // January 2022
   const props = {
@@ -21,7 +21,7 @@ it("should return undefined if navigation is disabled", () => {
   expect(result).toBeUndefined();
 });
 
-it("should return the previous month if startMonth is not provided", () => {
+test("should return the previous month if startMonth is not provided", () => {
   const firstDisplayedMonth = new Date(2022, 1, 1); // February 2022
   const props = {
     disableNavigation: false,
@@ -39,7 +39,7 @@ it("should return the previous month if startMonth is not provided", () => {
   expect(result).toEqual(new Date(2022, 0, 1)); // January 2022
 });
 
-it("should return undefined if the previous month is before the startMonth", () => {
+test("should return undefined if the previous month is before the startMonth", () => {
   const firstDisplayedMonth = new Date(2022, 0, 1); // January 2022
   const calendarStartMonth = new Date(2022, 0, 1); // January 2022
   const props = {
@@ -56,7 +56,7 @@ it("should return undefined if the previous month is before the startMonth", () 
   expect(result).toBeUndefined();
 });
 
-it("should return the correct previous month when pagedNavigation is true", () => {
+test("should return the correct previous month when pagedNavigation is true", () => {
   const firstDisplayedMonth = new Date(2022, 2, 1); // March 2022
   const calendarStartMonth = new Date(2022, 0, 1); // January 2022
   const props = {

--- a/packages/react-day-picker/src/helpers/getWeeks.test.ts
+++ b/packages/react-day-picker/src/helpers/getWeeks.test.ts
@@ -25,6 +25,6 @@ const months = [
   new CalendarMonth(days1[0].date, weeks2),
 ];
 
-it("should return all the days belonging to the calendar by merging the days in the weeks for each month", () => {
+test("should return all the days belonging to the calendar by merging the days in the weeks for each month", () => {
   expect(getWeeks(months)).toEqual([...weeks1, ...weeks2]);
 });

--- a/packages/react-day-picker/src/helpers/useControlledValue.test.ts
+++ b/packages/react-day-picker/src/helpers/useControlledValue.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook } from "@/test/render";
 
 import { useControlledValue } from "./useControlledValue";
 

--- a/packages/react-day-picker/src/selection/useMulti.test.tsx
+++ b/packages/react-day-picker/src/selection/useMulti.test.tsx
@@ -6,7 +6,7 @@ import type { DayPickerProps } from "../types";
 import { useMulti } from "./useMulti";
 
 describe("useMulti", () => {
-  it("uses the selected value from props when onSelect is provided", () => {
+  test("uses the selected value from props when onSelect is provided", () => {
     const mockOnSelect = jest.fn();
     const selectedDates = [new Date(2023, 9, 1), new Date(2023, 9, 2)];
     const props: DayPickerProps = {
@@ -20,7 +20,7 @@ describe("useMulti", () => {
     expect(result.current.selected).toBe(selectedDates);
   });
 
-  it("uses the internally selected value when onSelect is not provided", () => {
+  test("uses the internally selected value when onSelect is not provided", () => {
     const initialSelectedDates = [new Date(2023, 9, 1), new Date(2023, 9, 2)];
     const props: DayPickerProps = {
       mode: "multiple",

--- a/packages/react-day-picker/src/selection/useRange.test.tsx
+++ b/packages/react-day-picker/src/selection/useRange.test.tsx
@@ -223,7 +223,7 @@ describe("useRange", () => {
     });
   });
 
-  it("uses the selected value from props when onSelect is provided", () => {
+  test("uses the selected value from props when onSelect is provided", () => {
     const mockOnSelect = jest.fn();
     const selectedRange = {
       from: new Date(2023, 9, 1),
@@ -241,7 +241,7 @@ describe("useRange", () => {
     expect(result.current.selected).toBe(selectedRange);
   });
 
-  it("uses the internally selected value when onSelect is not provided", () => {
+  test("uses the internally selected value when onSelect is not provided", () => {
     const initialSelectedRange = {
       from: new Date(2023, 9, 1),
       to: new Date(2023, 9, 5),

--- a/packages/react-day-picker/src/selection/useSingle.test.tsx
+++ b/packages/react-day-picker/src/selection/useSingle.test.tsx
@@ -6,7 +6,7 @@ import type { DayPickerProps } from "../types";
 import { useSingle } from "./useSingle";
 
 describe("useSingle", () => {
-  it("uses the selected value from props when onSelect is provided", () => {
+  test("uses the selected value from props when onSelect is provided", () => {
     const mockOnSelect = jest.fn();
     const selectedDate = new Date(2023, 9, 1);
     const props: DayPickerProps = {
@@ -20,7 +20,7 @@ describe("useSingle", () => {
     expect(result.current.selected).toBe(selectedDate);
   });
 
-  it("uses the internally selected value when onSelect is not provided", () => {
+  test("uses the internally selected value when onSelect is not provided", () => {
     const initialSelectedDate = new Date(2023, 9, 1);
     const props: DayPickerProps = {
       mode: "single",

--- a/packages/react-day-picker/src/types/props.test.tsx
+++ b/packages/react-day-picker/src/types/props.test.tsx
@@ -35,8 +35,6 @@ const dateLike: DateLike = {
   getDate: () => date.getDate(),
 };
 
-const acceptDate = (_date: Date) => {};
-const acceptDateRange = (_range: DateRange) => {};
 const dateMatchers: Matcher[] = [
   date,
   [date],
@@ -66,16 +64,16 @@ const dateShapedProps: DayPickerProps = {
     weekend: { dayOfWeek: [0, 6] },
   },
   onDayClick: (clickedDate) => {
-    acceptDate(clickedDate);
+    void (clickedDate satisfies Date);
   },
   onMonthChange: (changedMonth) => {
-    acceptDate(changedMonth);
+    void (changedMonth satisfies Date);
   },
   onNextClick: (nextMonth) => {
-    acceptDate(nextMonth);
+    void (nextMonth satisfies Date);
   },
   onPrevClick: (previousMonth) => {
-    acceptDate(previousMonth);
+    void (previousMonth satisfies Date);
   },
 };
 
@@ -89,16 +87,20 @@ const Test = () => {
         mode="single"
         selected={undefined}
         onSelect={(selectedDate, triggerDate) => {
-          if (selectedDate) acceptDate(selectedDate);
-          acceptDate(triggerDate);
+          if (selectedDate) {
+            void (selectedDate satisfies Date);
+          }
+          void (triggerDate satisfies Date);
         }}
       />
       <DayPicker
         mode="single"
         selected={new Date()}
         onSelect={(selectedDate, triggerDate) => {
-          if (selectedDate) acceptDate(selectedDate);
-          acceptDate(triggerDate);
+          if (selectedDate) {
+            void (selectedDate satisfies Date);
+          }
+          void (triggerDate satisfies Date);
         }}
       />
       {/* @ts-expect-error Missing `selected` */}
@@ -114,8 +116,8 @@ const Test = () => {
         required
         selected={undefined}
         onSelect={(selectedDates, triggerDate) => {
-          selectedDates.forEach(acceptDate);
-          acceptDate(triggerDate);
+          void (selectedDates satisfies Date[]);
+          void (triggerDate satisfies Date);
         }}
       />
       <DayPicker
@@ -123,8 +125,8 @@ const Test = () => {
         required
         selected={undefined}
         onSelect={(selectedRange, triggerDate) => {
-          acceptDateRange(selectedRange);
-          acceptDate(triggerDate);
+          void (selectedRange satisfies DateRange);
+          void (triggerDate satisfies Date);
         }}
       />
       <DayPicker
@@ -148,9 +150,13 @@ const Test = () => {
         mode="range"
         selected={{ from: month, to: endMonth }}
         onSelect={(selectedRange, triggerDate) => {
-          if (selectedRange?.from) acceptDate(selectedRange.from);
-          if (selectedRange?.to) acceptDate(selectedRange.to);
-          acceptDate(triggerDate);
+          if (selectedRange?.from) {
+            void (selectedRange.from satisfies Date);
+          }
+          if (selectedRange?.to) {
+            void (selectedRange.to satisfies Date);
+          }
+          void (triggerDate satisfies Date);
         }}
       />
       <DayPicker modifiers={{ selected: new Date() }} onDayClick={() => {}} />

--- a/packages/react-day-picker/src/types/props.test.tsx
+++ b/packages/react-day-picker/src/types/props.test.tsx
@@ -35,8 +35,8 @@ const dateLike: DateLike = {
   getDate: () => date.getDate(),
 };
 
-const expectDate = (_date: Date) => {};
-const expectDateRange = (_range: DateRange) => {};
+const acceptDate = (_date: Date) => {};
+const acceptDateRange = (_range: DateRange) => {};
 const dateMatchers: Matcher[] = [
   date,
   [date],
@@ -66,16 +66,16 @@ const dateShapedProps: DayPickerProps = {
     weekend: { dayOfWeek: [0, 6] },
   },
   onDayClick: (clickedDate) => {
-    expectDate(clickedDate);
+    acceptDate(clickedDate);
   },
   onMonthChange: (changedMonth) => {
-    expectDate(changedMonth);
+    acceptDate(changedMonth);
   },
   onNextClick: (nextMonth) => {
-    expectDate(nextMonth);
+    acceptDate(nextMonth);
   },
   onPrevClick: (previousMonth) => {
-    expectDate(previousMonth);
+    acceptDate(previousMonth);
   },
 };
 
@@ -89,16 +89,16 @@ const Test = () => {
         mode="single"
         selected={undefined}
         onSelect={(selectedDate, triggerDate) => {
-          if (selectedDate) expectDate(selectedDate);
-          expectDate(triggerDate);
+          if (selectedDate) acceptDate(selectedDate);
+          acceptDate(triggerDate);
         }}
       />
       <DayPicker
         mode="single"
         selected={new Date()}
         onSelect={(selectedDate, triggerDate) => {
-          if (selectedDate) expectDate(selectedDate);
-          expectDate(triggerDate);
+          if (selectedDate) acceptDate(selectedDate);
+          acceptDate(triggerDate);
         }}
       />
       {/* @ts-expect-error Missing `selected` */}
@@ -114,8 +114,8 @@ const Test = () => {
         required
         selected={undefined}
         onSelect={(selectedDates, triggerDate) => {
-          selectedDates.forEach(expectDate);
-          expectDate(triggerDate);
+          selectedDates.forEach(acceptDate);
+          acceptDate(triggerDate);
         }}
       />
       <DayPicker
@@ -123,8 +123,8 @@ const Test = () => {
         required
         selected={undefined}
         onSelect={(selectedRange, triggerDate) => {
-          expectDateRange(selectedRange);
-          expectDate(triggerDate);
+          acceptDateRange(selectedRange);
+          acceptDate(triggerDate);
         }}
       />
       <DayPicker
@@ -148,9 +148,9 @@ const Test = () => {
         mode="range"
         selected={{ from: month, to: endMonth }}
         onSelect={(selectedRange, triggerDate) => {
-          if (selectedRange?.from) expectDate(selectedRange.from);
-          if (selectedRange?.to) expectDate(selectedRange.to);
-          expectDate(triggerDate);
+          if (selectedRange?.from) acceptDate(selectedRange.from);
+          if (selectedRange?.to) acceptDate(selectedRange.to);
+          acceptDate(triggerDate);
         }}
       />
       <DayPicker modifiers={{ selected: new Date() }} onDayClick={() => {}} />

--- a/packages/react-day-picker/src/types/props.test.tsx
+++ b/packages/react-day-picker/src/types/props.test.tsx
@@ -218,6 +218,6 @@ const Test = () => {
   );
 };
 
-it("should type-check", () => {
+test("should type-check", () => {
   expect(Test).toBeTruthy();
 });

--- a/packages/react-day-picker/src/useAnimation.test.tsx
+++ b/packages/react-day-picker/src/useAnimation.test.tsx
@@ -24,162 +24,348 @@ const getMonthWeeksContainers = () => [
   ...document.querySelectorAll(`[data-animated-weeks]`),
 ];
 
-function expectAnimatedPartsToHaveLength(length: number) {
-  expect(getMonthContainers()).toHaveLength(length);
-  expect(getMonthCaptionContainers()).toHaveLength(length);
-  expect(getMonthWeekdaysContainers()).toHaveLength(length);
-  expect(getMonthWeeksContainers()).toHaveLength(length);
-}
-
-function expectActiveAnimationState() {
-  const navContainers = getNavContainers();
-  const monthContainers = getMonthContainers();
-  const monthCaptionContainers = getMonthCaptionContainers();
-  const monthWeekdaysContainers = getMonthWeekdaysContainers();
-  const monthWeeksContainers = getMonthWeeksContainers();
-
-  expect(navContainers).toHaveLength(2);
-  expect(monthContainers).toHaveLength(2);
-  expect(monthCaptionContainers).toHaveLength(2);
-  expect(monthWeekdaysContainers).toHaveLength(2);
-  expect(monthWeeksContainers).toHaveLength(2);
-  expect(getRootContainer()).toHaveStyle("isolation: isolate");
-  expect(navContainers[1]).toHaveStyle("z-index: 1");
-  expect(monthContainers[0]).toHaveStyle("position: relative");
-  expect(monthContainers[0]).toHaveStyle("overflow: hidden");
-  expect(monthContainers[1]).toHaveStyle("overflow: hidden");
-  expect(monthContainers[1]).toHaveStyle("pointer-events: none");
-  expect(monthContainers[1]).toHaveStyle("position: absolute");
-  expect(monthContainers[1]).toHaveAttribute("aria-hidden", "true");
-  expect(monthWeekdaysContainers[0]).toHaveStyle("opacity: 0");
-  expect(monthCaptionContainers[1]).toHaveClass("rdp-caption_after_enter");
-  expect(monthWeeksContainers[1]).toHaveClass("rdp-weeks_after_enter");
-}
-
-function expectCleanedAnimationState() {
-  const navContainers = getNavContainers();
-  const monthContainers = getMonthContainers();
-  const monthCaptionContainers = getMonthCaptionContainers();
-  const monthWeekdaysContainers = getMonthWeekdaysContainers();
-  const monthWeeksContainers = getMonthWeeksContainers();
-
-  expect(navContainers).toHaveLength(1);
-  expect(monthContainers).toHaveLength(1);
-  expect(monthCaptionContainers).toHaveLength(1);
-  expect(monthWeekdaysContainers).toHaveLength(1);
-  expect(monthWeeksContainers).toHaveLength(1);
-  expect(getRootContainer()).not.toHaveStyle("isolation: isolate");
-  expect(navContainers[0]).not.toHaveStyle("z-index: 1");
-  expect(monthContainers[0]).not.toHaveStyle("position: relative");
-  expect(monthContainers[0]).not.toHaveStyle("overflow: hidden");
-  expect(monthCaptionContainers[0]).not.toHaveClass("rdp-caption_after_enter");
-  expect(monthWeeksContainers[0]).not.toHaveClass("rdp-weeks_after_enter");
-}
-
 describe("useAnimation", () => {
   describe("animate prop is falsy", () => {
-    test("should not render elements with data-animated-* attributes", () => {
+    beforeEach(() => {
       render(<DayPicker />);
+    });
 
-      expectAnimatedPartsToHaveLength(0);
+    test("does not render animated month containers", () => {
+      expect(getMonthContainers()).toHaveLength(0);
+    });
+
+    test("does not render animated caption containers", () => {
+      expect(getMonthCaptionContainers()).toHaveLength(0);
+    });
+
+    test("does not render animated weekday containers", () => {
+      expect(getMonthWeekdaysContainers()).toHaveLength(0);
+    });
+
+    test("does not render animated week containers", () => {
+      expect(getMonthWeeksContainers()).toHaveLength(0);
     });
   });
 
   describe("animate prop is true", () => {
-    test("should render elements with data-animated-* attributes", () => {
-      render(<DayPicker animate={true} numberOfMonths={2} />);
+    describe("when rendering two months", () => {
+      beforeEach(() => {
+        render(<DayPicker animate={true} numberOfMonths={2} />);
+      });
 
-      expectAnimatedPartsToHaveLength(2);
+      test("renders two animated month containers", () => {
+        expect(getMonthContainers()).toHaveLength(2);
+      });
+
+      test("renders two animated caption containers", () => {
+        expect(getMonthCaptionContainers()).toHaveLength(2);
+      });
+
+      test("renders two animated weekday containers", () => {
+        expect(getMonthWeekdaysContainers()).toHaveLength(2);
+      });
+
+      test("renders two animated week containers", () => {
+        expect(getMonthWeeksContainers()).toHaveLength(2);
+      });
+
+      describe("when navigating to the next month", () => {
+        beforeEach(async () => {
+          await user.click(nextButton());
+        });
+
+        test("keeps snapshots for four animated month containers", () => {
+          expect(getMonthContainers()).toHaveLength(4);
+        });
+
+        test("keeps snapshots for four animated caption containers", () => {
+          expect(getMonthCaptionContainers()).toHaveLength(4);
+        });
+
+        test("keeps snapshots for four animated weekday containers", () => {
+          expect(getMonthWeekdaysContainers()).toHaveLength(4);
+        });
+
+        test("keeps snapshots for four animated week containers", () => {
+          expect(getMonthWeeksContainers()).toHaveLength(4);
+        });
+      });
     });
 
-    test("should add dom snapshots for each month for animation", async () => {
-      render(<DayPicker animate={true} numberOfMonths={2} />);
+    describe("when navigating while a month is exiting", () => {
+      beforeEach(async () => {
+        render(<DayPicker animate={true} />);
+        await user.click(nextButton());
+      });
 
-      await user.click(nextButton());
+      test("keeps February as the exiting month", () => {
+        expect(getMonthCaptionContainers()[0]).toHaveTextContent(
+          "February 2025",
+        );
+      });
 
-      expectAnimatedPartsToHaveLength(4);
+      test("shows March as the entering month", () => {
+        expect(getMonthCaptionContainers()[1]).toHaveTextContent("March 2025");
+      });
+
+      describe("when navigating again", () => {
+        beforeEach(async () => {
+          await user.click(nextButton());
+        });
+
+        test("keeps February as the exiting month", () => {
+          expect(getMonthCaptionContainers()[0]).toHaveTextContent(
+            "February 2025",
+          );
+        });
+
+        test("shows April as the entering month", () => {
+          expect(getMonthCaptionContainers()[1]).toHaveTextContent(
+            "April 2025",
+          );
+        });
+      });
     });
 
-    test("should continue animating the same exiting month if month changed during animation", async () => {
-      render(<DayPicker animate={true} />);
+    describe("when navigating after a previous animation ends", () => {
+      beforeEach(async () => {
+        render(<DayPicker animate={true} />);
+        await user.click(nextButton());
+        await user.click(nextButton());
 
-      await user.click(nextButton());
+        const animationEndEvent = new Event("animationend");
+        getMonthCaptionContainers()[0].dispatchEvent(animationEndEvent);
 
-      expect(getMonthCaptionContainers()[0]).toHaveTextContent("February 2025");
-      expect(getMonthCaptionContainers()[1]).toHaveTextContent("March 2025");
+        await user.click(nextButton());
+      });
 
-      await user.click(nextButton());
+      test("shows April as the exiting month", () => {
+        expect(getMonthCaptionContainers()[0]).toHaveTextContent("April 2025");
+      });
 
-      expect(getMonthCaptionContainers()[0]).toHaveTextContent("February 2025");
-      expect(getMonthCaptionContainers()[1]).toHaveTextContent("April 2025");
+      test("shows May as the entering month", () => {
+        expect(getMonthCaptionContainers()[1]).toHaveTextContent("May 2025");
+      });
+
+      test("renders two animated month containers", () => {
+        expect(getMonthContainers()).toHaveLength(2);
+      });
+
+      test("renders two animated caption containers", () => {
+        expect(getMonthCaptionContainers()).toHaveLength(2);
+      });
+
+      test("renders two animated weekday containers", () => {
+        expect(getMonthWeekdaysContainers()).toHaveLength(2);
+      });
+
+      test("renders two animated week containers", () => {
+        expect(getMonthWeeksContainers()).toHaveLength(2);
+      });
+
+      test("clears the previous caption enter class", () => {
+        expect(getMonthCaptionContainers()[0]).not.toHaveClass(
+          "rdp-caption_after_enter",
+        );
+      });
+
+      test("clears the previous weeks enter class", () => {
+        expect(getMonthWeeksContainers()[0]).not.toHaveClass(
+          "rdp-weeks_after_enter",
+        );
+      });
     });
 
-    test("should handle month changes during animation to correctly animate the next month change", async () => {
-      render(<DayPicker animate={true} />);
-      await user.click(nextButton());
-      await user.click(nextButton());
+    describe("when entering month is after the exiting month", () => {
+      beforeEach(async () => {
+        render(<DayPicker animate={true} />);
+        await user.click(nextButton());
+      });
 
-      const animationEndEvent = new Event("animationend");
-      getMonthCaptionContainers()[0].dispatchEvent(animationEndEvent);
+      test("marks the exiting caption before exit", () => {
+        expect(getMonthCaptionContainers()[0]).toHaveClass(
+          "rdp-caption_before_exit",
+        );
+      });
 
-      await user.click(nextButton());
+      test("marks the entering caption after enter", () => {
+        expect(getMonthCaptionContainers()[1]).toHaveClass(
+          "rdp-caption_after_enter",
+        );
+      });
 
-      expect(getMonthCaptionContainers()[0]).toHaveTextContent("April 2025");
-      expect(getMonthCaptionContainers()[1]).toHaveTextContent("May 2025");
-      expectAnimatedPartsToHaveLength(2);
-      expect(getMonthCaptionContainers()[0]).not.toHaveClass(
-        "rdp-caption_after_enter",
-      );
-      expect(getMonthWeeksContainers()[0]).not.toHaveClass(
-        "rdp-weeks_after_enter",
-      );
+      test("marks the exiting weeks before exit", () => {
+        expect(getMonthWeeksContainers()[0]).toHaveClass(
+          "rdp-weeks_before_exit",
+        );
+      });
+
+      test("marks the entering weeks after enter", () => {
+        expect(getMonthWeeksContainers()[1]).toHaveClass(
+          "rdp-weeks_after_enter",
+        );
+      });
     });
 
-    test("should apply the correct animation class when entering month is after the exiting month", async () => {
-      render(<DayPicker animate={true} />);
+    describe("when entering month is before the exiting month", () => {
+      beforeEach(async () => {
+        render(<DayPicker animate={true} />);
+        await user.click(previousButton());
+      });
 
-      await user.click(nextButton());
+      test("marks the exiting caption after exit", () => {
+        expect(getMonthCaptionContainers()[0]).toHaveClass(
+          "rdp-caption_after_exit",
+        );
+      });
 
-      expect(getMonthCaptionContainers()[0]).toHaveClass(
-        "rdp-caption_before_exit",
-      );
-      expect(getMonthCaptionContainers()[1]).toHaveClass(
-        "rdp-caption_after_enter",
-      );
+      test("marks the entering caption before enter", () => {
+        expect(getMonthCaptionContainers()[1]).toHaveClass(
+          "rdp-caption_before_enter",
+        );
+      });
 
-      expect(getMonthWeeksContainers()[0]).toHaveClass("rdp-weeks_before_exit");
-      expect(getMonthWeeksContainers()[1]).toHaveClass("rdp-weeks_after_enter");
+      test("marks the exiting weeks after exit", () => {
+        expect(getMonthWeeksContainers()[0]).toHaveClass(
+          "rdp-weeks_after_exit",
+        );
+      });
+
+      test("marks the entering weeks before enter", () => {
+        expect(getMonthWeeksContainers()[1]).toHaveClass(
+          "rdp-weeks_before_enter",
+        );
+      });
     });
 
-    test("should apply the correct animation class when entering month is before the exiting month", async () => {
-      render(<DayPicker animate={true} />);
+    describe("when a month is exiting", () => {
+      beforeEach(async () => {
+        render(<DayPicker animate={true} />);
+        await user.click(nextButton());
+      });
 
-      await user.click(previousButton());
+      test("renders two animated nav containers", () => {
+        expect(getNavContainers()).toHaveLength(2);
+      });
 
-      expect(getMonthCaptionContainers()[0]).toHaveClass(
-        "rdp-caption_after_exit",
-      );
-      expect(getMonthCaptionContainers()[1]).toHaveClass(
-        "rdp-caption_before_enter",
-      );
+      test("renders two animated month containers", () => {
+        expect(getMonthContainers()).toHaveLength(2);
+      });
 
-      expect(getMonthWeeksContainers()[0]).toHaveClass("rdp-weeks_after_exit");
-      expect(getMonthWeeksContainers()[1]).toHaveClass(
-        "rdp-weeks_before_enter",
-      );
-    });
+      test("renders two animated caption containers", () => {
+        expect(getMonthCaptionContainers()).toHaveLength(2);
+      });
 
-    test("should clean up the exiting month after animation ends", async () => {
-      render(<DayPicker animate={true} />);
+      test("renders two animated weekday containers", () => {
+        expect(getMonthWeekdaysContainers()).toHaveLength(2);
+      });
 
-      await user.click(nextButton());
+      test("renders two animated week containers", () => {
+        expect(getMonthWeeksContainers()).toHaveLength(2);
+      });
 
-      expectActiveAnimationState();
+      test("isolates the root container", () => {
+        expect(getRootContainer()).toHaveStyle("isolation: isolate");
+      });
 
-      const animationEndEvent = new Event("animationend");
-      getMonthCaptionContainers()[0].dispatchEvent(animationEndEvent);
+      test("places the entering nav container above the exiting nav container", () => {
+        expect(getNavContainers()[1]).toHaveStyle("z-index: 1");
+      });
 
-      expectCleanedAnimationState();
+      test("positions the exiting month container relatively", () => {
+        expect(getMonthContainers()[0]).toHaveStyle("position: relative");
+      });
+
+      test("hides overflow for the exiting month container", () => {
+        expect(getMonthContainers()[0]).toHaveStyle("overflow: hidden");
+      });
+
+      test("hides overflow for the entering month container", () => {
+        expect(getMonthContainers()[1]).toHaveStyle("overflow: hidden");
+      });
+
+      test("disables pointer events for the entering month container", () => {
+        expect(getMonthContainers()[1]).toHaveStyle("pointer-events: none");
+      });
+
+      test("positions the entering month container absolutely", () => {
+        expect(getMonthContainers()[1]).toHaveStyle("position: absolute");
+      });
+
+      test("hides the entering month from assistive technology", () => {
+        expect(getMonthContainers()[1]).toHaveAttribute("aria-hidden", "true");
+      });
+
+      test("hides the exiting weekday container", () => {
+        expect(getMonthWeekdaysContainers()[0]).toHaveStyle("opacity: 0");
+      });
+
+      test("marks the entering caption after enter", () => {
+        expect(getMonthCaptionContainers()[1]).toHaveClass(
+          "rdp-caption_after_enter",
+        );
+      });
+
+      test("marks the entering weeks after enter", () => {
+        expect(getMonthWeeksContainers()[1]).toHaveClass(
+          "rdp-weeks_after_enter",
+        );
+      });
+
+      describe("when the animation ends", () => {
+        beforeEach(() => {
+          const animationEndEvent = new Event("animationend");
+          getMonthCaptionContainers()[0].dispatchEvent(animationEndEvent);
+        });
+
+        test("keeps one animated nav container", () => {
+          expect(getNavContainers()).toHaveLength(1);
+        });
+
+        test("keeps one animated month container", () => {
+          expect(getMonthContainers()).toHaveLength(1);
+        });
+
+        test("keeps one animated caption container", () => {
+          expect(getMonthCaptionContainers()).toHaveLength(1);
+        });
+
+        test("keeps one animated weekday container", () => {
+          expect(getMonthWeekdaysContainers()).toHaveLength(1);
+        });
+
+        test("keeps one animated week container", () => {
+          expect(getMonthWeeksContainers()).toHaveLength(1);
+        });
+
+        test("clears root isolation", () => {
+          expect(getRootContainer()).not.toHaveStyle("isolation: isolate");
+        });
+
+        test("clears nav stacking", () => {
+          expect(getNavContainers()[0]).not.toHaveStyle("z-index: 1");
+        });
+
+        test("clears relative month positioning", () => {
+          expect(getMonthContainers()[0]).not.toHaveStyle("position: relative");
+        });
+
+        test("clears month overflow clipping", () => {
+          expect(getMonthContainers()[0]).not.toHaveStyle("overflow: hidden");
+        });
+
+        test("clears the caption enter class", () => {
+          expect(getMonthCaptionContainers()[0]).not.toHaveClass(
+            "rdp-caption_after_enter",
+          );
+        });
+
+        test("clears the weeks enter class", () => {
+          expect(getMonthWeeksContainers()[0]).not.toHaveClass(
+            "rdp-weeks_after_enter",
+          );
+        });
+      });
     });
   });
 });

--- a/packages/react-day-picker/src/useAnimation.test.tsx
+++ b/packages/react-day-picker/src/useAnimation.test.tsx
@@ -1,6 +1,6 @@
-import { render } from "@/test/render";
 import React from "react";
 import { nextButton, previousButton } from "@/test/elements";
+import { render } from "@/test/render";
 import { setTestTime } from "@/test/setTestTime";
 import { user } from "@/test/user";
 import { DayPicker } from "./DayPicker";

--- a/packages/react-day-picker/src/useAnimation.test.tsx
+++ b/packages/react-day-picker/src/useAnimation.test.tsx
@@ -24,15 +24,64 @@ const getMonthWeeksContainers = () => [
   ...document.querySelectorAll(`[data-animated-weeks]`),
 ];
 
+function expectAnimatedPartsToHaveLength(length: number) {
+  expect(getMonthContainers()).toHaveLength(length);
+  expect(getMonthCaptionContainers()).toHaveLength(length);
+  expect(getMonthWeekdaysContainers()).toHaveLength(length);
+  expect(getMonthWeeksContainers()).toHaveLength(length);
+}
+
+function expectActiveAnimationState() {
+  const navContainers = getNavContainers();
+  const monthContainers = getMonthContainers();
+  const monthCaptionContainers = getMonthCaptionContainers();
+  const monthWeekdaysContainers = getMonthWeekdaysContainers();
+  const monthWeeksContainers = getMonthWeeksContainers();
+
+  expect(navContainers).toHaveLength(2);
+  expect(monthContainers).toHaveLength(2);
+  expect(monthCaptionContainers).toHaveLength(2);
+  expect(monthWeekdaysContainers).toHaveLength(2);
+  expect(monthWeeksContainers).toHaveLength(2);
+  expect(getRootContainer()).toHaveStyle("isolation: isolate");
+  expect(navContainers[1]).toHaveStyle("z-index: 1");
+  expect(monthContainers[0]).toHaveStyle("position: relative");
+  expect(monthContainers[0]).toHaveStyle("overflow: hidden");
+  expect(monthContainers[1]).toHaveStyle("overflow: hidden");
+  expect(monthContainers[1]).toHaveStyle("pointer-events: none");
+  expect(monthContainers[1]).toHaveStyle("position: absolute");
+  expect(monthContainers[1]).toHaveAttribute("aria-hidden", "true");
+  expect(monthWeekdaysContainers[0]).toHaveStyle("opacity: 0");
+  expect(monthCaptionContainers[1]).toHaveClass("rdp-caption_after_enter");
+  expect(monthWeeksContainers[1]).toHaveClass("rdp-weeks_after_enter");
+}
+
+function expectCleanedAnimationState() {
+  const navContainers = getNavContainers();
+  const monthContainers = getMonthContainers();
+  const monthCaptionContainers = getMonthCaptionContainers();
+  const monthWeekdaysContainers = getMonthWeekdaysContainers();
+  const monthWeeksContainers = getMonthWeeksContainers();
+
+  expect(navContainers).toHaveLength(1);
+  expect(monthContainers).toHaveLength(1);
+  expect(monthCaptionContainers).toHaveLength(1);
+  expect(monthWeekdaysContainers).toHaveLength(1);
+  expect(monthWeeksContainers).toHaveLength(1);
+  expect(getRootContainer()).not.toHaveStyle("isolation: isolate");
+  expect(navContainers[0]).not.toHaveStyle("z-index: 1");
+  expect(monthContainers[0]).not.toHaveStyle("position: relative");
+  expect(monthContainers[0]).not.toHaveStyle("overflow: hidden");
+  expect(monthCaptionContainers[0]).not.toHaveClass("rdp-caption_after_enter");
+  expect(monthWeeksContainers[0]).not.toHaveClass("rdp-weeks_after_enter");
+}
+
 describe("useAnimation", () => {
   describe("animate prop is falsy", () => {
     test("should not render elements with data-animated-* attributes", () => {
       render(<DayPicker />);
 
-      expect(getMonthContainers()).toHaveLength(0);
-      expect(getMonthCaptionContainers()).toHaveLength(0);
-      expect(getMonthWeekdaysContainers()).toHaveLength(0);
-      expect(getMonthWeeksContainers()).toHaveLength(0);
+      expectAnimatedPartsToHaveLength(0);
     });
   });
 
@@ -40,10 +89,7 @@ describe("useAnimation", () => {
     test("should render elements with data-animated-* attributes", () => {
       render(<DayPicker animate={true} numberOfMonths={2} />);
 
-      expect(getMonthContainers()).toHaveLength(2);
-      expect(getMonthCaptionContainers()).toHaveLength(2);
-      expect(getMonthWeekdaysContainers()).toHaveLength(2);
-      expect(getMonthWeeksContainers()).toHaveLength(2);
+      expectAnimatedPartsToHaveLength(2);
     });
 
     test("should add dom snapshots for each month for animation", async () => {
@@ -51,10 +97,7 @@ describe("useAnimation", () => {
 
       await user.click(nextButton());
 
-      expect(getMonthContainers()).toHaveLength(4);
-      expect(getMonthCaptionContainers()).toHaveLength(4);
-      expect(getMonthWeekdaysContainers()).toHaveLength(4);
-      expect(getMonthWeeksContainers()).toHaveLength(4);
+      expectAnimatedPartsToHaveLength(4);
     });
 
     test("should continue animating the same exiting month if month changed during animation", async () => {
@@ -83,10 +126,7 @@ describe("useAnimation", () => {
 
       expect(getMonthCaptionContainers()[0]).toHaveTextContent("April 2025");
       expect(getMonthCaptionContainers()[1]).toHaveTextContent("May 2025");
-      expect(getMonthContainers()).toHaveLength(2);
-      expect(getMonthCaptionContainers()).toHaveLength(2);
-      expect(getMonthWeekdaysContainers()).toHaveLength(2);
-      expect(getMonthWeeksContainers()).toHaveLength(2);
+      expectAnimatedPartsToHaveLength(2);
       expect(getMonthCaptionContainers()[0]).not.toHaveClass(
         "rdp-caption_after_enter",
       );
@@ -134,53 +174,12 @@ describe("useAnimation", () => {
 
       await user.click(nextButton());
 
-      let navContainers = getNavContainers();
-      let monthContainers = getMonthContainers();
-      let monthCaptionContainers = getMonthCaptionContainers();
-      let monthWeekdaysContainers = getMonthWeekdaysContainers();
-      let monthWeeksContainers = getMonthWeeksContainers();
-
-      expect(navContainers).toHaveLength(2);
-      expect(monthContainers).toHaveLength(2);
-      expect(monthCaptionContainers).toHaveLength(2);
-      expect(monthWeekdaysContainers).toHaveLength(2);
-      expect(monthWeeksContainers).toHaveLength(2);
-
-      expect(getRootContainer()).toHaveStyle("isolation: isolate");
-      expect(navContainers[1]).toHaveStyle("z-index: 1");
-      expect(monthContainers[0]).toHaveStyle("position: relative");
-      expect(monthContainers[0]).toHaveStyle("overflow: hidden");
-      expect(monthContainers[1]).toHaveStyle("overflow: hidden");
-      expect(monthContainers[1]).toHaveStyle("pointer-events: none");
-      expect(monthContainers[1]).toHaveStyle("position: absolute");
-      expect(monthContainers[1]).toHaveAttribute("aria-hidden", "true");
-      expect(monthWeekdaysContainers[0]).toHaveStyle("opacity: 0");
-      expect(monthCaptionContainers[1]).toHaveClass("rdp-caption_after_enter");
-      expect(monthWeeksContainers[1]).toHaveClass("rdp-weeks_after_enter");
+      expectActiveAnimationState();
 
       const animationEndEvent = new Event("animationend");
       getMonthCaptionContainers()[0].dispatchEvent(animationEndEvent);
 
-      navContainers = getNavContainers();
-      monthContainers = getMonthContainers();
-      monthCaptionContainers = getMonthCaptionContainers();
-      monthWeekdaysContainers = getMonthWeekdaysContainers();
-      monthWeeksContainers = getMonthWeeksContainers();
-
-      expect(navContainers).toHaveLength(1);
-      expect(monthContainers).toHaveLength(1);
-      expect(monthCaptionContainers).toHaveLength(1);
-      expect(monthWeekdaysContainers).toHaveLength(1);
-      expect(monthWeeksContainers).toHaveLength(1);
-
-      expect(getRootContainer()).not.toHaveStyle("isolation: isolate");
-      expect(navContainers[0]).not.toHaveStyle("z-index: 1");
-      expect(monthContainers[0]).not.toHaveStyle("position: relative");
-      expect(monthContainers[0]).not.toHaveStyle("overflow: hidden");
-      expect(monthCaptionContainers[0]).not.toHaveClass(
-        "rdp-caption_after_enter",
-      );
-      expect(monthWeeksContainers[0]).not.toHaveClass("rdp-weeks_after_enter");
+      expectCleanedAnimationState();
     });
   });
 });

--- a/packages/react-day-picker/src/useAnimation.test.tsx
+++ b/packages/react-day-picker/src/useAnimation.test.tsx
@@ -26,7 +26,7 @@ const getMonthWeeksContainers = () => [
 
 describe("useAnimation", () => {
   describe("animate prop is falsy", () => {
-    it("should not render elements with data-animated-* attributes", () => {
+    test("should not render elements with data-animated-* attributes", () => {
       render(<DayPicker />);
 
       expect(getMonthContainers()).toHaveLength(0);
@@ -37,7 +37,7 @@ describe("useAnimation", () => {
   });
 
   describe("animate prop is true", () => {
-    it("should render elements with data-animated-* attributes", () => {
+    test("should render elements with data-animated-* attributes", () => {
       render(<DayPicker animate={true} numberOfMonths={2} />);
 
       expect(getMonthContainers()).toHaveLength(2);
@@ -46,7 +46,7 @@ describe("useAnimation", () => {
       expect(getMonthWeeksContainers()).toHaveLength(2);
     });
 
-    it("should add dom snapshots for each month for animation", async () => {
+    test("should add dom snapshots for each month for animation", async () => {
       render(<DayPicker animate={true} numberOfMonths={2} />);
 
       await user.click(nextButton());
@@ -57,7 +57,7 @@ describe("useAnimation", () => {
       expect(getMonthWeeksContainers()).toHaveLength(4);
     });
 
-    it("should continue animating the same exiting month if month changed during animation", async () => {
+    test("should continue animating the same exiting month if month changed during animation", async () => {
       render(<DayPicker animate={true} />);
 
       await user.click(nextButton());
@@ -71,7 +71,7 @@ describe("useAnimation", () => {
       expect(getMonthCaptionContainers()[1]).toHaveTextContent("April 2025");
     });
 
-    it("should handle month changes during animation to correctly animate the next month change", async () => {
+    test("should handle month changes during animation to correctly animate the next month change", async () => {
       render(<DayPicker animate={true} />);
       await user.click(nextButton());
       await user.click(nextButton());
@@ -95,7 +95,7 @@ describe("useAnimation", () => {
       );
     });
 
-    it("should apply the correct animation class when entering month is after the exiting month", async () => {
+    test("should apply the correct animation class when entering month is after the exiting month", async () => {
       render(<DayPicker animate={true} />);
 
       await user.click(nextButton());
@@ -111,7 +111,7 @@ describe("useAnimation", () => {
       expect(getMonthWeeksContainers()[1]).toHaveClass("rdp-weeks_after_enter");
     });
 
-    it("should apply the correct animation class when entering month is before the exiting month", async () => {
+    test("should apply the correct animation class when entering month is before the exiting month", async () => {
       render(<DayPicker animate={true} />);
 
       await user.click(previousButton());
@@ -129,7 +129,7 @@ describe("useAnimation", () => {
       );
     });
 
-    it("should clean up the exiting month after animation ends", async () => {
+    test("should clean up the exiting month after animation ends", async () => {
       render(<DayPicker animate={true} />);
 
       await user.click(nextButton());

--- a/packages/react-day-picker/src/useAnimation.test.tsx
+++ b/packages/react-day-picker/src/useAnimation.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render } from "@/test/render";
 import React from "react";
 import { nextButton, previousButton } from "@/test/elements";
 import { setTestTime } from "@/test/setTestTime";

--- a/packages/react-day-picker/src/useDayPicker.test.tsx
+++ b/packages/react-day-picker/src/useDayPicker.test.tsx
@@ -128,10 +128,6 @@ describe("useDayPicker", () => {
     } as DayPickerProps,
   };
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it("should return the context value when used within a DayPicker provider", () => {
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <dayPickerContext.Provider value={mockContextValue}>

--- a/packages/react-day-picker/src/useDayPicker.test.tsx
+++ b/packages/react-day-picker/src/useDayPicker.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react";
+import { renderHook } from "@/test/render";
 import React from "react";
 import type { CalendarDay } from "./classes/CalendarDay";
 import { CalendarMonth } from "./classes/CalendarMonth";

--- a/packages/react-day-picker/src/useDayPicker.test.tsx
+++ b/packages/react-day-picker/src/useDayPicker.test.tsx
@@ -24,6 +24,7 @@ describe("useDayPicker", () => {
 
   let mockContextValue: SingleDayPickerContext;
   let wrapper: React.ComponentType<{ children: React.ReactNode }>;
+  let context: SingleDayPickerContext;
 
   function createMockContextValue(): SingleDayPickerContext {
     return {
@@ -149,24 +150,54 @@ describe("useDayPicker", () => {
     expect(result.current).toEqual(mockContextValue);
   });
 
-  test("keeps public calendar context values Date-shaped", () => {
-    const { result } = renderHook(() => useDayPicker(), { wrapper });
-    const context = result.current;
+  describe("when returning public calendar context values", () => {
     const targetMonth = new Date(2024, 2, 1);
 
-    expect(context.months[0].date).toBe(displayedMonth);
-    expect(context.months[0].date).toBeInstanceOf(Date);
-    expect(context.nextMonth).toBe(nextMonth);
-    expect(context.nextMonth).toBeInstanceOf(Date);
-    expect(context.previousMonth).toBe(previousMonth);
-    expect(context.previousMonth).toBeInstanceOf(Date);
-    expect(context.selected).toBe(selectedDate);
-    expect(context.selected).toBeInstanceOf(Date);
+    beforeEach(() => {
+      const { result } = renderHook(() => useDayPicker(), { wrapper });
+      context = result.current;
+    });
 
-    context.goToMonth(targetMonth);
-    expect(mockContextValue.goToMonth).toHaveBeenCalledWith(targetMonth);
+    test("keeps the displayed month date as a Date", () => {
+      expect(context.months[0].date).toBeInstanceOf(Date);
+    });
 
-    context.isSelected?.(selectedDate);
-    expect(mockContextValue.isSelected).toHaveBeenCalledWith(selectedDate);
+    test("keeps the displayed month date value", () => {
+      expect(context.months[0].date).toBe(displayedMonth);
+    });
+
+    test("keeps the next month as a Date", () => {
+      expect(context.nextMonth).toBeInstanceOf(Date);
+    });
+
+    test("keeps the next month value", () => {
+      expect(context.nextMonth).toBe(nextMonth);
+    });
+
+    test("keeps the previous month as a Date", () => {
+      expect(context.previousMonth).toBeInstanceOf(Date);
+    });
+
+    test("keeps the previous month value", () => {
+      expect(context.previousMonth).toBe(previousMonth);
+    });
+
+    test("keeps the selected value as a Date", () => {
+      expect(context.selected).toBeInstanceOf(Date);
+    });
+
+    test("keeps the selected value", () => {
+      expect(context.selected).toBe(selectedDate);
+    });
+
+    test("calls goToMonth with the target Date", () => {
+      context.goToMonth(targetMonth);
+      expect(mockContextValue.goToMonth).toHaveBeenCalledWith(targetMonth);
+    });
+
+    test("calls isSelected with the selected Date", () => {
+      context.isSelected?.(selectedDate);
+      expect(mockContextValue.isSelected).toHaveBeenCalledWith(selectedDate);
+    });
   });
 });

--- a/packages/react-day-picker/src/useDayPicker.test.tsx
+++ b/packages/react-day-picker/src/useDayPicker.test.tsx
@@ -1,5 +1,5 @@
-import { renderHook } from "@/test/render";
 import React from "react";
+import { renderHook } from "@/test/render";
 import type { CalendarDay } from "./classes/CalendarDay";
 import { CalendarMonth } from "./classes/CalendarMonth";
 import type { DayPickerProps } from "./types/props";

--- a/packages/react-day-picker/src/useDayPicker.test.tsx
+++ b/packages/react-day-picker/src/useDayPicker.test.tsx
@@ -128,7 +128,7 @@ describe("useDayPicker", () => {
     } as DayPickerProps,
   };
 
-  it("should return the context value when used within a DayPicker provider", () => {
+  test("should return the context value when used within a DayPicker provider", () => {
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <dayPickerContext.Provider value={mockContextValue}>
         {children}
@@ -139,7 +139,7 @@ describe("useDayPicker", () => {
     expect(result.current).toEqual(mockContextValue);
   });
 
-  it("keeps public calendar context values Date-shaped", () => {
+  test("keeps public calendar context values Date-shaped", () => {
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <dayPickerContext.Provider value={mockContextValue}>
         {children}

--- a/packages/react-day-picker/src/useDayPicker.test.tsx
+++ b/packages/react-day-picker/src/useDayPicker.test.tsx
@@ -17,135 +17,139 @@ describe("useDayPicker", () => {
   const nextMonth = new Date(2024, 1, 1);
   const selectedDate = new Date(2024, 0, 15);
 
-  const mockContextValue: DayPickerContext<{
+  type SingleDayPickerContext = DayPickerContext<{
     required: false;
     mode: "single";
-  }> = {
-    months: [new CalendarMonth(displayedMonth, [])],
-    nextMonth,
-    previousMonth,
-    goToMonth: jest.fn(),
-    getModifiers: jest.fn((_day: CalendarDay) => ({}) as Modifiers),
-    selected: selectedDate,
-    select: jest.fn(),
-    isSelected: jest.fn((_date: Date) => false),
-    components: {
-      Chevron: jest.fn(),
-      CaptionLabel: jest.fn(),
-      Day: jest.fn(),
-      DayButton: jest.fn(),
-      Dropdown: jest.fn(),
-      DropdownNav: jest.fn(),
-      Footer: jest.fn(),
-      Month: jest.fn(),
-      MonthCaption: jest.fn(),
-      MonthGrid: jest.fn(),
-      Months: jest.fn(),
-      Nav: jest.fn(),
-      Option: jest.fn(),
-      PreviousMonthButton: jest.fn(),
-      NextMonthButton: jest.fn(),
-      Root: jest.fn(),
-      Select: jest.fn(),
-      Weeks: jest.fn(),
-      Week: jest.fn(),
-      Weekday: jest.fn(),
-      Weekdays: jest.fn(),
-      WeekNumber: jest.fn(),
-      WeekNumberHeader: jest.fn(),
-      MonthsDropdown: jest.fn(),
-      YearsDropdown: jest.fn(),
-    },
-    classNames: {
-      [UI.Root]: "",
-      [UI.Chevron]: "",
-      [UI.Day]: "",
-      [UI.DayButton]: "",
-      [UI.CaptionLabel]: "",
-      [UI.Dropdowns]: "",
-      [UI.Dropdown]: "",
-      [UI.DropdownRoot]: "",
-      [UI.Footer]: "",
-      [UI.MonthGrid]: "",
-      [UI.MonthCaption]: "",
-      [UI.MonthsDropdown]: "",
-      [UI.Month]: "",
-      [UI.Months]: "",
-      [UI.Nav]: "",
-      [UI.NextMonthButton]: "",
-      [UI.PreviousMonthButton]: "",
-      [UI.Week]: "",
-      [UI.Weeks]: "",
-      [UI.Weekday]: "",
-      [UI.Weekdays]: "",
-      [UI.WeekNumber]: "",
-      [UI.WeekNumberHeader]: "",
-      [UI.YearsDropdown]: "",
-      [SelectionState.range_end]: "",
-      [SelectionState.range_middle]: "",
-      [SelectionState.range_start]: "",
-      [SelectionState.selected]: "",
-      [DayFlag.disabled]: "",
-      [DayFlag.hidden]: "",
-      [DayFlag.outside]: "",
-      [DayFlag.focused]: "",
-      [DayFlag.today]: "",
-      [Animation.weeks_after_enter]: "",
-      [Animation.weeks_before_exit]: "",
-      [Animation.weeks_before_enter]: "",
-      [Animation.weeks_after_exit]: "",
-      [Animation.caption_after_enter]: "",
-      [Animation.caption_before_exit]: "",
-      [Animation.caption_before_enter]: "",
-      [Animation.caption_after_exit]: "",
-    },
-    styles: {},
-    labels: {
-      labelNav: jest.fn(),
-      labelGrid: jest.fn(),
-      labelGridcell: jest.fn(),
-      labelMonthDropdown: jest.fn(),
-      labelYearDropdown: jest.fn(),
-      labelNext: jest.fn(),
-      labelPrevious: jest.fn(),
-      labelDayButton: jest.fn(),
-      labelWeekday: jest.fn(),
-      labelWeekNumber: jest.fn(),
-      labelWeekNumberHeader: jest.fn(),
-    },
-    formatters: {
-      formatCaption: jest.fn(),
-      formatDay: jest.fn(),
-      formatMonthDropdown: jest.fn(),
-      formatWeekNumber: jest.fn(),
-      formatWeekNumberHeader: jest.fn(),
-      formatWeekdayName: jest.fn(),
-      formatYearDropdown: jest.fn(),
-    },
-    dayPickerProps: {
-      mode: "single",
-      required: false,
-    } as DayPickerProps,
-  };
+  }>;
 
-  test("should return the context value when used within a DayPicker provider", () => {
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
+  let mockContextValue: SingleDayPickerContext;
+  let wrapper: React.ComponentType<{ children: React.ReactNode }>;
+
+  function createMockContextValue(): SingleDayPickerContext {
+    return {
+      months: [new CalendarMonth(displayedMonth, [])],
+      nextMonth,
+      previousMonth,
+      goToMonth: jest.fn(),
+      getModifiers: jest.fn((_day: CalendarDay) => ({}) as Modifiers),
+      selected: selectedDate,
+      select: jest.fn(),
+      isSelected: jest.fn((_date: Date) => false),
+      components: {
+        Chevron: jest.fn(),
+        CaptionLabel: jest.fn(),
+        Day: jest.fn(),
+        DayButton: jest.fn(),
+        Dropdown: jest.fn(),
+        DropdownNav: jest.fn(),
+        Footer: jest.fn(),
+        Month: jest.fn(),
+        MonthCaption: jest.fn(),
+        MonthGrid: jest.fn(),
+        Months: jest.fn(),
+        Nav: jest.fn(),
+        Option: jest.fn(),
+        PreviousMonthButton: jest.fn(),
+        NextMonthButton: jest.fn(),
+        Root: jest.fn(),
+        Select: jest.fn(),
+        Weeks: jest.fn(),
+        Week: jest.fn(),
+        Weekday: jest.fn(),
+        Weekdays: jest.fn(),
+        WeekNumber: jest.fn(),
+        WeekNumberHeader: jest.fn(),
+        MonthsDropdown: jest.fn(),
+        YearsDropdown: jest.fn(),
+      },
+      classNames: {
+        [UI.Root]: "",
+        [UI.Chevron]: "",
+        [UI.Day]: "",
+        [UI.DayButton]: "",
+        [UI.CaptionLabel]: "",
+        [UI.Dropdowns]: "",
+        [UI.Dropdown]: "",
+        [UI.DropdownRoot]: "",
+        [UI.Footer]: "",
+        [UI.MonthGrid]: "",
+        [UI.MonthCaption]: "",
+        [UI.MonthsDropdown]: "",
+        [UI.Month]: "",
+        [UI.Months]: "",
+        [UI.Nav]: "",
+        [UI.NextMonthButton]: "",
+        [UI.PreviousMonthButton]: "",
+        [UI.Week]: "",
+        [UI.Weeks]: "",
+        [UI.Weekday]: "",
+        [UI.Weekdays]: "",
+        [UI.WeekNumber]: "",
+        [UI.WeekNumberHeader]: "",
+        [UI.YearsDropdown]: "",
+        [SelectionState.range_end]: "",
+        [SelectionState.range_middle]: "",
+        [SelectionState.range_start]: "",
+        [SelectionState.selected]: "",
+        [DayFlag.disabled]: "",
+        [DayFlag.hidden]: "",
+        [DayFlag.outside]: "",
+        [DayFlag.focused]: "",
+        [DayFlag.today]: "",
+        [Animation.weeks_after_enter]: "",
+        [Animation.weeks_before_exit]: "",
+        [Animation.weeks_before_enter]: "",
+        [Animation.weeks_after_exit]: "",
+        [Animation.caption_after_enter]: "",
+        [Animation.caption_before_exit]: "",
+        [Animation.caption_before_enter]: "",
+        [Animation.caption_after_exit]: "",
+      },
+      styles: {},
+      labels: {
+        labelNav: jest.fn(),
+        labelGrid: jest.fn(),
+        labelGridcell: jest.fn(),
+        labelMonthDropdown: jest.fn(),
+        labelYearDropdown: jest.fn(),
+        labelNext: jest.fn(),
+        labelPrevious: jest.fn(),
+        labelDayButton: jest.fn(),
+        labelWeekday: jest.fn(),
+        labelWeekNumber: jest.fn(),
+        labelWeekNumberHeader: jest.fn(),
+      },
+      formatters: {
+        formatCaption: jest.fn(),
+        formatDay: jest.fn(),
+        formatMonthDropdown: jest.fn(),
+        formatWeekNumber: jest.fn(),
+        formatWeekNumberHeader: jest.fn(),
+        formatWeekdayName: jest.fn(),
+        formatYearDropdown: jest.fn(),
+      },
+      dayPickerProps: {
+        mode: "single",
+        required: false,
+      } as DayPickerProps,
+    };
+  }
+
+  beforeEach(() => {
+    mockContextValue = createMockContextValue();
+    wrapper = ({ children }: { children: React.ReactNode }) => (
       <dayPickerContext.Provider value={mockContextValue}>
         {children}
       </dayPickerContext.Provider>
     );
+  });
 
+  test("should return the context value when used within a DayPicker provider", () => {
     const { result } = renderHook(() => useDayPicker(), { wrapper });
     expect(result.current).toEqual(mockContextValue);
   });
 
   test("keeps public calendar context values Date-shaped", () => {
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <dayPickerContext.Provider value={mockContextValue}>
-        {children}
-      </dayPickerContext.Provider>
-    );
-
     const { result } = renderHook(() => useDayPicker(), { wrapper });
     const context = result.current;
     const targetMonth = new Date(2024, 2, 1);

--- a/packages/react-day-picker/src/utils/rangeContainsDayOfWeek.test.ts
+++ b/packages/react-day-picker/src/utils/rangeContainsDayOfWeek.test.ts
@@ -16,7 +16,7 @@ describe("should return false", () => {
   ];
 
   for (const [range, dayOfWeek] of testCases) {
-    it(`range from ${range.from} to ${range.to} should not contain ${JSON.stringify(dayOfWeek)}`, () => {
+    test(`range from ${range.from} to ${range.to} should not contain ${JSON.stringify(dayOfWeek)}`, () => {
       expect(rangeContainsDayOfWeek(range, dayOfWeek, defaultDateLib)).toBe(
         false,
       );
@@ -39,7 +39,7 @@ describe("should return true", () => {
   ];
 
   for (const [range, dayOfWeek] of testCases) {
-    it(`range from ${range.from} to ${range.to} should contain ${JSON.stringify(dayOfWeek)}`, () => {
+    test(`range from ${range.from} to ${range.to} should contain ${JSON.stringify(dayOfWeek)}`, () => {
       expect(rangeContainsDayOfWeek(range, dayOfWeek, defaultDateLib)).toBe(
         true,
       );


### PR DESCRIPTION
## Why

The Jest suite had a few inconsistent lifecycle and assertion patterns that made tests easier to accidentally share state or harder to diagnose when assertions failed.

## What Changed

- Centralized mock call cleanup through Jest config.
- Normalized test declarations to `test()` and moved relevant render/action setup into lifecycle hooks.
- Split dense example, animation, and DayPicker context assertions into focused tests.
- Replaced shared DayPicker context mock state with a fresh factory.
- Moved Radix DOM polyfills for the custom dropdown example into explicit setup/teardown.
- Removed assertion-helper patterns so expectations live directly in tests.
- Kept repo-local skill files and unrelated `rfc/` files out of the branch.

## Review Notes

This is intentionally test-only cleanup. The script release workflow tests still keep their broader medium-test style; this PR focuses on component/example/source Jest consistency.

## Validation

- `pnpm test`
- `pnpm test:tz`
- `pnpm lint`
- `pnpm typecheck`
- Focused Jest runs for the refactored files during the cleanup pass.