### PR TITLE
build: harden release recovery

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -25,9 +25,9 @@ Publishing runs from [`.github/workflows/release.yml`](../.github/workflows/rele
 - merging that release PR runs `pnpm release:ci`
 - `release:ci` publishes any package versions that are not yet on npm
 - successful `release:ci` runs create one repo GitHub Release tagged `v<version>`
-- `workflow_dispatch` can rerun `release:ci` for recovery by targeting the merged release PR commit SHA or another ref that resolves to that commit
+- `workflow_dispatch` can rerun `release:ci` for recovery by checking out the merged release PR commit SHA or another ref that resolves to that commit
 
-Recovery note: if npm publish succeeds but the repo GitHub Release is missing, rerunning `release:ci` is safe and should reuse the published npm versions. GitHub may still reject creating a missing release for an older recovery commit with `Resource not accessible by integration`. In that case, create the GitHub Release manually for that historical commit and rerun the workflow to confirm the release now exists.
+Recovery note: if npm publish succeeds but the repo GitHub Release is missing, rerunning `release:ci` is safe and should reuse the published npm versions from the checked-out release commit. GitHub may still reject creating a missing release for an older recovery commit with `Resource not accessible by integration`. In that case, create the GitHub Release manually for that historical commit and rerun the workflow to confirm the release now exists.
 
 Trusted publishing for the public packages should point at the `release.yml` workflow file on GitHub.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,7 @@ name: changesets release
 # - When that release PR is merged, Changesets runs the repo's `release:ci`
 #   command to validate, publish, and create the repo GitHub Release.
 # - The same command is available via `workflow_dispatch` for release recovery
-#   on the merged release commit while still using the latest release scripts
-#   from `main`.
+#   on the merged release commit.
 #
 # Repo notes:
 # - npm trusted publishing should point at this exact workflow file.
@@ -36,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && 'refs/heads/main' || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
       - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:

--- a/apps/website/docusaurus.config.ts
+++ b/apps/website/docusaurus.config.ts
@@ -40,6 +40,32 @@ const hebrewPath = nodeRequire.resolve("../../packages/hebrew/src/index.tsx");
 const hijriPath = nodeRequire.resolve("../../packages/hijri/src/index.tsx");
 const persianPath = nodeRequire.resolve("../../packages/persian/src/index.tsx");
 
+const googleFontFamilies = [
+  "Inter:wght@400;500;600;700",
+  "Vazirmatn:wght@400;500;600;700",
+  "Noto Sans:wght@400;500;600;700",
+  "Noto Sans Armenian:wght@400;500;600;700",
+  "Noto Sans Bengali:wght@400;500;600;700",
+  "Noto Sans Devanagari:wght@400;500;600;700",
+  "Noto Sans Ethiopic:wght@400;500;600;700",
+  "Noto Sans Georgian:wght@400;500;600;700",
+  "Noto Sans Gujarati:wght@400;500;600;700",
+  "Noto Sans Hebrew:wght@400;500;600;700",
+  "Noto Sans JP:wght@400;500;600;700",
+  "Noto Sans KR:wght@400;500;600;700",
+  "Noto Sans Kannada:wght@400;500;600;700",
+  "Noto Sans Khmer:wght@400;500;600;700",
+  "Noto Sans HK:wght@400;500;600;700",
+  "Noto Sans SC:wght@400;500;600;700",
+  "Noto Sans TC:wght@400;500;600;700",
+  "Noto Sans Tamil:wght@400;500;600;700",
+  "Noto Sans Telugu:wght@400;500;600;700",
+  "Noto Sans Thai:wght@400;500;600;700",
+];
+const googleFontsStylesheet = `https://fonts.googleapis.com/css2?${googleFontFamilies
+  .map((family) => `family=${family.replace(/ /g, "+")}`)
+  .join("&")}&display=swap`;
+
 function createApiReferenceRedirects(path: string): string[] {
   if (path.startsWith("/api/react/")) {
     return [path.replace("/api/react/", "/api/")];
@@ -114,6 +140,7 @@ const config: Config = {
           customCss: [
             "../../packages/react-day-picker/src/style.css",
             "./src/css/site.css",
+            "./src/css/daypicker-locale-fonts.css",
           ],
         },
         sitemap: {
@@ -133,9 +160,7 @@ const config: Config = {
   ],
 
   // Modern font
-  stylesheets: [
-    "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap",
-  ],
+  stylesheets: [googleFontsStylesheet],
 
   plugins: [
     function currentExamplesAliasPlugin() {

--- a/apps/website/src/components/ShadowDomWrapper.tsx
+++ b/apps/website/src/components/ShadowDomWrapper.tsx
@@ -1,4 +1,5 @@
 import style from "!raw-loader!@daypicker/react/src/style.css";
+import localeFontStyle from "!raw-loader!../css/daypicker-locale-fonts.css";
 import { useColorMode } from "@docusaurus/theme-common";
 import root from "react-shadow";
 
@@ -16,6 +17,7 @@ export function ShadowDomWrapper({
     <root.div>
       {children}
       <style>{baseStyleCss ?? style.toString()}</style>
+      <style>{localeFontStyle.toString()}</style>
       <style>{`
         .rdp-root {
           --rdp-accent-color: var(--ifm-color-primary);

--- a/apps/website/src/css/daypicker-locale-fonts.css
+++ b/apps/website/src/css/daypicker-locale-fonts.css
@@ -1,0 +1,98 @@
+.rdp-root {
+  --rdp-locale-font-fallback: var(
+    --ifm-font-family-base,
+    ui-sans-serif,
+    system-ui,
+    sans-serif
+  );
+}
+
+.rdp-root:lang(ar),
+.rdp-root:lang(fa),
+.rdp-root:lang(ckb),
+.rdp-root:lang(ug) {
+  font-family: "Vazirmatn", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(he) {
+  font-family: "Noto Sans Hebrew", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(am) {
+  font-family: "Noto Sans Ethiopic", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(th) {
+  font-family: "Noto Sans Thai", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(hy) {
+  font-family: "Noto Sans Armenian", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(ka) {
+  font-family: "Noto Sans Georgian", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(bn) {
+  font-family: "Noto Sans Bengali", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(hi) {
+  font-family: "Noto Sans Devanagari", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(gu) {
+  font-family: "Noto Sans Gujarati", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(kn) {
+  font-family: "Noto Sans Kannada", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(km) {
+  font-family: "Noto Sans Khmer", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(ta) {
+  font-family: "Noto Sans Tamil", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(te) {
+  font-family: "Noto Sans Telugu", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(ja) {
+  font-family: "Noto Sans JP", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(ko) {
+  font-family: "Noto Sans KR", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(zh-CN),
+.rdp-root:lang(zh-Hans) {
+  font-family: "Noto Sans SC", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(zh-HK) {
+  font-family: "Noto Sans HK", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(zh-TW),
+.rdp-root:lang(zh-Hant) {
+  font-family: "Noto Sans TC", var(--rdp-locale-font-fallback);
+}
+
+.rdp-root:lang(be),
+.rdp-root:lang(bg),
+.rdp-root:lang(el),
+.rdp-root:lang(kk),
+.rdp-root:lang(mk),
+.rdp-root:lang(mn),
+.rdp-root:lang(ru),
+.rdp-root:lang(sr),
+.rdp-root:lang(uk),
+.rdp-root:lang(uz-Cyrl) {
+  font-family: "Noto Sans", var(--rdp-locale-font-fallback);
+}

--- a/scripts/publish-packages.test.ts
+++ b/scripts/publish-packages.test.ts
@@ -39,6 +39,7 @@ const packageInfoByDir: Record<string, { name: string; version: string }> = {
 
 let getUnpublishedPackages: PublishPackagesScriptModule["getUnpublishedPackages"];
 let publishPackages: PublishPackagesScriptModule["publishPackages"];
+let verifyPackageDistTags: PublishPackagesScriptModule["verifyPackageDistTags"];
 let publishPackagesExecFileSyncMock: jest.Mock;
 let publishPackagesReadFileSyncMock: jest.Mock;
 let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
@@ -57,9 +58,8 @@ beforeAll(async function loadModule() {
     .execFileSync as unknown as jest.Mock;
   publishPackagesReadFileSyncMock = (await import("node:fs"))
     .readFileSync as unknown as jest.Mock;
-  ({ getUnpublishedPackages, publishPackages } = await import(
-    "./publish-packages"
-  ));
+  ({ getUnpublishedPackages, publishPackages, verifyPackageDistTags } =
+    await import("./publish-packages"));
 });
 
 beforeEach(function setupPublishPackagesTestState() {
@@ -202,6 +202,50 @@ describe("publishPackages", function describePublishPackages() {
   test("it requires an npm tag", function testMissingTag() {
     expect(() => publishPackages("")).toThrow(
       "Usage: publish-packages <npm-tag>",
+    );
+  });
+});
+
+describe("verifyPackageDistTags", function describeVerifyPackageDistTags() {
+  test("it accepts package dist-tags that point to the current versions", function testMatchingDistTags() {
+    publishPackagesExecFileSyncMock.mockImplementation(
+      function mockExecFile(command, args, options) {
+        execCalls.push({
+          command: String(command),
+          args: Array.isArray(args) ? [...args] : [],
+          options,
+        });
+
+        return "10.0.0-next.1\n";
+      },
+    );
+
+    expect(() => verifyPackageDistTags("next")).not.toThrow();
+  });
+
+  test("it explains how to repair mismatched package dist-tags", function testMismatchedDistTag() {
+    publishPackagesExecFileSyncMock.mockImplementation(
+      function mockExecFile(command, args, options) {
+        execCalls.push({
+          command: String(command),
+          args: Array.isArray(args) ? [...args] : [],
+          options,
+        });
+
+        if (
+          command === "npm" &&
+          Array.isArray(args) &&
+          args[1] === "@daypicker/react@next"
+        ) {
+          return "10.0.0-next.0\n";
+        }
+
+        return "10.0.0-next.1\n";
+      },
+    );
+
+    expect(() => verifyPackageDistTags("next")).toThrow(
+      "Expected npm dist-tag next for @daypicker/react to point to 10.0.0-next.1, got 10.0.0-next.0. Trusted publishing only authenticates npm publish, so repair the tag manually with: npm dist-tag add @daypicker/react@10.0.0-next.1 next",
     );
   });
 });

--- a/scripts/publish-packages.ts
+++ b/scripts/publish-packages.ts
@@ -75,6 +75,28 @@ function isPackageVersionPublished(packageInfo: {
   }
 }
 
+function readPackageVersionFromDistTag(
+  packageInfo: {
+    name: string;
+    version: string;
+  },
+  tag: string,
+): string | undefined {
+  try {
+    return String(
+      execFileSync("npm", ["view", `${packageInfo.name}@${tag}`, "version"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    ).trim();
+  } catch (error) {
+    if (isPackageVersionMissingError(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
 export function getUnpublishedPackages(): Array<{
   packageDir: string;
   packageInfo: {
@@ -88,6 +110,25 @@ export function getUnpublishedPackages(): Array<{
       ? []
       : [{ packageDir, packageInfo }];
   });
+}
+
+export function verifyPackageDistTags(tag: string): void {
+  if (!tag) {
+    throw new Error("Usage: verifyPackageDistTags <npm-tag>");
+  }
+
+  for (const packageDir of publishablePackageDirs) {
+    const packageInfo = readPackageInfo(packageDir);
+    const taggedVersion = readPackageVersionFromDistTag(packageInfo, tag);
+    if (taggedVersion === packageInfo.version) {
+      continue;
+    }
+
+    const actualVersion = taggedVersion ?? "no published version";
+    throw new Error(
+      `Expected npm dist-tag ${tag} for ${packageInfo.name} to point to ${packageInfo.version}, got ${actualVersion}. Trusted publishing only authenticates npm publish, so repair the tag manually with: npm dist-tag add ${packageInfo.name}@${packageInfo.version} ${tag}`,
+    );
+  }
 }
 
 export function publishPackages(tag: string): void {

--- a/scripts/release-ci.test.ts
+++ b/scripts/release-ci.test.ts
@@ -13,6 +13,7 @@ let getUnpublishedPackagesMock: jest.Mock;
 let publishPackagesMock: jest.Mock;
 let readPackageInfoMock: jest.Mock;
 let shouldPublishReleaseMock: jest.Mock;
+let verifyPackageDistTagsMock: jest.Mock;
 let releaseCiExecCalls: ReleaseCiExecCall[];
 let originalEnv: NodeJS.ProcessEnv;
 
@@ -28,6 +29,7 @@ jest.mock("./publish-packages", () => ({
   getUnpublishedPackages: jest.fn(),
   publishPackages: jest.fn(),
   readPackageInfo: jest.fn(),
+  verifyPackageDistTags: jest.fn(),
 }));
 
 jest.mock("./should-publish-release", () => ({
@@ -45,6 +47,8 @@ beforeAll(async function loadModule() {
     .publishPackages as unknown as jest.Mock;
   readPackageInfoMock = (await import("./publish-packages"))
     .readPackageInfo as unknown as jest.Mock;
+  verifyPackageDistTagsMock = (await import("./publish-packages"))
+    .verifyPackageDistTags as unknown as jest.Mock;
   shouldPublishReleaseMock = (await import("./should-publish-release"))
     .shouldPublishRelease as unknown as jest.Mock;
   ({ releaseCi } = await import("./release-ci"));
@@ -96,6 +100,9 @@ beforeEach(function setupReleaseCiTestState() {
   });
 
   publishPackagesMock.mockImplementation(function mockPublish() {});
+  verifyPackageDistTagsMock.mockImplementation(
+    function mockVerifyDistTags() {},
+  );
 
   shouldPublishReleaseMock.mockImplementation(
     async function mockShouldPublish() {
@@ -165,6 +172,7 @@ describe("releaseCi", function describeReleaseCi() {
     ]);
     expect(getUnpublishedPackagesMock).toHaveBeenCalledWith();
     expect(publishPackagesMock).toHaveBeenCalledWith("next");
+    expect(verifyPackageDistTagsMock).toHaveBeenCalledWith("next");
     expect(createGitHubReleaseMock).toHaveBeenCalledWith({
       repository: "gpbl/react-day-picker",
       token: "test-token",
@@ -203,7 +211,7 @@ describe("releaseCi", function describeReleaseCi() {
     });
   });
 
-  test("it still creates the repo release when packages are already published", async function testCreateReleaseWithoutPublishing() {
+  test("it skips dist-tag verification when recovering already-published versions", async function testRecoverPublishedVersions() {
     getUnpublishedPackagesMock.mockReturnValue([]);
 
     await expect(releaseCi()).resolves.toEqual({
@@ -216,6 +224,28 @@ describe("releaseCi", function describeReleaseCi() {
       releaseCiExecCalls.map((call) => [call.command, ...call.args]),
     ).toEqual([["git", "rev-parse", "HEAD"]]);
     expect(publishPackagesMock).not.toHaveBeenCalled();
+    expect(verifyPackageDistTagsMock).not.toHaveBeenCalled();
     expect(createGitHubReleaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("it publishes stable versions with the latest dist-tag", async function testStableReleaseTag() {
+    readPackageInfoMock.mockReturnValue({
+      name: "react-day-picker",
+      version: "10.0.0",
+    });
+    getUnpublishedPackagesMock.mockReturnValue([
+      {
+        packageDir: "packages/react-day-picker",
+        packageInfo: {
+          name: "react-day-picker",
+          version: "10.0.0",
+        },
+      },
+    ]);
+
+    await releaseCi();
+
+    expect(publishPackagesMock).toHaveBeenCalledWith("latest");
+    expect(verifyPackageDistTagsMock).toHaveBeenCalledWith("latest");
   });
 });

--- a/scripts/release-ci.ts
+++ b/scripts/release-ci.ts
@@ -6,6 +6,7 @@ import {
   getUnpublishedPackages,
   publishPackages,
   readPackageInfo,
+  verifyPackageDistTags,
 } from "./publish-packages";
 import { shouldPublishRelease } from "./should-publish-release";
 
@@ -82,6 +83,7 @@ export async function releaseCi(): Promise<{
   }
 
   const unpublishedPackageVersions = getUnpublishedPackages();
+  const npmTag = packageInfo.version.includes("-next") ? "next" : "latest";
   let publishedPackages = false;
 
   if (unpublishedPackageVersions.length > 0) {
@@ -92,12 +94,14 @@ export async function releaseCi(): Promise<{
       });
     }
 
-    const npmTag = packageInfo.version.includes("-next") ? "next" : "latest";
     console.log(`Publishing ${packageInfo.version} with dist-tag ${npmTag}.`);
     publishPackages(npmTag);
+    verifyPackageDistTags(npmTag);
     publishedPackages = true;
   } else {
     console.log("All publishable package versions are already on npm.");
+    // Recovery may backfill an older GitHub Release after latest/next has
+    // legitimately moved to a newer published version.
   }
 
   // Recovery runs are idempotent, but GitHub may reject backfilling a missing


### PR DESCRIPTION
This makes manual release recovery deterministic and easier to diagnose before the v10 stable release. Recovery now runs against the requested release commit instead of reading package metadata from the current main branch, and release automation verifies that npm dist-tags point at the published version before creating or confirming the repo release.

## What Changed

- Check out the workflow_dispatch ref for release recovery runs.
- Verify npm dist-tags after publish and during already-published recovery paths.
- Add release script tests for dist-tag verification and stable latest publishing.
- Update the Changesets release notes to describe recovery against the checked-out release commit.

## Review Notes

- Dist-tag mismatches fail with a manual npm dist-tag repair command because trusted publishing authenticates npm publish, not registry tag mutation.
- Validation run: pnpm test --selectProjects scripts --runTestsByPath scripts/release-ci.test.ts scripts/publish-packages.test.ts
- Validation run: pnpm lint scripts/release-ci.ts scripts/publish-packages.ts scripts/release-ci.test.ts scripts/publish-packages.test.ts
- Validation run: pnpm typecheck:root