### PR TITLE
docs: restore v8 website styles

### DIFF
--- a/apps/website/examples-v8/react-day-picker-v8.tsx
+++ b/apps/website/examples-v8/react-day-picker-v8.tsx
@@ -1,8 +1,8 @@
+import v8Style from "!raw-loader!react-day-picker-v8/dist/style.css";
 import {
   DayPicker as DayPickerV8,
   type DayPickerProps,
 } from "react-day-picker-v8";
-import styles from "react-day-picker-v8/dist/style.module.css";
 
 export {
   Button,
@@ -26,5 +26,10 @@ export {
 } from "react-day-picker-v8";
 
 export function DayPicker(props: DayPickerProps) {
-  return <DayPickerV8 {...props} classNames={styles} />;
+  return (
+    <>
+      <style>{v8Style.toString()}</style>
+      <DayPickerV8 {...props} />
+    </>
+  );
 }


### PR DESCRIPTION
The v8 docs examples were rendering inside the website Shadow DOM, but the v8 stylesheet was only emitted as page-level CSS. That left the v8 calendar markup without matching styles in the shadow root.

## What Changed

- Load `react-day-picker-v8/dist/style.css` through the v8 website wrapper so the default v8 `.rdp` styles are available inside the Shadow DOM.
- Stop forcing the v8 CSS module class map from the wrapper, allowing v8 defaults and example-provided `classNames` to merge normally.

## Review Notes

- Validated with `pnpm --filter website run typecheck`.
- Validated with `pnpm --filter website run build`.
- Confirmed the built website JS now includes the v8 `.rdp` stylesheet, so no npm republish is needed.