### PR TITLE
fix: combine playground calendar imports

### DIFF
--- a/apps/website/src/components/Playground/index.tsx
+++ b/apps/website/src/components/Playground/index.tsx
@@ -83,30 +83,36 @@ export function Playground({ basePath = "/playground" }: PlaygroundProps) {
     localeEntries.find(([, localeValue]) => localeValue === props.locale);
   const localeName = localeEntry?.[0];
   const localeProp = localeName ? ` locale={${localeName}}` : "";
-  const localeImport =
-    localeName &&
-    (calendarLocale
-      ? `import { ${localeName} } from "@daypicker/${props.calendar}";`
-      : `import { ${localeName} } from "@daypicker/react/locale";`);
 
   const importStatements: string[] = [];
 
   if (props.calendar === "persian") {
-    importStatements.push(`import { DayPicker } from "@daypicker/persian";`);
+    importStatements.push(
+      `import { DayPicker${localeName ? `, ${localeName}` : ""} } from "@daypicker/persian";`,
+    );
   } else if (props.calendar === "ethiopic") {
-    importStatements.push(`import { DayPicker } from "@daypicker/ethiopic";`);
+    importStatements.push(
+      `import { DayPicker${localeName ? `, ${localeName}` : ""} } from "@daypicker/ethiopic";`,
+    );
   } else if (props.calendar === "buddhist") {
-    importStatements.push(`import { DayPicker } from "@daypicker/buddhist";`);
+    importStatements.push(
+      `import { DayPicker${localeName ? `, ${localeName}` : ""} } from "@daypicker/buddhist";`,
+    );
   } else if (props.calendar === "hebrew") {
-    importStatements.push(`import { DayPicker } from "@daypicker/hebrew";`);
+    importStatements.push(
+      `import { DayPicker${localeName ? `, ${localeName}` : ""} } from "@daypicker/hebrew";`,
+    );
   } else if (props.calendar === "hijri") {
-    importStatements.push(`import { DayPicker } from "@daypicker/hijri";`);
+    importStatements.push(
+      `import { DayPicker${localeName ? `, ${localeName}` : ""} } from "@daypicker/hijri";`,
+    );
   } else {
     importStatements.push(`import { DayPicker } from "@daypicker/react";`);
-  }
-
-  if (localeImport) {
-    importStatements.unshift(localeImport);
+    if (localeName) {
+      importStatements.unshift(
+        `import { ${localeName} } from "@daypicker/react/locale";`,
+      );
+    }
   }
 
   const formattedProps = `${importStatements.join("\n")}\n\n<DayPicker${toJSX({

--- a/apps/website/src/components/PlaygroundV9/index.tsx
+++ b/apps/website/src/components/PlaygroundV9/index.tsx
@@ -84,40 +84,36 @@ export function Playground({ basePath = "/playground" }: PlaygroundProps) {
     localeEntries.find(([, localeValue]) => localeValue === props.locale);
   const localeName = localeEntry?.[0];
   const localeProp = localeName ? ` locale={${localeName}}` : "";
-  const localeImport =
-    localeName &&
-    (calendarLocale
-      ? `import { ${localeName} } from "react-day-picker/${props.calendar}";`
-      : `import { ${localeName} } from "react-day-picker/locale";`);
 
   const importStatements: string[] = [];
 
   if (props.calendar === "persian") {
     importStatements.push(
-      `import { DayPicker } from "react-day-picker/persian";`,
+      `import { DayPicker${localeName ? `, ${localeName}` : ""} } from "react-day-picker/persian";`,
     );
   } else if (props.calendar === "ethiopic") {
     importStatements.push(
-      `import { DayPicker } from "react-day-picker/ethiopic";`,
+      `import { DayPicker${localeName ? `, ${localeName}` : ""} } from "react-day-picker/ethiopic";`,
     );
   } else if (props.calendar === "buddhist") {
     importStatements.push(
-      `import { DayPicker } from "react-day-picker/buddhist";`,
+      `import { DayPicker${localeName ? `, ${localeName}` : ""} } from "react-day-picker/buddhist";`,
     );
   } else if (props.calendar === "hebrew") {
     importStatements.push(
-      `import { DayPicker } from "react-day-picker/hebrew";`,
+      `import { DayPicker${localeName ? `, ${localeName}` : ""} } from "react-day-picker/hebrew";`,
     );
   } else if (props.calendar === "hijri") {
     importStatements.push(
-      `import { DayPicker } from "react-day-picker/hijri";`,
+      `import { DayPicker${localeName ? `, ${localeName}` : ""} } from "react-day-picker/hijri";`,
     );
   } else {
     importStatements.push(`import { DayPicker } from "react-day-picker";`);
-  }
-
-  if (localeImport) {
-    importStatements.unshift(localeImport);
+    if (localeName) {
+      importStatements.unshift(
+        `import { ${localeName} } from "react-day-picker/locale";`,
+      );
+    }
   }
 
   const formattedProps = `${importStatements.join("\n")}\n\n<DayPicker${toJSX({


### PR DESCRIPTION
Fixes duplicated calendar package imports in the v10 and v9 playground code output.

## What Changed
- Combine DayPicker and calendar locale imports for v10 calendar packages.
- Apply the same import formatting to the v9 playground.

## Review Notes
- Validated with `pnpm --filter website typecheck`.
- Validated with focused Biome checks for both playground entry points.