### PR TITLE
docs: fix v8 website style cascade

### DIFF
--- a/apps/website/examples-v8/react-day-picker-v8.tsx
+++ b/apps/website/examples-v8/react-day-picker-v8.tsx
@@ -1,4 +1,3 @@
-import v8Style from "!raw-loader!react-day-picker-v8/dist/style.css";
 import {
   DayPicker as DayPickerV8,
   type DayPickerProps,
@@ -26,10 +25,5 @@ export {
 } from "react-day-picker-v8";
 
 export function DayPicker(props: DayPickerProps) {
-  return (
-    <>
-      <style>{v8Style.toString()}</style>
-      <DayPickerV8 {...props} />
-    </>
-  );
+  return <DayPickerV8 {...props} />;
 }

--- a/apps/website/src/theme/MDXComponents.tsx
+++ b/apps/website/src/theme/MDXComponents.tsx
@@ -1,9 +1,10 @@
+import v8Style from "!raw-loader!react-day-picker-v8/dist/style.css";
 import { useDocsVersion } from "@docusaurus/plugin-content-docs/client";
 import MDXComponents from "@theme-original/MDXComponents";
 import type { ComponentProps, ComponentType } from "react";
 import * as ExamplesV8 from "../../examples-v8";
 import * as ExamplesV9 from "../../examples-v9";
-import { BrowserWindow } from "../components/BrowserWindow";
+import { BrowserWindow as BaseBrowserWindow } from "../components/BrowserWindow";
 import * as CurrentExamples from "../examples";
 
 type TableComponent = ComponentType<ComponentProps<"table">>;
@@ -62,6 +63,15 @@ function ResponsiveTable(props: ComponentProps<typeof Table>) {
       <Table {...props} />
     </div>
   );
+}
+
+function BrowserWindow(props: ComponentProps<typeof BaseBrowserWindow>) {
+  const version = useDocsVersion();
+  const baseStyleCss =
+    props.baseStyleCss ??
+    (version.version === "8.10.2" ? v8Style.toString() : undefined);
+
+  return <BaseBrowserWindow {...props} baseStyleCss={baseStyleCss} />;
 }
 
 export default {


### PR DESCRIPTION
The v8 docs calendar still had incorrect day sizing after the first style fix because the v8 stylesheet was injected before `ShadowDomWrapper` appended the current v10 stylesheet. Both versions share some `.rdp-*` selectors, so v10 rules could still override v8 day dimensions inside the Shadow DOM.

## What Changed

- Move the v8 stylesheet injection to the MDX `BrowserWindow` wrapper for docs version `8.10.2`.
- Pass the v8 stylesheet as `baseStyleCss` so `ShadowDomWrapper` uses it instead of the current/v10 default stylesheet on v8 pages.
- Simplify the v8 DayPicker example wrapper so it only renders the v8 component and does not inject another style tag.

## Review Notes

- Validated locally at `http://localhost:2001/v8`; the selected-day circle and cell spacing render correctly.
- Ran `pnpm lint apps/website/src/theme/MDXComponents.tsx`.
- Ran `pnpm --filter website run typecheck`.
- Ran `pnpm --filter website run build`.
- The build succeeds; Docusaurus still prints its non-fatal update-check config warning.