### PR TITLE
docs: add locale-specific fonts to demos

### DIFF
--- a/apps/website/docusaurus.config.ts
+++ b/apps/website/docusaurus.config.ts
@@ -40,6 +40,32 @@ const hebrewPath = nodeRequire.resolve("../../packages/hebrew/src/index.tsx");
 const hijriPath = nodeRequire.resolve("../../packages/hijri/src/index.tsx");
 const persianPath = nodeRequire.resolve("../../packages/persian/src/index.tsx");
 
+const googleFontFamilies = [
+  "Inter:wght@400;500;600;700",
+  "Vazirmatn:wght@400;500;600;700",
+  "Noto Sans:wght@400;500;600;700",
+  "Noto Sans Armenian:wght@400;500;600;700",
+  "Noto Sans Bengali:wght@400;500;600;700",
+  "Noto Sans Devanagari:wght@400;500;600;700",
+  "Noto Sans Ethiopic:wght@400;500;600;700",
+  "Noto Sans Georgian:wght@400;500;600;700",
+  "Noto Sans Gujarati:wght@400;500;600;700",
+  "Noto Sans Hebrew:wght@400;500;600;700",
+  "Noto Sans JP:wght@400;500;600;700",
+  "Noto Sans KR:wght@400;500;600;700",
+  "Noto Sans Kannada:wght@400;500;600;700",
+  "Noto Sans Khmer:wght@400;500;600;700",
+  "Noto Sans HK:wght@400;500;600;700",
+  "Noto Sans SC:wght@400;500;600;700",
+  "Noto Sans TC:wght@400;500;600;700",
+  "Noto Sans Tamil:wght@400;500;600;700",
+  "Noto Sans Telugu:wght@400;500;600;700",
+  "Noto Sans Thai:wght@400;500;600;700",
+];
+const googleFontsStylesheet = `https://fonts.googleapis.com/css2?${googleFontFamilies
+  .map((family) => `family=${family.replace(/ /g, "+")}`)
+  .join("&")}&display=swap`;
+
 function createApiReferenceRedirects(path: string): string[] {
   if (path.startsWith("/api/react/")) {
     return [path.replace("/api/react/", "/api/")];
@@ -114,6 +140,7 @@ const config: Config = {
           customCss: [
             "../../packages/react-day-picker/src/style.css",
             "./src/css/site.css",
+            "./src/css/daypicker-locale-fonts.css",
           ],
         },
         sitemap: {
@@ -133,9 +160,7 @@ const config: Config = {
   ],
 
   // Modern font
-  stylesheets: [
-    "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap",
-  ],
+  stylesheets: [googleFontsStylesheet],
 
   plugins: [
     function currentExamplesAliasPlugin() {

--- a/apps/website/src/components/ShadowDomWrapper.tsx
+++ b/apps/website/src/components/ShadowDomWrapper.tsx
@@ -1,4 +1,5 @@
 import style from "!raw-loader!@daypicker/react/src/style.css";
+import localeFontStyle from "!raw-loader!../css/daypicker-locale-fonts.css";
 import { useColorMode } from "@docusaurus/theme-common";
 import root from "react-shadow";
 
@@ -16,6 +17,7 @@ export function ShadowDomWrapper({
     <root.div>
       {children}
       <style>{baseStyleCss ?? style.toString()}</style>
+      <style>{localeFontStyle.toString()}</style>
       <style>{`
         .rdp-root {
           --rdp-accent-color: var(--ifm-color-primary);

--- a/apps/website/src/css/daypicker-locale-fonts.css
+++ b/apps/website/src/css/daypicker-locale-fonts.css
@@ -1,0 +1,98 @@
+.rdp-root {
+  --rdp-locale-font-fallback: var(
+    --ifm-font-family-base,
+    ui-sans-serif,
+    system-ui,
+    sans-serif
+  );
+}
+
+.rdp-root:lang(ar),
+.rdp-root:lang(fa),
+.rdp-root:lang(ckb),
+.rdp-root:lang(ug) {
+  font-family: "Vazirmatn", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(he) {
+  font-family: "Noto Sans Hebrew", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(am) {
+  font-family: "Noto Sans Ethiopic", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(th) {
+  font-family: "Noto Sans Thai", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(hy) {
+  font-family: "Noto Sans Armenian", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(ka) {
+  font-family: "Noto Sans Georgian", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(bn) {
+  font-family: "Noto Sans Bengali", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(hi) {
+  font-family: "Noto Sans Devanagari", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(gu) {
+  font-family: "Noto Sans Gujarati", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(kn) {
+  font-family: "Noto Sans Kannada", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(km) {
+  font-family: "Noto Sans Khmer", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(ta) {
+  font-family: "Noto Sans Tamil", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(te) {
+  font-family: "Noto Sans Telugu", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(ja) {
+  font-family: "Noto Sans JP", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(ko) {
+  font-family: "Noto Sans KR", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(zh-CN),
+.rdp-root:lang(zh-Hans) {
+  font-family: "Noto Sans SC", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(zh-HK) {
+  font-family: "Noto Sans HK", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(zh-TW),
+.rdp-root:lang(zh-Hant) {
+  font-family: "Noto Sans TC", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(be),
+.rdp-root:lang(bg),
+.rdp-root:lang(el),
+.rdp-root:lang(kk),
+.rdp-root:lang(mk),
+.rdp-root:lang(mn),
+.rdp-root:lang(ru),
+.rdp-root:lang(sr),
+.rdp-root:lang(uk),
+.rdp-root:lang(uz-Cyrl) {
+  font-family: "Noto Sans", var(--rdp-locale-font-fallback);
+}


### PR DESCRIPTION
Closes #2896

This improves the docs demos for calendars rendered with non-Latin locales by applying script-specific Google font families from the DayPicker root `lang` attribute.

## What Changed

- Added website-only `:lang(...)` font rules for DayPicker demos, using Vazirmatn for Arabic-script locales and Noto Sans families for other non-Latin scripts.
- Loaded the required Google Fonts from the Docusaurus config.
- Injected the same locale font rules into shadow DOM examples and playground previews.

## Review Notes

- This does not change the package CSS, package exports, generated dist files, locale docs, or DayPicker runtime behavior.
- Validation: `pnpm --filter website typecheck`, `pnpm --filter website build`, `pnpm lint`.
