### PR TITLE
build: exit prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "next",
   "initialVersions": {
     "examples-app": "0.0.0",


### PR DESCRIPTION
Prepare the v10 stable release by exiting Changesets prerelease mode.

After this lands on main, the Changesets action should create the stable `changeset-release/main` PR with the `10.0.0` version and changelog updates.