### PR TITLE
fix: correct dropdown navigation in multi-month calendars

### DIFF
--- a/.changeset/multi-month-dropdown-navigation.md
+++ b/.changeset/multi-month-dropdown-navigation.md
@@ -1,0 +1,6 @@
+---
+"react-day-picker": patch
+"@daypicker/react": patch
+---
+
+fix: keep multi-month dropdown selections on the edited calendar.

--- a/packages/react-day-picker/src/DayPicker.test.tsx
+++ b/packages/react-day-picker/src/DayPicker.test.tsx
@@ -472,6 +472,50 @@ test("places the year dropdown before the month dropdown for year-first locales"
   );
 });
 
+describe("when using dropdowns with numberOfMonths > 1 (issue #2741)", () => {
+  test("changing the month dropdown on the second calendar updates only that calendar", () => {
+    render(
+      <DayPicker
+        captionLayout="dropdown"
+        numberOfMonths={2}
+        defaultMonth={new Date(2024, 0, 1)}
+      />,
+    );
+    // Dropdowns: [month-1, year-1, month-2, year-2]
+    const combos = screen.getAllByRole("combobox");
+    const secondMonthDropdown = combos[2];
+
+    // Select June (month index 5) from the second calendar's dropdown
+    fireEvent.change(secondMonthDropdown, { target: { value: "5" } });
+
+    const grids = screen.getAllByRole("grid");
+    // First calendar should show May 2024, second should show June 2024
+    expect(grids[0]).toHaveAccessibleName("May 2024");
+    expect(grids[1]).toHaveAccessibleName("June 2024");
+  });
+
+  test("changing the year dropdown on the second calendar updates only that calendar", () => {
+    render(
+      <DayPicker
+        captionLayout="dropdown"
+        numberOfMonths={2}
+        defaultMonth={new Date(2024, 0, 1)}
+      />,
+    );
+    // Dropdowns: [month-1, year-1, month-2, year-2]
+    const combos = screen.getAllByRole("combobox");
+    const secondYearDropdown = combos[3];
+
+    // Select 2025 from the second calendar's year dropdown
+    fireEvent.change(secondYearDropdown, { target: { value: "2025" } });
+
+    const grids = screen.getAllByRole("grid");
+    // First calendar should show January 2025, second should show February 2025
+    expect(grids[0]).toHaveAccessibleName("January 2025");
+    expect(grids[1]).toHaveAccessibleName("February 2025");
+  });
+});
+
 test("should render the custom components", () => {
   render(
     <DayPicker

--- a/packages/react-day-picker/src/DayPicker.test.tsx
+++ b/packages/react-day-picker/src/DayPicker.test.tsx
@@ -15,6 +15,7 @@ import { DateLib, defaultLocale } from "./classes/DateLib";
 import type { MonthProps } from "./components/Month";
 import type { MonthsProps } from "./components/Months";
 import { DayPicker } from "./DayPicker";
+import { labelMonthDropdown, labelYearDropdown } from "./labels/index.js";
 import { ja } from "./locale/ja.js";
 
 const testId = "test";
@@ -473,7 +474,7 @@ test("places the year dropdown before the month dropdown for year-first locales"
 });
 
 describe("when using dropdowns with numberOfMonths > 1 (issue #2741)", () => {
-  test("changing the month dropdown on the second calendar updates only that calendar", () => {
+  beforeEach(() => {
     render(
       <DayPicker
         captionLayout="dropdown"
@@ -481,38 +482,85 @@ describe("when using dropdowns with numberOfMonths > 1 (issue #2741)", () => {
         defaultMonth={new Date(2024, 0, 1)}
       />,
     );
-    // Dropdowns: [month-1, year-1, month-2, year-2]
-    const combos = screen.getAllByRole("combobox");
-    const secondMonthDropdown = combos[2];
-
-    // Select June (month index 5) from the second calendar's dropdown
-    fireEvent.change(secondMonthDropdown, { target: { value: "5" } });
-
-    const grids = screen.getAllByRole("grid");
-    // First calendar should show May 2024, second should show June 2024
-    expect(grids[0]).toHaveAccessibleName("May 2024");
-    expect(grids[1]).toHaveAccessibleName("June 2024");
   });
 
-  test("changing the year dropdown on the second calendar updates only that calendar", () => {
+  describe("when choosing June from the second month dropdown", () => {
+    let grids: HTMLElement[];
+
+    beforeEach(async () => {
+      const secondMonthDropdown = screen.getAllByRole("combobox", {
+        name: labelMonthDropdown(),
+      })[1];
+
+      await user.selectOptions(secondMonthDropdown, "5");
+
+      grids = screen.getAllByRole("grid");
+    });
+
+    test("updates the first calendar to May 2024", () => {
+      expect(grids[0]).toHaveAccessibleName("May 2024");
+    });
+
+    test("updates the second calendar to June 2024", () => {
+      expect(grids[1]).toHaveAccessibleName("June 2024");
+    });
+  });
+
+  describe("when choosing 2025 from the second year dropdown", () => {
+    let grids: HTMLElement[];
+
+    beforeEach(async () => {
+      const secondYearDropdown = screen.getAllByRole("combobox", {
+        name: labelYearDropdown(),
+      })[1];
+
+      await user.selectOptions(secondYearDropdown, "2025");
+
+      grids = screen.getAllByRole("grid");
+    });
+
+    test("updates the first calendar to January 2025", () => {
+      expect(grids[0]).toHaveAccessibleName("January 2025");
+    });
+
+    test("updates the second calendar to February 2025", () => {
+      expect(grids[1]).toHaveAccessibleName("February 2025");
+    });
+  });
+});
+
+describe("when using reversed dropdowns with numberOfMonths > 1 (issue #2741)", () => {
+  beforeEach(() => {
     render(
       <DayPicker
         captionLayout="dropdown"
         numberOfMonths={2}
         defaultMonth={new Date(2024, 0, 1)}
+        reverseMonths
       />,
     );
-    // Dropdowns: [month-1, year-1, month-2, year-2]
-    const combos = screen.getAllByRole("combobox");
-    const secondYearDropdown = combos[3];
+  });
 
-    // Select 2025 from the second calendar's year dropdown
-    fireEvent.change(secondYearDropdown, { target: { value: "2025" } });
+  describe("when choosing June from the second month dropdown", () => {
+    let grids: HTMLElement[];
 
-    const grids = screen.getAllByRole("grid");
-    // First calendar should show January 2025, second should show February 2025
-    expect(grids[0]).toHaveAccessibleName("January 2025");
-    expect(grids[1]).toHaveAccessibleName("February 2025");
+    beforeEach(async () => {
+      const secondMonthDropdown = screen.getAllByRole("combobox", {
+        name: labelMonthDropdown(),
+      })[1];
+
+      await user.selectOptions(secondMonthDropdown, "5");
+
+      grids = screen.getAllByRole("grid");
+    });
+
+    test("updates the first calendar to July 2024", () => {
+      expect(grids[0]).toHaveAccessibleName("July 2024");
+    });
+
+    test("updates the second calendar to June 2024", () => {
+      expect(grids[1]).toHaveAccessibleName("June 2024");
+    });
   });
 });
 

--- a/packages/react-day-picker/src/DayPicker.tsx
+++ b/packages/react-day-picker/src/DayPicker.tsx
@@ -326,21 +326,24 @@ export function DayPicker(initialProps: DayPickerProps) {
   );
 
   const handleMonthChange = useCallback(
-    (date: Date, displayIndex: number) =>
+    (date: Date, monthOffset: number) =>
       (e: ChangeEvent<HTMLSelectElement>) => {
         const selectedMonth = Number(e.target.value);
-        const month = dateLib.setMonth(dateLib.startOfMonth(date), selectedMonth);
-        goToMonth(dateLib.addMonths(month, -displayIndex));
+        const month = dateLib.setMonth(
+          dateLib.startOfMonth(date),
+          selectedMonth,
+        );
+        goToMonth(dateLib.addMonths(month, -monthOffset));
       },
     [dateLib, goToMonth],
   );
 
   const handleYearChange = useCallback(
-    (date: Date, displayIndex: number) =>
+    (date: Date, monthOffset: number) =>
       (e: ChangeEvent<HTMLSelectElement>) => {
         const selectedYear = Number(e.target.value);
         const month = dateLib.setYear(dateLib.startOfMonth(date), selectedYear);
-        goToMonth(dateLib.addMonths(month, -displayIndex));
+        goToMonth(dateLib.addMonths(month, -monthOffset));
       },
     [dateLib, goToMonth],
   );
@@ -415,6 +418,10 @@ export function DayPicker(initialProps: DayPickerProps) {
             />
           )}
           {months.map((calendarMonth, displayIndex) => {
+            const monthOffset = props.reverseMonths
+              ? months.length - 1 - displayIndex
+              : displayIndex;
+
             return (
               <components.Month
                 data-animated-month={props.animate ? "true" : undefined}
@@ -465,7 +472,10 @@ export function DayPicker(initialProps: DayPickerProps) {
                               className={classNames[UI.MonthsDropdown]}
                               aria-label={labelMonthDropdown()}
                               disabled={Boolean(props.disableNavigation)}
-                              onChange={handleMonthChange(calendarMonth.date, displayIndex)}
+                              onChange={handleMonthChange(
+                                calendarMonth.date,
+                                monthOffset,
+                              )}
                               options={getMonthOptions(
                                 calendarMonth.date,
                                 navStart,
@@ -490,7 +500,10 @@ export function DayPicker(initialProps: DayPickerProps) {
                               className={classNames[UI.YearsDropdown]}
                               aria-label={labelYearDropdown(dateLib.options)}
                               disabled={Boolean(props.disableNavigation)}
-                              onChange={handleYearChange(calendarMonth.date, displayIndex)}
+                              onChange={handleYearChange(
+                                calendarMonth.date,
+                                monthOffset,
+                              )}
                               options={getYearOptions(
                                 navStart,
                                 navEnd,

--- a/packages/react-day-picker/src/DayPicker.tsx
+++ b/packages/react-day-picker/src/DayPicker.tsx
@@ -326,20 +326,22 @@ export function DayPicker(initialProps: DayPickerProps) {
   );
 
   const handleMonthChange = useCallback(
-    (date: Date) => (e: ChangeEvent<HTMLSelectElement>) => {
-      const selectedMonth = Number(e.target.value);
-      const month = dateLib.setMonth(dateLib.startOfMonth(date), selectedMonth);
-      goToMonth(month);
-    },
+    (date: Date, displayIndex: number) =>
+      (e: ChangeEvent<HTMLSelectElement>) => {
+        const selectedMonth = Number(e.target.value);
+        const month = dateLib.setMonth(dateLib.startOfMonth(date), selectedMonth);
+        goToMonth(dateLib.addMonths(month, -displayIndex));
+      },
     [dateLib, goToMonth],
   );
 
   const handleYearChange = useCallback(
-    (date: Date) => (e: ChangeEvent<HTMLSelectElement>) => {
-      const selectedYear = Number(e.target.value);
-      const month = dateLib.setYear(dateLib.startOfMonth(date), selectedYear);
-      goToMonth(month);
-    },
+    (date: Date, displayIndex: number) =>
+      (e: ChangeEvent<HTMLSelectElement>) => {
+        const selectedYear = Number(e.target.value);
+        const month = dateLib.setYear(dateLib.startOfMonth(date), selectedYear);
+        goToMonth(dateLib.addMonths(month, -displayIndex));
+      },
     [dateLib, goToMonth],
   );
 
@@ -463,7 +465,7 @@ export function DayPicker(initialProps: DayPickerProps) {
                               className={classNames[UI.MonthsDropdown]}
                               aria-label={labelMonthDropdown()}
                               disabled={Boolean(props.disableNavigation)}
-                              onChange={handleMonthChange(calendarMonth.date)}
+                              onChange={handleMonthChange(calendarMonth.date, displayIndex)}
                               options={getMonthOptions(
                                 calendarMonth.date,
                                 navStart,
@@ -488,7 +490,7 @@ export function DayPicker(initialProps: DayPickerProps) {
                               className={classNames[UI.YearsDropdown]}
                               aria-label={labelYearDropdown(dateLib.options)}
                               disabled={Boolean(props.disableNavigation)}
-                              onChange={handleYearChange(calendarMonth.date)}
+                              onChange={handleYearChange(calendarMonth.date, displayIndex)}
                               options={getYearOptions(
                                 navStart,
                                 navEnd,


### PR DESCRIPTION
When using captionLayout="dropdown" with numberOfMonths > 1, selecting a month or year from the Nth calendar's dropdown was incorrectly setting firstMonth to the selected value directly, causing the first calendar to jump instead of the intended one. Offset the target by -displayIndex before calling goToMonth so the selected calendar shows the chosen month.

Fixes #2741


