### PR TITLE
docs: update anatomy diagrams

### DIFF
--- a/apps/website/docs/docs/anatomy.mdx
+++ b/apps/website/docs/docs/anatomy.mdx
@@ -2,9 +2,6 @@
 sidebar_position: 1
 ---
 
-import anatomyDark from "../img/anatomy-dark.png";
-import anatomyLight from "../img/anatomy-light.png";
-
 # DayPicker Anatomy
 
 To better understand the documentation, familiarize yourself with the elements that compose DayPicker:
@@ -16,33 +13,71 @@ To better understand the documentation, familiarize yourself with the elements t
 - **Day**: Represents a day of the month, which can have different modifiers, such as:
   - **selected**: The day is selected.
   - **disabled**: The day is disabled.
+  - **hidden**: The day is hidden.
+  - **focused**: The day has focus.
   - **today**: The day is today.
   - **outside**: The day is outside the current month.
-- **Footer**: An ARIA live region used to announce the selected date.
+  - **range_start**: The day is the start of a selected range.
+  - **range_middle**: The day is inside a selected range.
+  - **range_end**: The day is the end of a selected range.
+- **Footer**: An ARIA live region that displays custom footer content, often used to announce selected dates.
 
-The UI elements are mapped to CSS classes. A complete list can be found in the [`UI`](../api/enumerations/UI.md) enum.
+The stylable UI elements are mapped to CSS classes. A complete list can be found in the [`UI`](../api/enumerations/UI.md) enum.
 
-<BrowserWindow shadow={false}>
-  <div style={{ overflow: "auto" }}>
-    <img
-      style={{
-        maxWidth: 600,
-        width: "100%",
-        margin: "2em auto",
-        display: "block",
-      }}
-      src={`${anatomyLight}#gh-light-mode-only`}
-      alt="Screenshot of DayPicker displaying the September 2025 calendar, with the date range from the 17th to the 20th selected."
-    />
-    <img
-      style={{
-        maxWidth: 600,
-        width: "100%",
-        margin: "2em auto",
-        display: "block",
-      }}
-      src={`${anatomyDark}#gh-dark-mode-only`}
-      alt="Screenshot of DayPicker displaying the September 2025 calendar, with the date range from the 17th to the 20th selected."
-    />
-  </div>
+<BrowserWindow
+  shadow={false}
+  bodyStyle={{ justifyContent: "flex-start", padding: 0 }}
+>
+  <AnatomyDiagram>
+    <Examples.Anatomy />
+  </AnatomyDiagram>
 </BrowserWindow>
+
+## Rendered Structure
+
+DayPicker renders the calendar with this component structure:
+
+```text
+Root
+├── Months
+│   ├── Nav
+│   │   ├── PreviousMonthButton
+│   │   │   └── Chevron
+│   │   └── NextMonthButton
+│   │       └── Chevron
+│   └── Month
+│       ├── MonthCaption
+│       │   ├── CaptionLabel
+│       │   └── DropdownNav
+│       │       ├── MonthsDropdown
+│       │       │   └── Dropdown
+│       │       │       └── DropdownRoot
+│       │       │           ├── Select
+│       │       │           │   └── Option
+│       │       │           └── CaptionLabel
+│       │       │               └── Chevron
+│       │       └── YearsDropdown
+│       │           └── Dropdown
+│       │               └── DropdownRoot
+│       │                   ├── Select
+│       │                   │   └── Option
+│       │                   └── CaptionLabel
+│       │                       └── Chevron
+│       └── MonthGrid
+│           ├── Weekdays
+│           │   ├── WeekNumberHeader
+│           │   └── Weekday
+│           └── Weeks
+│               └── Week
+│                   ├── WeekNumber
+│                   └── Day
+│                       └── DayButton
+└── Footer
+```
+
+Some components are conditional:
+
+- `Footer` renders only when the `footer` prop is set.
+- Week-number elements render only with `showWeekNumber`.
+- Dropdown elements render only with a dropdown `captionLayout`.
+- Navigation placement depends on `navLayout`: the hierarchy above shows the default placement; with `navLayout="around"`, navigation buttons render beside the month caption, and with `navLayout="after"`, the navigation bar renders after the caption in the last month.

--- a/apps/website/examples-v9/Anatomy.tsx
+++ b/apps/website/examples-v9/Anatomy.tsx
@@ -1,0 +1,29 @@
+// @ts-nocheck
+import React from "react";
+import { type DateRange, DayPicker } from "react-day-picker-v9";
+
+const selectedRange: DateRange = {
+  from: new Date(2024, 5, 17),
+  to: new Date(2024, 5, 20),
+};
+
+const selectedDay = new Date(2024, 5, 28);
+const month = new Date(2024, 5);
+const noop = () => undefined;
+
+export function Anatomy() {
+  return (
+    <DayPicker
+      mode="range"
+      month={month}
+      selected={selectedRange}
+      today={new Date(2024, 5, 6)}
+      disabled={new Date(2024, 5, 15)}
+      modifiers={{ selected: selectedDay }}
+      onSelect={noop}
+      showOutsideDays
+      showWeekNumber
+      footer="Please pick a date"
+    />
+  );
+}

--- a/apps/website/examples-v9/index.ts
+++ b/apps/website/examples-v9/index.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 export * from "./AccessibleDatePicker";
+export * from "./Anatomy";
 export * from "./Animate";
 export * from "./AnimateCSSVars";
 export * from "./AnimateRange";

--- a/apps/website/src/components/AnatomyDiagram.module.css
+++ b/apps/website/src/components/AnatomyDiagram.module.css
@@ -1,0 +1,155 @@
+.viewport {
+  margin: 0 0 var(--ifm-leading);
+  overflow-x: auto;
+  width: 100%;
+}
+
+.frame {
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+}
+
+.diagram {
+  color: #111927;
+  font-family: var(--ifm-font-family-base);
+  height: 590px;
+  margin: 0;
+  position: relative;
+  transform-origin: top left;
+  width: 780px;
+}
+
+:global([data-theme="dark"]) .diagram {
+  color: #f9fafb;
+}
+
+.calendar {
+  left: 260px;
+  position: absolute;
+  top: 125px;
+  z-index: 1;
+}
+
+.lines {
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+  transform: translateY(-60px);
+  z-index: 2;
+}
+
+.lines path {
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.15;
+  vector-effect: non-scaling-stroke;
+}
+
+.callout {
+  color: currentColor;
+  font-size: 14px;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.1;
+  position: absolute;
+  transform: translateY(-60px);
+  white-space: nowrap;
+  z-index: 3;
+}
+
+.leftCallout {
+  text-align: right;
+  width: 178px;
+}
+
+.centerCallout {
+  text-align: center;
+  transform: translate(-50%, -60px);
+}
+
+.monthCaption {
+  left: 300px;
+  top: 90px;
+}
+
+.navigationBar {
+  left: 540px;
+  top: 80px;
+}
+
+.navigationButtons {
+  left: 640px;
+  top: 104px;
+}
+
+.weekdaysRow {
+  left: 20px;
+  top: 240px;
+}
+
+.weekdays {
+  left: 426px;
+  top: 134px;
+}
+
+.weekNumberHeader {
+  left: 20px;
+  top: 192px;
+}
+
+.weekRows {
+  left: 20px;
+  top: 318px;
+}
+
+.weekNumbers {
+  left: 20px;
+  top: 466px;
+}
+
+.dayButton {
+  left: 648px;
+  top: 318px;
+}
+
+.today {
+  left: 648px;
+  top: 278px;
+}
+
+.disabledDay {
+  left: 648px;
+  top: 370px;
+}
+
+.rangeStart {
+  left: 370px;
+  top: 608px;
+}
+
+.rangeMiddle {
+  left: 440px;
+  top: 576px;
+}
+
+.rangeEnd {
+  left: 502px;
+  top: 608px;
+}
+
+.selectedDay {
+  left: 648px;
+  top: 478px;
+}
+
+.outsideDays {
+  left: 648px;
+  top: 592px;
+}
+
+.footer {
+  left: 6px;
+  top: 538px;
+}

--- a/apps/website/src/components/AnatomyDiagram.tsx
+++ b/apps/website/src/components/AnatomyDiagram.tsx
@@ -1,0 +1,159 @@
+import v9Style from "!raw-loader!react-day-picker-v9/src/style.css";
+import { useDocsVersion } from "@docusaurus/plugin-content-docs/client";
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import styles from "./AnatomyDiagram.module.css";
+import { ShadowDomWrapper } from "./ShadowDomWrapper";
+
+const diagramWidth = 780;
+const diagramHeight = 590;
+
+export function AnatomyDiagram({ children }: { children: ReactNode }) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+  const version = useDocsVersion();
+  const baseStyleCss =
+    version.version === "current" ? v9Style.toString() : undefined;
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+
+    const updateScale = () => {
+      setScale(Math.min(1, viewport.clientWidth / diagramWidth));
+    };
+
+    updateScale();
+
+    const resizeObserver = new ResizeObserver(updateScale);
+    resizeObserver.observe(viewport);
+
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  return (
+    <div className={styles.viewport} ref={viewportRef}>
+      <div
+        className={styles.frame}
+        style={{ height: `${diagramHeight * scale}px` }}
+      >
+        <figure
+          aria-label="Annotated DayPicker anatomy diagram"
+          className={styles.diagram}
+          data-anatomy-diagram
+          style={{ transform: `scale(${scale})` }}
+        >
+          <div className={styles.calendar}>
+            <ShadowDomWrapper baseStyleCss={baseStyleCss} styleStr={undefined}>
+              {children}
+            </ShadowDomWrapper>
+          </div>
+
+          <svg
+            aria-hidden
+            className={styles.lines}
+            fill="none"
+            viewBox="0 0 780 650"
+          >
+            <title>Annotation connector lines</title>
+            <path d="M 300 110 L 326 190" />
+            <path d="M 540 100 L 540 190" />
+            <path d="M 642 126 L 558 190" />
+            <path d="M 642 126 L 596 190" />
+            <path d="M 208 248 L 260 248" />
+            <path d="M 426 154 L 382 246" />
+            <path d="M 426 154 L 536 246" />
+            <path d="M 208 200 L 282 248" />
+            <path d="M 642 286 L 502 326" />
+            <path d="M 642 326 L 590 326" />
+            <path d="M 642 378 L 590 378" />
+            <path d="M 208 326 L 260 326" />
+            <path d="M 208 474 L 260 427" />
+            <path d="M 208 474 L 260 471" />
+            <path d="M 370 602 L 370 427" />
+            <path d="M 440 574 L 440 427" />
+            <path d="M 502 602 L 502 427" />
+            <path d="M 642 486 L 546 471" />
+            <path d="M 642 600 L 590 515" />
+            <path d="M 196 546 L 246 546" />
+          </svg>
+
+          <span
+            className={`${styles.callout} ${styles.centerCallout} ${styles.monthCaption}`}
+          >
+            Month Caption
+          </span>
+          <span
+            className={`${styles.callout} ${styles.centerCallout} ${styles.navigationBar}`}
+          >
+            Navigation Bar
+          </span>
+          <span
+            className={`${styles.callout} ${styles.centerCallout} ${styles.navigationButtons}`}
+          >
+            Navigation Buttons
+          </span>
+          <span
+            className={`${styles.callout} ${styles.leftCallout} ${styles.weekdaysRow}`}
+          >
+            Weekdays Row
+          </span>
+          <span
+            className={`${styles.callout} ${styles.centerCallout} ${styles.weekdays}`}
+          >
+            Weekdays
+          </span>
+          <span
+            className={`${styles.callout} ${styles.leftCallout} ${styles.weekNumberHeader}`}
+          >
+            Week Number Header
+          </span>
+          <span
+            className={`${styles.callout} ${styles.leftCallout} ${styles.weekRows}`}
+          >
+            Week Rows
+          </span>
+          <span
+            className={`${styles.callout} ${styles.leftCallout} ${styles.weekNumbers}`}
+          >
+            Week Numbers
+          </span>
+          <span className={`${styles.callout} ${styles.dayButton}`}>
+            Day / DayButton
+          </span>
+          <span className={`${styles.callout} ${styles.today}`}>
+            Today&apos;s Date
+          </span>
+          <span className={`${styles.callout} ${styles.disabledDay}`}>
+            Disabled Day
+          </span>
+          <span
+            className={`${styles.callout} ${styles.centerCallout} ${styles.rangeStart}`}
+          >
+            Range Start
+          </span>
+          <span
+            className={`${styles.callout} ${styles.centerCallout} ${styles.rangeMiddle}`}
+          >
+            Range Middle
+          </span>
+          <span
+            className={`${styles.callout} ${styles.centerCallout} ${styles.rangeEnd}`}
+          >
+            Range End
+          </span>
+          <span className={`${styles.callout} ${styles.selectedDay}`}>
+            Selected Day
+          </span>
+          <span className={`${styles.callout} ${styles.outsideDays}`}>
+            Outside Days
+          </span>
+          <span
+            className={`${styles.callout} ${styles.leftCallout} ${styles.footer}`}
+          >
+            Footer
+          </span>
+        </figure>
+      </div>
+    </div>
+  );
+}

--- a/apps/website/src/theme/MDXComponents.tsx
+++ b/apps/website/src/theme/MDXComponents.tsx
@@ -4,6 +4,7 @@ import MDXComponents from "@theme-original/MDXComponents";
 import type { ComponentProps, ComponentType } from "react";
 import * as ExamplesV8 from "../../examples-v8";
 import * as ExamplesV9 from "../../examples-v9";
+import { AnatomyDiagram } from "../components/AnatomyDiagram";
 import { BrowserWindow as BaseBrowserWindow } from "../components/BrowserWindow";
 import * as CurrentExamples from "../examples";
 
@@ -78,6 +79,7 @@ export default {
   ...MDXComponents,
   table: ResponsiveTable,
   BrowserWindow,
+  AnatomyDiagram,
   Examples,
   ExamplesV8,
 };

--- a/apps/website/versioned_docs/version-next/docs/anatomy.mdx
+++ b/apps/website/versioned_docs/version-next/docs/anatomy.mdx
@@ -2,9 +2,6 @@
 sidebar_position: 1
 ---
 
-import anatomyDark from "../img/anatomy-dark.png";
-import anatomyLight from "../img/anatomy-light.png";
-
 # DayPicker Anatomy
 
 To better understand the documentation, familiarize yourself with the elements that compose DayPicker:
@@ -16,33 +13,71 @@ To better understand the documentation, familiarize yourself with the elements t
 - **Day**: Represents a day of the month, which can have different modifiers, such as:
   - **selected**: The day is selected.
   - **disabled**: The day is disabled.
+  - **hidden**: The day is hidden.
+  - **focused**: The day has focus.
   - **today**: The day is today.
   - **outside**: The day is outside the current month.
-- **Footer**: An ARIA live region used to announce the selected date.
+  - **range_start**: The day is the start of a selected range.
+  - **range_middle**: The day is inside a selected range.
+  - **range_end**: The day is the end of a selected range.
+- **Footer**: An ARIA live region that displays custom footer content, often used to announce selected dates.
 
-The UI elements are mapped to CSS classes. A complete list can be found in the [`UI`](../api/react/enumerations/UI.md) enum.
+The stylable UI elements are mapped to CSS classes. A complete list can be found in the [`UI`](../api/react/enumerations/UI.md) enum.
 
-<BrowserWindow shadow={false}>
-  <div style={{ overflow: "auto" }}>
-    <img
-      style={{
-        maxWidth: 600,
-        width: "100%",
-        margin: "2em auto",
-        display: "block",
-      }}
-      src={`${anatomyLight}#gh-light-mode-only`}
-      alt="Screenshot of DayPicker displaying the September 2025 calendar, with the date range from the 17th to the 20th selected."
-    />
-    <img
-      style={{
-        maxWidth: 600,
-        width: "100%",
-        margin: "2em auto",
-        display: "block",
-      }}
-      src={`${anatomyDark}#gh-dark-mode-only`}
-      alt="Screenshot of DayPicker displaying the September 2025 calendar, with the date range from the 17th to the 20th selected."
-    />
-  </div>
+<BrowserWindow
+  shadow={false}
+  bodyStyle={{ justifyContent: "flex-start", padding: 0 }}
+>
+  <AnatomyDiagram>
+    <Examples.Anatomy />
+  </AnatomyDiagram>
 </BrowserWindow>
+
+## Rendered Structure
+
+DayPicker renders the calendar with this component structure:
+
+```text
+Root
+├── Months
+│   ├── Nav
+│   │   ├── PreviousMonthButton
+│   │   │   └── Chevron
+│   │   └── NextMonthButton
+│   │       └── Chevron
+│   └── Month
+│       ├── MonthCaption
+│       │   ├── CaptionLabel
+│       │   └── DropdownNav
+│       │       ├── MonthsDropdown
+│       │       │   └── Dropdown
+│       │       │       └── DropdownRoot
+│       │       │           ├── Select
+│       │       │           │   └── Option
+│       │       │           └── CaptionLabel
+│       │       │               └── Chevron
+│       │       └── YearsDropdown
+│       │           └── Dropdown
+│       │               └── DropdownRoot
+│       │                   ├── Select
+│       │                   │   └── Option
+│       │                   └── CaptionLabel
+│       │                       └── Chevron
+│       └── MonthGrid
+│           ├── Weekdays
+│           │   ├── WeekNumberHeader
+│           │   └── Weekday
+│           └── Weeks
+│               └── Week
+│                   ├── WeekNumber
+│                   └── Day
+│                       └── DayButton
+└── Footer
+```
+
+Some components are conditional:
+
+- `Footer` renders only when the `footer` prop is set.
+- Week-number elements render only with `showWeekNumber`.
+- Dropdown elements render only with a dropdown `captionLayout`.
+- Navigation placement depends on `navLayout`: the hierarchy above shows the default placement; with `navLayout="around"`, navigation buttons render beside the month caption, and with `navLayout="after"`, the navigation bar renders after the caption in the last month.

--- a/examples/Anatomy.tsx
+++ b/examples/Anatomy.tsx
@@ -1,0 +1,28 @@
+import { type DateRange, DayPicker } from "@daypicker/react";
+import React from "react";
+
+const selectedRange: DateRange = {
+  from: new Date(2024, 5, 17),
+  to: new Date(2024, 5, 20),
+};
+
+const selectedDay = new Date(2024, 5, 28);
+const month = new Date(2024, 5);
+const noop = () => undefined;
+
+export function Anatomy() {
+  return (
+    <DayPicker
+      mode="range"
+      month={month}
+      selected={selectedRange}
+      today={new Date(2024, 5, 6)}
+      disabled={new Date(2024, 5, 15)}
+      modifiers={{ selected: selectedDay }}
+      onSelect={noop}
+      showOutsideDays
+      showWeekNumber
+      footer="Please pick a date"
+    />
+  );
+}

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -1,4 +1,5 @@
 export * from "./AccessibleDatePicker";
+export * from "./Anatomy";
 export * from "./Animate";
 export * from "./AnimateCSSVars";
 export * from "./AnimateRange";


### PR DESCRIPTION
Updates the DayPicker anatomy docs so the page uses a rendered, annotated anatomy diagram instead of static screenshot assets.

## What Changed

- Replaced the static anatomy screenshots in v9 and v10 docs with a generated `AnatomyDiagram` component.
- Added a read-only anatomy example for v9 and v10 that shows week numbers, outside days, today, disabled day, selected day, range states, navigation, and footer.
- Added the rendered component hierarchy below the diagram on both anatomy pages.
- Registered the diagram component and example exports for MDX docs rendering.

## Review Notes

- The diagram isolates DayPicker default styles through the existing shadow DOM wrapper and keeps diagram CSS additive.
- The v9 docs use the v9 DayPicker stylesheet; v10/current docs use the current package stylesheet.
- The example keeps month and selection controlled with no-op handlers so the diagram remains stable when clicked.

## Validation

- `pnpm exec prettier --check apps/website/docs/docs/anatomy.mdx apps/website/versioned_docs/version-next/docs/anatomy.mdx apps/website/src/components/AnatomyDiagram.tsx apps/website/src/components/AnatomyDiagram.module.css`
- `pnpm --filter website typecheck`