### PR TITLE
fix: support React 19 in v8

### DIFF
--- a/.github/scripts/smoke-v8-release.mjs
+++ b/.github/scripts/smoke-v8-release.mjs
@@ -1,0 +1,235 @@
+/* eslint-env node */
+import { execFileSync } from 'node:child_process';
+import { copyFileSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const command = process.argv[2];
+
+if (!command) {
+  throw new Error('Expected a smoke test command.');
+}
+
+const env = {
+  ...process.env,
+  NPM_CONFIG_CACHE:
+    process.env.NPM_CONFIG_CACHE || join(tmpdir(), 'rdp-v8-npm-cache')
+};
+
+function run(binary, args, cwd) {
+  execFileSync(binary, args, { cwd, env, stdio: 'inherit' });
+}
+
+function packTarball() {
+  const destination =
+    process.env.RUNNER_TEMP || mkdtempSync(join(tmpdir(), 'rdp-pack-'));
+  const filename = execFileSync(
+    'npm',
+    ['pack', '--pack-destination', destination, '--silent'],
+    { encoding: 'utf8' }
+  )
+    .trim()
+    .split('\n')
+    .pop();
+
+  return join(destination, filename);
+}
+
+function createConsumer(tarball) {
+  const directory = mkdtempSync(join(tmpdir(), 'rdp-consumer-'));
+
+  copyFileSync(tarball, join(directory, 'react-day-picker.tgz'));
+  writeFileSync(
+    join(directory, 'package.json'),
+    `${JSON.stringify({ private: true, type: 'commonjs' }, null, 2)}\n`
+  );
+
+  return directory;
+}
+
+function installConsumer(directory, dependencies) {
+  run(
+    'npm',
+    ['install', '--ignore-scripts', './react-day-picker.tgz', ...dependencies],
+    directory
+  );
+}
+
+function writeTypescriptConfig(directory) {
+  writeFileSync(
+    join(directory, 'tsconfig.json'),
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          strict: true,
+          jsx: 'react-jsx',
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          target: 'ES2022',
+          skipLibCheck: false,
+          noEmit: true
+        },
+        include: ['src']
+      },
+      null,
+      2
+    )}\n`
+  );
+}
+
+function writeTypescriptFixture(directory, options) {
+  mkdirSync(join(directory, 'src'));
+
+  const multiplePicker = options.includeMultiple
+    ? `
+export function MultiplePicker() {
+  const [selected, setSelected] = useState<Date[]>();
+  return <DayPicker mode="multiple" selected={selected} onSelect={setSelected} />;
+}
+`
+    : '';
+
+  const customDayContentPicker = options.includeCustomDayContent
+    ? `
+export function CustomDayContentPicker() {
+  return (
+    <DayPicker
+      components={{
+        DayContent(props) {
+          return <span>{props.date.getDate()}</span>;
+        }
+      }}
+    />
+  );
+}
+`
+    : '';
+
+  writeFileSync(
+    join(directory, 'src/index.tsx'),
+    `import { createRef, useState } from "react";
+import { DayPicker, type ButtonProps, type DateRange } from "react-day-picker";
+import "react-day-picker/dist/style.css";
+
+const buttonRef = createRef<HTMLButtonElement>();
+const buttonProps: ButtonProps = { ref: buttonRef, type: "button" };
+void buttonProps;
+
+export function SinglePicker() {
+  const [selected, setSelected] = useState<Date>();
+  return <DayPicker mode="single" selected={selected} onSelect={setSelected} />;
+}
+${multiplePicker}
+export function RangePicker() {
+  const [selected, setSelected] = useState<DateRange>();
+  return <DayPicker mode="range" selected={selected} onSelect={setSelected} />;
+}
+${customDayContentPicker}`
+  );
+}
+
+function runTypescriptSmoke(tarball, options) {
+  const directory = createConsumer(tarball);
+
+  installConsumer(directory, [
+    `react@${options.react}`,
+    `react-dom@${options.react}`,
+    `date-fns@${options.dateFns}`,
+    'typescript@^5',
+    `@types/react@${options.reactTypes}`,
+    `@types/react-dom@${options.reactDomTypes}`
+  ]);
+
+  writeTypescriptConfig(directory);
+  writeTypescriptFixture(directory, options);
+  run('npx', ['tsc', '--noEmit'], directory);
+}
+
+function writeRuntimeFixture(directory) {
+  writeFileSync(
+    join(directory, 'smoke.mjs'),
+    `import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { JSDOM } = require("jsdom");
+
+const dom = new JSDOM('<div id="root"></div>');
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.Node = dom.window.Node;
+Object.defineProperty(globalThis, "navigator", {
+  value: dom.window.navigator,
+  configurable: true
+});
+
+const React = require("react");
+const { flushSync } = require("react-dom");
+const { createRoot } = require("react-dom/client");
+const { DayPicker } = require("react-day-picker");
+
+const container = document.getElementById("root");
+const root = createRoot(container);
+
+flushSync(() => {
+  root.render(React.createElement(DayPicker, { month: new Date(2024, 0, 1) }));
+});
+
+if (!container.querySelector(".rdp")) {
+  throw new Error("DayPicker did not render its root element.");
+}
+
+root.unmount();
+`
+  );
+}
+
+function runRuntimeSmoke(tarball, options) {
+  const directory = createConsumer(tarball);
+
+  installConsumer(directory, [
+    `react@${options.react}`,
+    `react-dom@${options.react}`,
+    `date-fns@${options.dateFns}`,
+    'jsdom@^24.1.3'
+  ]);
+
+  writeRuntimeFixture(directory);
+  run('node', ['smoke.mjs'], directory);
+}
+
+const tarball = packTarball();
+
+switch (command) {
+  case 'react19-runtime':
+    runRuntimeSmoke(tarball, { react: '19', dateFns: '3' });
+    runRuntimeSmoke(tarball, { react: '19', dateFns: '2' });
+    break;
+
+  case 'react19-types':
+    runTypescriptSmoke(tarball, {
+      react: '19',
+      reactTypes: '19',
+      reactDomTypes: '19',
+      dateFns: '3',
+      includeMultiple: false,
+      includeCustomDayContent: false
+    });
+    break;
+
+  case 'react18-types':
+    for (const dateFns of ['2', '3']) {
+      runTypescriptSmoke(tarball, {
+        react: '18',
+        reactTypes: '18',
+        reactDomTypes: '18',
+        dateFns,
+        includeMultiple: true,
+        includeCustomDayContent: true
+      });
+    }
+    break;
+
+  default:
+    throw new Error(`Unknown smoke test command: ${command}`);
+}

--- a/.github/scripts/verify-npm-version.mjs
+++ b/.github/scripts/verify-npm-version.mjs
@@ -1,0 +1,18 @@
+/* eslint-env node */
+import { execFileSync } from 'node:child_process';
+
+const minimum = [11, 5, 1];
+const version = execFileSync('npm', ['--version'], {
+  encoding: 'utf8'
+}).trim();
+const current = version.split('.').map(Number);
+
+for (let index = 0; index < minimum.length; index += 1) {
+  if (current[index] > minimum[index]) {
+    process.exit(0);
+  }
+
+  if (current[index] < minimum[index]) {
+    throw new Error(`npm ${version} does not satisfy >=11.5.1`);
+  }
+}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,29 +1,17 @@
 name: react-day-picker
 
 on:
-  release:
-    types: [published]
   pull_request:
     branches:
       - main
+      - maintenance/v8
   push:
     branches:
       - main
+      - maintenance/v8
   workflow_dispatch:
-    inputs:
-      publish:
-        description: Publish on npm
-        required: false
-        default: false
-        type: boolean
 
 jobs:
-  # print-env:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - run: |
-  #         echo "publish=${{ github.event.inputs.publish || false }}"
-
   typecheck:
     runs-on: ubuntu-latest
     steps:
@@ -84,28 +72,3 @@ jobs:
         with:
           name: rdp-dist
           path: dist
-
-  publish-on-npm:
-    runs-on: ubuntu-latest
-    needs: [build, test]
-    if: ${{ github.event_name == 'release' || github.event.inputs.publish }}
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 8.6.2
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18.16
-          registry-url: https://registry.npmjs.org/
-          always-auth: false
-      - uses: actions/download-artifact@v4
-        with:
-          name: rdp-dist
-          path: dist
-      - run: echo "//<npm-registry>:8080/:_authToken=$NODE_AUTH_TOKEN" > ~/.npmrc
-      - run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: react-day-picker v8 release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 8.6.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm test
+      - run: pnpm build
+      - name: Verify npm trusted publishing support
+        run: node .github/scripts/verify-npm-version.mjs
+      - name: Smoke test React 19 consumer installs
+        run: node .github/scripts/smoke-v8-release.mjs react19-runtime
+      - name: Smoke test React 19 TypeScript declarations
+        run: node .github/scripts/smoke-v8-release.mjs react19-types
+      - name: Smoke test React 18 TypeScript declarations
+        run: node .github/scripts/smoke-v8-release.mjs react18-types
+
+  publish:
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 8.6.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org/
+      - name: Block prerelease publishing
+        env:
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          if [ "$RELEASE_PRERELEASE" = "true" ]; then
+            echo "Prerelease GitHub Releases cannot publish stable v8 packages." >&2
+            exit 1
+          fi
+      - name: Verify release tag matches package version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          expected_tag="v$(node -p "require('./package.json').version")"
+          if [ "$RELEASE_TAG" != "$expected_tag" ]; then
+            echo "Release tag $RELEASE_TAG does not match package version $expected_tag." >&2
+            exit 1
+          fi
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - name: Verify npm trusted publishing support
+        run: node .github/scripts/verify-npm-version.mjs
+      - run: npm publish --tag legacy-v8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
 # Changelog
 
+## v8.10.2
+
+_Release date: 2026-05-02_
+
+- Expand React peer dependency support to include React 19. This release has no runtime or API changes.
+
 Full release notes at https://github.com/gpbl/react-day-picker/releases

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ pnpm install react-day-picker date-fns # using pnpm
 yarn add react-day-picker date-fns     # using yarn
 ```
 
+DayPicker v8 supports React 16.8, 17, 18, and 19, with date-fns 2 or 3.
+
 <a href="https://www.npmjs.com/package/react-day-picker"><img src="https://img.shields.io/npm/v/react-day-picker.svg?style=flat-square" alt="npm version"/></a> <img src="https://img.shields.io/npm/dm/react-day-picker.svg?style=flat-square" alt="npm downloads"/> <img src="https://img.shields.io/bundlephobia/minzip/react-day-picker" alt="Min gzipped size"/>
 
 ## Example

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "react-day-picker",
-  "version": "8.10.1",
+  "version": "8.10.2",
   "description": "Customizable Date Picker for React",
   "author": "Giampaolo Bellavite <io@gpbl.dev>",
   "homepage": "http://react-day-picker.js.org",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gpbl/react-day-picker"
+    "url": "git+https://github.com/gpbl/react-day-picker.git"
   },
   "bugs": {
     "url": "https://github.com/gpbl/react-day-picker/issues"
@@ -81,7 +81,7 @@
   },
   "peerDependencies": {
     "date-fns": "^2.28.0 || ^3.0.0",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "funding": {
     "type": "individual",

--- a/src/DayPicker.tsx
+++ b/src/DayPicker.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import { DayPickerDefaultProps } from 'types/DayPickerDefault';
 import { DayPickerMultipleProps } from 'types/DayPickerMultiple';
 import { DayPickerRangeProps } from 'types/DayPickerRange';
@@ -105,7 +107,7 @@ export function DayPicker(
     | DayPickerSingleProps
     | DayPickerMultipleProps
     | DayPickerRangeProps
-): JSX.Element {
+): ReactElement {
   return (
     <RootProvider {...props}>
       <Root initialProps={props} />

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,9 +1,10 @@
 import { forwardRef } from 'react';
+import type { ComponentPropsWithRef } from 'react';
 
 import { useDayPicker } from 'contexts/DayPicker';
 
 /** The props for the {@link Button} component. */
-export type ButtonProps = JSX.IntrinsicElements['button'];
+export type ButtonProps = ComponentPropsWithRef<'button'>;
 
 /** Render a button HTML element applying the reset class name. */
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(

--- a/src/components/Caption/Caption.tsx
+++ b/src/components/Caption/Caption.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import { CaptionDropdowns } from 'components/CaptionDropdowns';
 import { CaptionLabel } from 'components/CaptionLabel';
 import { CaptionNavigation } from 'components/CaptionNavigation';
@@ -26,13 +28,13 @@ export type CaptionLayout = 'dropdown' | 'buttons' | 'dropdown-buttons';
  * Render the caption of a month. The caption has a different layout when
  * setting the {@link DayPickerBase.captionLayout} prop.
  */
-export function Caption(props: CaptionProps): JSX.Element {
+export function Caption(props: CaptionProps): ReactElement {
   const { classNames, disableNavigation, styles, captionLayout, components } =
     useDayPicker();
 
   const CaptionLabelComponent = components?.CaptionLabel ?? CaptionLabel;
 
-  let caption: JSX.Element;
+  let caption: ReactElement;
   if (disableNavigation) {
     caption = (
       <CaptionLabelComponent id={props.id} displayMonth={props.displayMonth} />

--- a/src/components/CaptionDropdowns/CaptionDropdowns.tsx
+++ b/src/components/CaptionDropdowns/CaptionDropdowns.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import { addMonths } from 'date-fns';
 
 import { CaptionProps } from 'components/Caption/Caption';
@@ -11,7 +13,7 @@ import { MonthChangeEventHandler } from 'types/EventHandlers';
 /**
  * Render a caption with the dropdowns to navigate between months and years.
  */
-export function CaptionDropdowns(props: CaptionProps): JSX.Element {
+export function CaptionDropdowns(props: CaptionProps): ReactElement {
   const { classNames, styles, components } = useDayPicker();
   const { goToMonth } = useNavigation();
 

--- a/src/components/CaptionLabel/CaptionLabel.tsx
+++ b/src/components/CaptionLabel/CaptionLabel.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import { useDayPicker } from 'contexts/DayPicker';
 
 /** The props for the {@link CaptionLabel} component. */
@@ -11,7 +13,7 @@ export interface CaptionLabelProps {
 }
 
 /** Render the caption for the displayed month. This component is used when `captionLayout="buttons"`. */
-export function CaptionLabel(props: CaptionLabelProps): JSX.Element {
+export function CaptionLabel(props: CaptionLabelProps): ReactElement {
   const {
     locale,
     classNames,

--- a/src/components/CaptionNavigation/CaptionNavigation.tsx
+++ b/src/components/CaptionNavigation/CaptionNavigation.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler } from 'react';
+import type { MouseEventHandler, ReactElement } from 'react';
 
 import { isSameMonth } from 'date-fns';
 
@@ -10,7 +10,7 @@ import { useNavigation } from 'contexts/Navigation';
 /**
  * Render a caption with a button-based navigation.
  */
-export function CaptionNavigation(props: CaptionProps): JSX.Element {
+export function CaptionNavigation(props: CaptionProps): ReactElement {
   const { numberOfMonths } = useDayPicker();
   const { previousMonth, nextMonth, goToMonth, displayMonths } =
     useNavigation();

--- a/src/components/Day/Day.tsx
+++ b/src/components/Day/Day.tsx
@@ -1,4 +1,5 @@
 import { useRef } from 'react';
+import type { ReactElement } from 'react';
 
 import { useDayRender } from 'hooks/useDayRender';
 
@@ -16,7 +17,7 @@ export interface DayProps {
  * The content of a day cell – as a button or span element according to its
  * modifiers.
  */
-export function Day(props: DayProps): JSX.Element {
+export function Day(props: DayProps): ReactElement {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dayRender = useDayRender(props.date, props.displayMonth, buttonRef);
 

--- a/src/components/DayContent/DayContent.tsx
+++ b/src/components/DayContent/DayContent.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import { useDayPicker } from 'contexts/DayPicker';
 import { ActiveModifiers } from 'types/Modifiers';
 
@@ -12,7 +14,7 @@ export interface DayContentProps {
 }
 
 /** Render the content of the day cell. */
-export function DayContent(props: DayContentProps): JSX.Element {
+export function DayContent(props: DayContentProps): ReactElement {
   const {
     locale,
     formatters: { formatDay }

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,6 +1,7 @@
-import {
+import type {
   ChangeEventHandler,
   CSSProperties,
+  ReactElement,
   ReactNode,
   SelectHTMLAttributes
 } from 'react';
@@ -27,7 +28,7 @@ export interface DropdownProps {
  * Render a styled select component – displaying a caption and a custom
  * drop-down icon.
  */
-export function Dropdown(props: DropdownProps): JSX.Element {
+export function Dropdown(props: DropdownProps): ReactElement {
   const { onChange, value, children, caption, className, style } = props;
   const dayPicker = useDayPicker();
 

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import { useDayPicker } from 'contexts/DayPicker';
 
 export interface FooterProps {
@@ -6,7 +8,7 @@ export interface FooterProps {
 }
 /** Render the Footer component (empty as default).*/
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function Footer(props: FooterProps): JSX.Element {
+export function Footer(props: FooterProps): ReactElement {
   const {
     footer,
     styles,

--- a/src/components/Head/Head.tsx
+++ b/src/components/Head/Head.tsx
@@ -1,8 +1,10 @@
+import type { ReactElement } from 'react';
+
 import { HeadRow } from 'components/HeadRow';
 import { useDayPicker } from 'contexts/DayPicker';
 
 /** Render the table head. */
-export function Head(): JSX.Element {
+export function Head(): ReactElement {
   const { classNames, styles, components } = useDayPicker();
   const HeadRowComponent = components?.HeadRow ?? HeadRow;
   return (

--- a/src/components/HeadRow/HeadRow.tsx
+++ b/src/components/HeadRow/HeadRow.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import { useDayPicker } from 'contexts/DayPicker';
 
 import { getWeekdays } from './utils';
@@ -5,7 +7,7 @@ import { getWeekdays } from './utils';
 /**
  * Render the HeadRow component - i.e. the table head row with the weekday names.
  */
-export function HeadRow(): JSX.Element {
+export function HeadRow(): ReactElement {
   const {
     classNames,
     styles,

--- a/src/components/IconDropdown/IconDropdown.tsx
+++ b/src/components/IconDropdown/IconDropdown.tsx
@@ -1,9 +1,11 @@
+import type { ReactElement } from 'react';
+
 import { StyledComponent } from 'types/Styles';
 
 /**
  * Render the icon in the styled drop-down.
  */
-export function IconDropdown(props: StyledComponent): JSX.Element {
+export function IconDropdown(props: StyledComponent): ReactElement {
   return (
     <svg
       width="8px"

--- a/src/components/IconLeft/IconLeft.tsx
+++ b/src/components/IconLeft/IconLeft.tsx
@@ -1,9 +1,11 @@
+import type { ReactElement } from 'react';
+
 import { StyledComponent } from 'types/Styles';
 
 /**
  * Render the "previous month" button in the navigation.
  */
-export function IconLeft(props: StyledComponent): JSX.Element {
+export function IconLeft(props: StyledComponent): ReactElement {
   return (
     <svg width="16px" height="16px" viewBox="0 0 120 120" {...props}>
       <path

--- a/src/components/IconRight/IconRight.tsx
+++ b/src/components/IconRight/IconRight.tsx
@@ -1,9 +1,11 @@
+import type { ReactElement } from 'react';
+
 import { StyledComponent } from 'types/Styles';
 
 /**
  * Render the "next month" button in the navigation.
  */
-export function IconRight(props: StyledComponent): JSX.Element {
+export function IconRight(props: StyledComponent): ReactElement {
   return (
     <svg width="16px" height="16px" viewBox="0 0 120 120" {...props}>
       <path

--- a/src/components/Months/Months.tsx
+++ b/src/components/Months/Months.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import { useDayPicker } from 'contexts/DayPicker';
 
@@ -8,7 +8,7 @@ export type MonthsProps = { children: ReactNode };
 /**
  * Render the wrapper for the month grids.
  */
-export function Months(props: MonthsProps): JSX.Element {
+export function Months(props: MonthsProps): ReactElement {
   const { classNames, styles } = useDayPicker();
 
   return (

--- a/src/components/MonthsDropdown/MonthsDropdown.tsx
+++ b/src/components/MonthsDropdown/MonthsDropdown.tsx
@@ -1,4 +1,4 @@
-import { ChangeEventHandler } from 'react';
+import type { ChangeEventHandler, ReactElement } from 'react';
 
 import { isSameYear, setMonth, startOfMonth } from 'date-fns';
 
@@ -14,7 +14,7 @@ export interface MonthsDropdownProps {
 }
 
 /** Render the dropdown to navigate between months. */
-export function MonthsDropdown(props: MonthsDropdownProps): JSX.Element {
+export function MonthsDropdown(props: MonthsDropdownProps): ReactElement {
   const {
     fromDate,
     toDate,

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler } from 'react';
+import type { MouseEventHandler, ReactElement } from 'react';
 
 import { IconLeft } from 'components/IconLeft';
 import { IconRight } from 'components/IconRight';
@@ -25,7 +25,7 @@ export interface NavigationProps {
 }
 
 /** A component rendering the navigation buttons or the drop-downs. */
-export function Navigation(props: NavigationProps): JSX.Element {
+export function Navigation(props: NavigationProps): ReactElement {
   const {
     dir,
     locale,

--- a/src/components/Root/Root.tsx
+++ b/src/components/Root/Root.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
 
 import { DayPickerProps } from 'DayPicker';
 
@@ -19,7 +20,7 @@ export interface RootProps {
 }
 
 /** Render the container with the months according to the number of months to display. */
-export function Root({ initialProps }: RootProps): JSX.Element {
+export function Root({ initialProps }: RootProps): ReactElement {
   const dayPicker = useDayPicker();
   const focusContext = useFocusContext();
   const navigation = useNavigation();

--- a/src/components/Row/Row.tsx
+++ b/src/components/Row/Row.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import { getUnixTime } from 'date-fns';
 
 import { Day } from 'components/Day';
@@ -17,7 +19,7 @@ export interface RowProps {
 }
 
 /** Render a row in the calendar, with the days and the week number. */
-export function Row(props: RowProps): JSX.Element {
+export function Row(props: RowProps): ReactElement {
   const { styles, classNames, showWeekNumber, components } = useDayPicker();
 
   const DayComponent = components?.Day ?? Day;

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import { Footer } from 'components/Footer';
 import { Head } from 'components/Head';
 import { Row } from 'components/Row';
@@ -16,7 +18,7 @@ export interface TableProps {
 }
 
 /** Render the table with the calendar. */
-export function Table(props: TableProps): JSX.Element {
+export function Table(props: TableProps): ReactElement {
   const {
     locale,
     classNames,

--- a/src/components/WeekNumber/WeekNumber.tsx
+++ b/src/components/WeekNumber/WeekNumber.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler } from 'react';
+import type { MouseEventHandler, ReactElement } from 'react';
 
 import { useDayPicker } from 'contexts/DayPicker';
 
@@ -18,7 +18,7 @@ export interface WeekNumberProps {
  * Render the week number element. If `onWeekNumberClick` is passed to DayPicker, it
  * renders a button, otherwise a span element.
  */
-export function WeekNumber(props: WeekNumberProps): JSX.Element {
+export function WeekNumber(props: WeekNumberProps): ReactElement {
   const { number: weekNumber, dates } = props;
   const {
     onWeekNumberClick,

--- a/src/components/YearsDropdown/YearsDropdown.tsx
+++ b/src/components/YearsDropdown/YearsDropdown.tsx
@@ -1,4 +1,4 @@
-import { ChangeEventHandler } from 'react';
+import type { ChangeEventHandler, ReactElement } from 'react';
 
 import { setYear, startOfMonth, startOfYear } from 'date-fns';
 
@@ -20,7 +20,7 @@ export interface YearsDropdownProps {
  * Render a dropdown to change the year. Take in account the `nav.fromDate` and
  * `toDate` from context.
  */
-export function YearsDropdown(props: YearsDropdownProps): JSX.Element {
+export function YearsDropdown(props: YearsDropdownProps): ReactElement {
   const { displayMonth } = props;
   const {
     fromDate,

--- a/src/contexts/DayPicker/DayPickerContext.tsx
+++ b/src/contexts/DayPicker/DayPickerContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, ReactNode, useContext } from 'react';
+import { createContext, useContext } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import { Locale } from 'date-fns';
 import { DayPickerProps } from 'DayPicker';
@@ -68,7 +69,7 @@ export interface DayPickerProviderProps {
  * The provider for the {@link DayPickerContext}, assigning the defaults from the
  * initial DayPicker props.
  */
-export function DayPickerProvider(props: DayPickerProviderProps): JSX.Element {
+export function DayPickerProvider(props: DayPickerProviderProps): ReactElement {
   const { initialProps } = props;
 
   const defaultContextValues = getDefaultContextValues();

--- a/src/contexts/Focus/FocusContext.tsx
+++ b/src/contexts/Focus/FocusContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, ReactNode, useContext, useState } from 'react';
+import { createContext, useContext, useState } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import { isSameDay } from 'date-fns';
 
@@ -57,7 +58,7 @@ export const FocusContext = createContext<FocusContextValue | undefined>(
 export type FocusProviderProps = { children: ReactNode };
 
 /** The provider for the {@link FocusContext}. */
-export function FocusProvider(props: FocusProviderProps): JSX.Element {
+export function FocusProvider(props: FocusProviderProps): ReactElement {
   const navigation = useNavigation();
   const modifiers = useModifiers();
 

--- a/src/contexts/Modifiers/ModifiersContext.tsx
+++ b/src/contexts/Modifiers/ModifiersContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, useContext, ReactNode } from 'react';
+import { createContext, useContext } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import { useDayPicker } from 'contexts/DayPicker';
 import { useSelectMultiple } from 'contexts/SelectMultiple';
@@ -14,7 +15,7 @@ export const ModifiersContext = createContext<Modifiers | undefined>(undefined);
 export type ModifiersProviderProps = { children: ReactNode };
 
 /** Provide the value for the {@link ModifiersContext}. */
-export function ModifiersProvider(props: ModifiersProviderProps): JSX.Element {
+export function ModifiersProvider(props: ModifiersProviderProps): ReactElement {
   const dayPicker = useDayPicker();
   const selectMultiple = useSelectMultiple();
   const selectRange = useSelectRange();

--- a/src/contexts/Navigation/NavigationContext.tsx
+++ b/src/contexts/Navigation/NavigationContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, ReactNode, useContext } from 'react';
+import { createContext, useContext } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import { addMonths, isBefore, isSameMonth } from 'date-fns';
 
@@ -37,7 +38,7 @@ export const NavigationContext = createContext<
 /** Provides the values for the {@link NavigationContext}. */
 export function NavigationProvider(props: {
   children?: ReactNode;
-}): JSX.Element {
+}): ReactElement {
   const dayPicker = useDayPicker();
   const [currentMonth, goToMonth] = useNavigationState();
 

--- a/src/contexts/RootProvider.tsx
+++ b/src/contexts/RootProvider.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import { ModifiersProvider } from 'contexts/Modifiers/ModifiersContext';
 
@@ -25,7 +25,7 @@ export type RootContext = RootContextProps & {
 };
 
 /** Provide the value for all the context providers. */
-export function RootProvider(props: RootContext): JSX.Element {
+export function RootProvider(props: RootContext): ReactElement {
   const { children, ...initialProps } = props;
 
   return (

--- a/src/contexts/SelectMultiple/SelectMultipleContext.test.ts
+++ b/src/contexts/SelectMultiple/SelectMultipleContext.test.ts
@@ -1,4 +1,4 @@
-import { MouseEvent } from 'react';
+import type { MouseEvent } from 'react';
 
 import { addDays, addMonths } from 'date-fns';
 import { DayPickerProps } from 'DayPicker';

--- a/src/contexts/SelectMultiple/SelectMultipleContext.tsx
+++ b/src/contexts/SelectMultiple/SelectMultipleContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, ReactNode, useContext } from 'react';
+import { createContext, useContext } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import { isSameDay } from 'date-fns';
 
@@ -44,7 +45,7 @@ export type SelectMultipleProviderProps = {
 /** Provides the values for the {@link SelectMultipleContext}. */
 export function SelectMultipleProvider(
   props: SelectMultipleProviderProps
-): JSX.Element {
+): ReactElement {
   if (!isDayPickerMultiple(props.initialProps)) {
     const emptyContextValue: SelectMultipleContextValue = {
       selected: undefined,
@@ -75,7 +76,7 @@ export interface SelectMultipleProviderInternalProps {
 export function SelectMultipleProviderInternal({
   initialProps,
   children
-}: SelectMultipleProviderInternalProps): JSX.Element {
+}: SelectMultipleProviderInternalProps): ReactElement {
   const { selected, min, max } = initialProps;
 
   const onDayClick: DayClickEventHandler = (day, activeModifiers, e) => {

--- a/src/contexts/SelectRange/SelectRangeContext.test.ts
+++ b/src/contexts/SelectRange/SelectRangeContext.test.ts
@@ -1,4 +1,4 @@
-import { MouseEvent } from 'react';
+import type { MouseEvent } from 'react';
 
 import {
   addDays,

--- a/src/contexts/SelectRange/SelectRangeContext.tsx
+++ b/src/contexts/SelectRange/SelectRangeContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, ReactNode, useContext } from 'react';
+import { createContext, useContext } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import {
   addDays,
@@ -52,7 +53,7 @@ export interface SelectRangeProviderProps {
 /** Provides the values for the {@link SelectRangeProvider}. */
 export function SelectRangeProvider(
   props: SelectRangeProviderProps
-): JSX.Element {
+): ReactElement {
   if (!isDayPickerRange(props.initialProps)) {
     const emptyContextValue: SelectRangeContextValue = {
       selected: undefined,
@@ -86,7 +87,7 @@ export interface SelectRangeProviderInternalProps {
 export function SelectRangeProviderInternal({
   initialProps,
   children
-}: SelectRangeProviderInternalProps): JSX.Element {
+}: SelectRangeProviderInternalProps): ReactElement {
   const { selected } = initialProps;
   const { from: selectedFrom, to: selectedTo } = selected || {};
   const min = initialProps.min;

--- a/src/contexts/SelectSingle/SelectSingleContext.test.ts
+++ b/src/contexts/SelectSingle/SelectSingleContext.test.ts
@@ -1,4 +1,4 @@
-import { MouseEvent } from 'react';
+import type { MouseEvent } from 'react';
 
 import { DayPickerProps } from 'DayPicker';
 

--- a/src/contexts/SelectSingle/SelectSingleContext.tsx
+++ b/src/contexts/SelectSingle/SelectSingleContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, ReactNode, useContext } from 'react';
+import { createContext, useContext } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import { DayPickerBase } from 'types/DayPickerBase';
 import { DayPickerSingleProps, isDayPickerSingle } from 'types/DayPickerSingle';
@@ -30,7 +31,7 @@ export interface SelectSingleProviderProps {
 /** Provides the values for the {@link SelectSingleProvider}. */
 export function SelectSingleProvider(
   props: SelectSingleProviderProps
-): JSX.Element {
+): ReactElement {
   if (!isDayPickerSingle(props.initialProps)) {
     const emptyContextValue: SelectSingleContextValue = {
       selected: undefined
@@ -58,7 +59,7 @@ export interface SelectSingleProviderInternal {
 export function SelectSingleProviderInternal({
   initialProps,
   children
-}: SelectSingleProviderInternal): JSX.Element {
+}: SelectSingleProviderInternal): ReactElement {
   const onDayClick: DayClickEventHandler = (day, activeModifiers, e) => {
     initialProps.onDayClick?.(day, activeModifiers, e);
 

--- a/src/hooks/useControlledValue/useControlledValue.test.ts
+++ b/src/hooks/useControlledValue/useControlledValue.test.ts
@@ -1,4 +1,4 @@
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 
 import { renderDayPickerHook } from 'test/render';
 

--- a/src/hooks/useDayEventHandlers/useDayEventHandlers.tsx
+++ b/src/hooks/useDayEventHandlers/useDayEventHandlers.tsx
@@ -1,4 +1,4 @@
-import {
+import type {
   FocusEventHandler,
   HTMLProps,
   KeyboardEventHandler,

--- a/src/hooks/useDayRender/useDayRender.tsx
+++ b/src/hooks/useDayRender/useDayRender.tsx
@@ -1,4 +1,5 @@
-import { RefObject, useEffect } from 'react';
+import { useEffect } from 'react';
+import type { RefObject } from 'react';
 
 import { isSameDay } from 'date-fns';
 

--- a/src/hooks/useDayRender/utils/getDayStyle.ts
+++ b/src/hooks/useDayRender/utils/getDayStyle.ts
@@ -1,4 +1,4 @@
-import { CSSProperties } from 'react';
+import type { CSSProperties } from 'react';
 
 import { DayPickerContextValue } from 'contexts/DayPicker';
 import { ActiveModifiers } from 'types/Modifiers';

--- a/src/hooks/useInput/useInput.ts
+++ b/src/hooks/useInput/useInput.ts
@@ -1,8 +1,8 @@
-import {
+import { useState } from 'react';
+import type {
   ChangeEventHandler,
   FocusEventHandler,
-  InputHTMLAttributes,
-  useState
+  InputHTMLAttributes
 } from 'react';
 
 import { differenceInCalendarDays, format as _format, parse } from 'date-fns';

--- a/src/types/DayPickerBase.ts
+++ b/src/types/DayPickerBase.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties, ReactElement, ReactNode } from 'react';
 
 import { Locale } from 'date-fns';
 
@@ -386,9 +386,9 @@ export interface DayPickerBase {
  */
 export interface CustomComponents {
   /** The component for the caption element. */
-  Caption?: (props: CaptionProps) => JSX.Element | null;
+  Caption?: (props: CaptionProps) => ReactElement | null;
   /** The component for the caption element. */
-  CaptionLabel?: (props: CaptionLabelProps) => JSX.Element | null;
+  CaptionLabel?: (props: CaptionLabelProps) => ReactElement | null;
   /**
    * The component for the day element.
    *
@@ -400,27 +400,27 @@ export interface CustomComponents {
    * - a `div` or a `span` element, when the day is not interactive
    *
    */
-  Day?: (props: DayProps) => JSX.Element | null;
+  Day?: (props: DayProps) => ReactElement | null;
   /** The component for the content of the day element. */
-  DayContent?: (props: DayContentProps) => JSX.Element | null;
+  DayContent?: (props: DayContentProps) => ReactElement | null;
   /** The component for the drop-down elements. */
-  Dropdown?: (props: DropdownProps) => JSX.Element | null;
+  Dropdown?: (props: DropdownProps) => ReactElement | null;
   /** The component for the table footer. */
-  Footer?: (props: FooterProps) => JSX.Element | null;
+  Footer?: (props: FooterProps) => ReactElement | null;
   /** The component for the table’s head. */
-  Head?: () => JSX.Element | null;
+  Head?: () => ReactElement | null;
   /** The component for the table’s head row. */
-  HeadRow?: () => JSX.Element | null;
+  HeadRow?: () => ReactElement | null;
   /** The component for the small icon in the drop-downs. */
-  IconDropdown?: (props: StyledComponent) => JSX.Element | null;
+  IconDropdown?: (props: StyledComponent) => ReactElement | null;
   /** The arrow right icon (used for the Navigation buttons). */
-  IconRight?: (props: StyledComponent) => JSX.Element | null;
+  IconRight?: (props: StyledComponent) => ReactElement | null;
   /** The arrow left icon (used for the Navigation buttons). */
-  IconLeft?: (props: StyledComponent) => JSX.Element | null;
+  IconLeft?: (props: StyledComponent) => ReactElement | null;
   /** The component wrapping the month grids. */
-  Months?: (props: MonthsProps) => JSX.Element | null;
+  Months?: (props: MonthsProps) => ReactElement | null;
   /** The component for the table rows. */
-  Row?: (props: RowProps) => JSX.Element | null;
+  Row?: (props: RowProps) => ReactElement | null;
   /** The component for the week number in the table rows. */
-  WeekNumber?: (props: WeekNumberProps) => JSX.Element | null;
+  WeekNumber?: (props: WeekNumberProps) => ReactElement | null;
 }

--- a/src/types/EventHandlers.ts
+++ b/src/types/EventHandlers.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   FocusEvent,
   KeyboardEvent,
   MouseEvent,

--- a/src/types/Formatters.ts
+++ b/src/types/Formatters.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import { Locale } from 'date-fns';
 

--- a/src/types/Modifiers.ts
+++ b/src/types/Modifiers.ts
@@ -1,4 +1,4 @@
-import { CSSProperties } from 'react';
+import type { CSSProperties } from 'react';
 
 import { Matcher } from './Matchers';
 

--- a/src/types/Styles.ts
+++ b/src/types/Styles.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 
 /** The style (either via class names or via in-line styles) of an element. */
 export type StyledElement<T = string | CSSProperties> = {

--- a/test/render/customRender.tsx
+++ b/test/render/customRender.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
 
 import { render } from '@testing-library/react';
 import { DayPickerProps } from 'DayPicker';

--- a/test/render/renderDayPickerHook.tsx
+++ b/test/render/renderDayPickerHook.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import { render } from '@testing-library/react';
 import { DayPickerProps } from 'DayPicker';
 
@@ -32,7 +34,7 @@ export function renderDayPickerHook<TResult>(
   }
 ): RenderHookResult<TResult> {
   const returnVal = { current: undefined as TResult };
-  function Test(): JSX.Element {
+  function Test(): ReactElement {
     const hookResult: TResult = hook();
     returnVal.current = hookResult;
     return <></>;


### PR DESCRIPTION
This v8 maintenance patch lets existing v8 consumers install DayPicker with React 19 while keeping the runtime API unchanged.

## What Changed

- Bumped `react-day-picker` to `8.10.2`.
- Expanded the React peer dependency to include `^19.0.0` while keeping the existing React 16.8, 17, and 18 support range.
- Replaced exported `JSX.*` declaration references with React types that remain valid across React 16.8 through React 19.
- Kept type-only React imports as `import type` in shipped `src/` files, so downstream source transpilation cannot preserve type-only React imports as runtime imports.
- Added v8 README and changelog notes for React 19 compatibility.
- Added a v8 Trusted Publishing release workflow that publishes with `npm publish --tag legacy-v8` and relies on npm Trusted Publishing for provenance.
- Added release-time packed smoke tests for React 19 runtime installs, React 19 TypeScript declarations, and React 18 TypeScript declarations with date-fns 2 and 3.
- Moved the release smoke fixtures into `.github/scripts/` so the workflow remains readable while keeping the same validation coverage.
- Added a release tag/package version guard before publish.
- Removed the old token-based publish job from the package workflow.
- Updated the one source test import that used `react-dom/test-utils` for `act`.

## Review Notes

Validation run locally on the v8 maintenance branch:

- `corepack pnpm@8.6.2 typecheck`
- `corepack pnpm@8.6.2 lint --max-warnings=0`
- `corepack pnpm@8.6.2 test`
- `corepack pnpm@8.6.2 build`
- Confirmed built declarations contain no `JSX.*` references
- Packed tarball comparison against `v8.10.1`: shipped JS and CSS runtime files have identical hashes; differences are limited to declarations, source maps/source text, docs, and package metadata
- Packed consumer runtime smoke test with `react@19`, `react-dom@19`, and `date-fns@3`
- Packed consumer runtime smoke test with `react@19`, `react-dom@19`, and `date-fns@2`
- Packed consumer TypeScript smoke test with `react@19`, `react-dom@19`, `@types/react@19`, `@types/react-dom@19`, `typescript@5`, `date-fns@3`, and `skipLibCheck: false`
- Packed consumer TypeScript smoke test with `react@16.14`, `react-dom@16.14`, `@types/react@16.14`, `@types/react-dom@16.9`, `typescript@4.9`, `date-fns@2`, and `skipLibCheck: false`
- Packed React 18 parity smoke against both `8.10.1` and `8.10.2`, with `date-fns@2` and `date-fns@3`; each case typechecked with `skipLibCheck: false` and rendered `<DayPicker />` in jsdom
- `npm publish --dry-run --tag legacy-v8`

After merge, publish by creating the `v8.10.2` GitHub Release from the merged maintenance commit. The npm publish should run from the release event, not from a manual workflow dispatch.
