### PR TITLE
docs: fill type alias API descriptions

### DIFF
--- a/apps/website/versioned_docs/version-next/api/buddhist/functions/DayPicker.md
+++ b/apps/website/versioned_docs/version-next/api/buddhist/functions/DayPicker.md
@@ -2,7 +2,7 @@
 
 > **DayPicker**(`props`): `Element`
 
-Defined in: [packages/buddhist/src/buddhist/index.tsx:38](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/buddhist/src/buddhist/index.tsx#L38)
+Defined in: [packages/buddhist/src/buddhist/index.tsx:38](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/buddhist/src/buddhist/index.tsx#L38)
 
 Render the Buddhist (Thai) calendar.
 

--- a/apps/website/versioned_docs/version-next/api/buddhist/functions/getDateLib.md
+++ b/apps/website/versioned_docs/version-next/api/buddhist/functions/getDateLib.md
@@ -2,7 +2,7 @@
 
 > **getDateLib**(`options?`): `DateLib`
 
-Defined in: [packages/buddhist/src/buddhist/index.tsx:69](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/buddhist/src/buddhist/index.tsx#L69)
+Defined in: [packages/buddhist/src/buddhist/index.tsx:69](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/buddhist/src/buddhist/index.tsx#L69)
 
 Returns the date library used in the Buddhist calendar.
 

--- a/apps/website/versioned_docs/version-next/api/buddhist/index.md
+++ b/apps/website/versioned_docs/version-next/api/buddhist/index.md
@@ -1,4 +1,4 @@
-# `@daypicker/buddhist` v10.0.0-next.5
+# `@daypicker/buddhist` v10.0.0-next.6
 
 ## Functions
 

--- a/apps/website/versioned_docs/version-next/api/buddhist/variables/enUS.md
+++ b/apps/website/versioned_docs/version-next/api/buddhist/variables/enUS.md
@@ -2,4 +2,4 @@
 
 > `const` **enUS**: *typeof* `enUSLocale` = `enUSLocale`
 
-Defined in: [packages/buddhist/src/buddhist/index.tsx:24](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/buddhist/src/buddhist/index.tsx#L24)
+Defined in: [packages/buddhist/src/buddhist/index.tsx:24](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/buddhist/src/buddhist/index.tsx#L24)

--- a/apps/website/versioned_docs/version-next/api/buddhist/variables/th.md
+++ b/apps/website/versioned_docs/version-next/api/buddhist/variables/th.md
@@ -2,4 +2,4 @@
 
 > `const` **th**: *typeof* `thLocale` = `thLocale`
 
-Defined in: [packages/buddhist/src/buddhist/index.tsx:23](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/buddhist/src/buddhist/index.tsx#L23)
+Defined in: [packages/buddhist/src/buddhist/index.tsx:23](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/buddhist/src/buddhist/index.tsx#L23)

--- a/apps/website/versioned_docs/version-next/api/ethiopic/functions/DayPicker.md
+++ b/apps/website/versioned_docs/version-next/api/ethiopic/functions/DayPicker.md
@@ -2,7 +2,7 @@
 
 > **DayPicker**(`props`): `Element`
 
-Defined in: [packages/ethiopic/src/ethiopic/index.tsx:30](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/ethiopic/src/ethiopic/index.tsx#L30)
+Defined in: [packages/ethiopic/src/ethiopic/index.tsx:30](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/ethiopic/src/ethiopic/index.tsx#L30)
 
 Render the Ethiopic calendar.
 

--- a/apps/website/versioned_docs/version-next/api/ethiopic/functions/getDateLib.md
+++ b/apps/website/versioned_docs/version-next/api/ethiopic/functions/getDateLib.md
@@ -2,7 +2,7 @@
 
 > **getDateLib**(`options?`): `DateLib`
 
-Defined in: [packages/ethiopic/src/ethiopic/index.tsx:63](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/ethiopic/src/ethiopic/index.tsx#L63)
+Defined in: [packages/ethiopic/src/ethiopic/index.tsx:63](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/ethiopic/src/ethiopic/index.tsx#L63)
 
 Returns the date library used in the calendar.
 

--- a/apps/website/versioned_docs/version-next/api/ethiopic/index.md
+++ b/apps/website/versioned_docs/version-next/api/ethiopic/index.md
@@ -1,4 +1,4 @@
-# `@daypicker/ethiopic` v10.0.0-next.5
+# `@daypicker/ethiopic` v10.0.0-next.6
 
 ## Functions
 

--- a/apps/website/versioned_docs/version-next/api/ethiopic/variables/amET.md
+++ b/apps/website/versioned_docs/version-next/api/ethiopic/variables/amET.md
@@ -2,7 +2,7 @@
 
 > `const` **amET**: `DayPickerLocale`
 
-Defined in: [packages/ethiopic/src/locale/am-ET.ts:104](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/ethiopic/src/locale/am-ET.ts#L104)
+Defined in: [packages/ethiopic/src/locale/am-ET.ts:104](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/ethiopic/src/locale/am-ET.ts#L104)
 
 Amharic (Ethiopia) locale backed by Intl for core names plus DayPicker
 labels.

--- a/apps/website/versioned_docs/version-next/api/ethiopic/variables/enUS.md
+++ b/apps/website/versioned_docs/version-next/api/ethiopic/variables/enUS.md
@@ -2,6 +2,6 @@
 
 > `const` **enUS**: `DayPickerLocale`
 
-Defined in: [packages/react-day-picker/src/locale/en-US.ts:12](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/locale/en-US.ts#L12)
+Defined in: [packages/react-day-picker/src/locale/en-US.ts:12](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/locale/en-US.ts#L12)
 
 English (United States) locale extended with DayPicker-specific translations.

--- a/apps/website/versioned_docs/version-next/api/hebrew/functions/DayPicker.md
+++ b/apps/website/versioned_docs/version-next/api/hebrew/functions/DayPicker.md
@@ -2,7 +2,7 @@
 
 > **DayPicker**(`props`): `Element`
 
-Defined in: [packages/hebrew/src/hebrew/index.tsx:24](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/hebrew/src/hebrew/index.tsx#L24)
+Defined in: [packages/hebrew/src/hebrew/index.tsx:24](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/hebrew/src/hebrew/index.tsx#L24)
 
 Render the Hebrew (lunisolar) calendar.
 

--- a/apps/website/versioned_docs/version-next/api/hebrew/functions/getDateLib.md
+++ b/apps/website/versioned_docs/version-next/api/hebrew/functions/getDateLib.md
@@ -2,7 +2,7 @@
 
 > **getDateLib**(`options?`): `DateLib`
 
-Defined in: [packages/hebrew/src/hebrew/index.tsx:55](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/hebrew/src/hebrew/index.tsx#L55)
+Defined in: [packages/hebrew/src/hebrew/index.tsx:55](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/hebrew/src/hebrew/index.tsx#L55)
 
 Returns the date library used in the Hebrew calendar.
 

--- a/apps/website/versioned_docs/version-next/api/hebrew/index.md
+++ b/apps/website/versioned_docs/version-next/api/hebrew/index.md
@@ -1,4 +1,4 @@
-# `@daypicker/hebrew` v10.0.0-next.5
+# `@daypicker/hebrew` v10.0.0-next.6
 
 ## Functions
 

--- a/apps/website/versioned_docs/version-next/api/hebrew/variables/enUS.md
+++ b/apps/website/versioned_docs/version-next/api/hebrew/variables/enUS.md
@@ -2,6 +2,6 @@
 
 > `const` **enUS**: `DayPickerLocale`
 
-Defined in: [packages/react-day-picker/src/locale/en-US.ts:12](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/locale/en-US.ts#L12)
+Defined in: [packages/react-day-picker/src/locale/en-US.ts:12](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/locale/en-US.ts#L12)
 
 English (United States) locale extended with DayPicker-specific translations.

--- a/apps/website/versioned_docs/version-next/api/hebrew/variables/he.md
+++ b/apps/website/versioned_docs/version-next/api/hebrew/variables/he.md
@@ -2,6 +2,6 @@
 
 > `const` **he**: `DayPickerLocale`
 
-Defined in: [packages/react-day-picker/src/locale/he.ts:8](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/locale/he.ts#L8)
+Defined in: [packages/react-day-picker/src/locale/he.ts:8](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/locale/he.ts#L8)
 
 Hebrew locale extended with DayPicker-specific translations.

--- a/apps/website/versioned_docs/version-next/api/hijri/functions/DayPicker.md
+++ b/apps/website/versioned_docs/version-next/api/hijri/functions/DayPicker.md
@@ -2,7 +2,7 @@
 
 > **DayPicker**(`props`): `Element`
 
-Defined in: [packages/hijri/src/hijri/index.tsx:38](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/hijri/src/hijri/index.tsx#L38)
+Defined in: [packages/hijri/src/hijri/index.tsx:38](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/hijri/src/hijri/index.tsx#L38)
 
 Render the Hijri (Umm al-Qura) calendar.
 

--- a/apps/website/versioned_docs/version-next/api/hijri/functions/getDateLib.md
+++ b/apps/website/versioned_docs/version-next/api/hijri/functions/getDateLib.md
@@ -2,7 +2,7 @@
 
 > **getDateLib**(`options?`): `DateLib`
 
-Defined in: [packages/hijri/src/hijri/index.tsx:75](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/hijri/src/hijri/index.tsx#L75)
+Defined in: [packages/hijri/src/hijri/index.tsx:75](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/hijri/src/hijri/index.tsx#L75)
 
 Returns the date library used in the Hijri calendar.
 

--- a/apps/website/versioned_docs/version-next/api/hijri/index.md
+++ b/apps/website/versioned_docs/version-next/api/hijri/index.md
@@ -1,4 +1,4 @@
-# `@daypicker/hijri` v10.0.0-next.5
+# `@daypicker/hijri` v10.0.0-next.6
 
 ## Functions
 

--- a/apps/website/versioned_docs/version-next/api/hijri/variables/arSA.md
+++ b/apps/website/versioned_docs/version-next/api/hijri/variables/arSA.md
@@ -2,6 +2,6 @@
 
 > `const` **arSA**: `DayPickerLocale`
 
-Defined in: [packages/react-day-picker/src/locale/ar-SA.ts:8](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/locale/ar-SA.ts#L8)
+Defined in: [packages/react-day-picker/src/locale/ar-SA.ts:8](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/locale/ar-SA.ts#L8)
 
 Arabic (Saudi Arabia) locale extended with DayPicker-specific translations.

--- a/apps/website/versioned_docs/version-next/api/hijri/variables/enUS.md
+++ b/apps/website/versioned_docs/version-next/api/hijri/variables/enUS.md
@@ -2,6 +2,6 @@
 
 > `const` **enUS**: `DayPickerLocale`
 
-Defined in: [packages/react-day-picker/src/locale/en-US.ts:12](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/locale/en-US.ts#L12)
+Defined in: [packages/react-day-picker/src/locale/en-US.ts:12](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/locale/en-US.ts#L12)
 
 English (United States) locale extended with DayPicker-specific translations.

--- a/apps/website/versioned_docs/version-next/api/persian/functions/DayPicker.md
+++ b/apps/website/versioned_docs/version-next/api/persian/functions/DayPicker.md
@@ -2,7 +2,7 @@
 
 > **DayPicker**(`props`): `Element`
 
-Defined in: [packages/persian/src/index.tsx:33](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/persian/src/index.tsx#L33)
+Defined in: [packages/persian/src/index.tsx:33](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/persian/src/index.tsx#L33)
 
 Renders the Persian calendar using the DayPicker component.
 

--- a/apps/website/versioned_docs/version-next/api/persian/functions/getDateLib.md
+++ b/apps/website/versioned_docs/version-next/api/persian/functions/getDateLib.md
@@ -2,7 +2,7 @@
 
 > **getDateLib**(`options?`): `DateLib`
 
-Defined in: [packages/persian/src/index.tsx:122](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/persian/src/index.tsx#L122)
+Defined in: [packages/persian/src/index.tsx:122](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/persian/src/index.tsx#L122)
 
 Returns the date library used in the Persian calendar.
 

--- a/apps/website/versioned_docs/version-next/api/persian/index.md
+++ b/apps/website/versioned_docs/version-next/api/persian/index.md
@@ -1,4 +1,4 @@
-# `@daypicker/persian` v10.0.0-next.5
+# `@daypicker/persian` v10.0.0-next.6
 
 ## Functions
 

--- a/apps/website/versioned_docs/version-next/api/persian/variables/enUS.md
+++ b/apps/website/versioned_docs/version-next/api/persian/variables/enUS.md
@@ -2,6 +2,6 @@
 
 > `const` **enUS**: *typeof* [`enUSJalali`](enUSJalali.md) = `enUSJalali`
 
-Defined in: [packages/persian/src/index.tsx:17](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/persian/src/index.tsx#L17)
+Defined in: [packages/persian/src/index.tsx:17](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/persian/src/index.tsx#L17)
 
 English (US) Jalali locale with DayPicker labels.

--- a/apps/website/versioned_docs/version-next/api/persian/variables/enUSJalali.md
+++ b/apps/website/versioned_docs/version-next/api/persian/variables/enUSJalali.md
@@ -2,7 +2,7 @@
 
 > `const` **enUSJalali**: `DayPickerLocale`
 
-Defined in: [packages/persian/src/locale/en-US-jalali.ts:12](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/persian/src/locale/en-US-jalali.ts#L12)
+Defined in: [packages/persian/src/locale/en-US-jalali.ts:12](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/persian/src/locale/en-US-jalali.ts#L12)
 
 English (United States) locale for the Jalali (Persian) calendar, extended
 with DayPicker-specific translations.

--- a/apps/website/versioned_docs/version-next/api/persian/variables/faIR.md
+++ b/apps/website/versioned_docs/version-next/api/persian/variables/faIR.md
@@ -2,6 +2,6 @@
 
 > `const` **faIR**: *typeof* [`faIRJalali`](faIRJalali.md) = `faIRJalali`
 
-Defined in: [packages/persian/src/index.tsx:15](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/persian/src/index.tsx#L15)
+Defined in: [packages/persian/src/index.tsx:15](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/persian/src/index.tsx#L15)
 
 Persian (Iran) Jalali locale with DayPicker labels.

--- a/apps/website/versioned_docs/version-next/api/persian/variables/faIRJalali.md
+++ b/apps/website/versioned_docs/version-next/api/persian/variables/faIRJalali.md
@@ -2,7 +2,7 @@
 
 > `const` **faIRJalali**: `DayPickerLocale`
 
-Defined in: [packages/persian/src/locale/fa-IR-jalali.ts:12](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/persian/src/locale/fa-IR-jalali.ts#L12)
+Defined in: [packages/persian/src/locale/fa-IR-jalali.ts:12](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/persian/src/locale/fa-IR-jalali.ts#L12)
 
 Persian (Iran) locale for the Jalali (Persian) calendar, extended with
 DayPicker-specific translations.

--- a/apps/website/versioned_docs/version-next/api/react/classes/CalendarDay.md
+++ b/apps/website/versioned_docs/version-next/api/react/classes/CalendarDay.md
@@ -1,6 +1,6 @@
 # Class: CalendarDay
 
-Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:10](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/CalendarDay.ts#L10)
+Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:10](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/CalendarDay.ts#L10)
 
 Represents a day displayed in the calendar.
 
@@ -14,7 +14,7 @@ the displayed month.
 
 > **new CalendarDay**(`date`, `displayMonth`, `dateLib?`): `CalendarDay`
 
-Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:11](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/CalendarDay.ts#L11)
+Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:11](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/CalendarDay.ts#L11)
 
 #### Parameters
 
@@ -34,7 +34,7 @@ Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:11](https://gi
 
 > **isEqualTo**(`day`): `boolean`
 
-Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:82](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/CalendarDay.ts#L82)
+Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:82](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/CalendarDay.ts#L82)
 
 Checks if this day is equal to another `CalendarDay`, considering both the
 date and the displayed month.
@@ -57,7 +57,7 @@ date and the displayed month.
 
 > `readonly` **date**: `Date`
 
-Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:52](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/CalendarDay.ts#L52)
+Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:52](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/CalendarDay.ts#L52)
 
 The date represented by this day.
 
@@ -67,7 +67,7 @@ The date represented by this day.
 
 > `readonly` **dateMonthId**: `string`
 
-Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:73](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/CalendarDay.ts#L73)
+Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:73](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/CalendarDay.ts#L73)
 
 Stable `yyyy-MM` representation of the date's actual month.
 
@@ -81,7 +81,7 @@ V9.11.2
 
 > `readonly` **displayMonth**: `Date`
 
-Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:49](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/CalendarDay.ts#L49)
+Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:49](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/CalendarDay.ts#L49)
 
 The month that is currently displayed in the calendar.
 
@@ -95,7 +95,7 @@ enabled.
 
 > `readonly` **displayMonthId**: `string`
 
-Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:66](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/CalendarDay.ts#L66)
+Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:66](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/CalendarDay.ts#L66)
 
 Stable `yyyy-MM` representation of the displayed month.
 
@@ -109,7 +109,7 @@ V9.11.2
 
 > `readonly` **isoDate**: `string`
 
-Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:59](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/CalendarDay.ts#L59)
+Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:59](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/CalendarDay.ts#L59)
 
 Stable `yyyy-MM-dd` representation for reuse in keys/data attrs.
 
@@ -123,7 +123,7 @@ V9.11.2
 
 > `readonly` **outside**: `boolean`
 
-Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:40](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/CalendarDay.ts#L40)
+Defined in: [packages/react-day-picker/src/classes/CalendarDay.ts:40](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/CalendarDay.ts#L40)
 
 Indicates whether the day does not belong to the displayed month.
 

--- a/apps/website/versioned_docs/version-next/api/react/classes/CalendarMonth.md
+++ b/apps/website/versioned_docs/version-next/api/react/classes/CalendarMonth.md
@@ -1,6 +1,6 @@
 # Class: CalendarMonth
 
-Defined in: [packages/react-day-picker/src/classes/CalendarMonth.ts:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/CalendarMonth.ts#L9)
+Defined in: [packages/react-day-picker/src/classes/CalendarMonth.ts:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/CalendarMonth.ts#L9)
 
 Represents a month in a calendar year.
 
@@ -13,7 +13,7 @@ month.
 
 > **new CalendarMonth**(`month`, `weeks`): `CalendarMonth`
 
-Defined in: [packages/react-day-picker/src/classes/CalendarMonth.ts:10](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/CalendarMonth.ts#L10)
+Defined in: [packages/react-day-picker/src/classes/CalendarMonth.ts:10](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/CalendarMonth.ts#L10)
 
 #### Parameters
 
@@ -32,7 +32,7 @@ Defined in: [packages/react-day-picker/src/classes/CalendarMonth.ts:10](https://
 
 > **date**: `Date`
 
-Defined in: [packages/react-day-picker/src/classes/CalendarMonth.ts:16](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/CalendarMonth.ts#L16)
+Defined in: [packages/react-day-picker/src/classes/CalendarMonth.ts:16](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/CalendarMonth.ts#L16)
 
 The date representing the first day of the month.
 
@@ -42,6 +42,6 @@ The date representing the first day of the month.
 
 > **weeks**: [`CalendarWeek`](CalendarWeek.md)[]
 
-Defined in: [packages/react-day-picker/src/classes/CalendarMonth.ts:19](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/CalendarMonth.ts#L19)
+Defined in: [packages/react-day-picker/src/classes/CalendarMonth.ts:19](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/CalendarMonth.ts#L19)
 
 The weeks that belong to this month.

--- a/apps/website/versioned_docs/version-next/api/react/classes/CalendarWeek.md
+++ b/apps/website/versioned_docs/version-next/api/react/classes/CalendarWeek.md
@@ -1,6 +1,6 @@
 # Class: CalendarWeek
 
-Defined in: [packages/react-day-picker/src/classes/CalendarWeek.ts:8](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/CalendarWeek.ts#L8)
+Defined in: [packages/react-day-picker/src/classes/CalendarWeek.ts:8](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/CalendarWeek.ts#L8)
 
 Represents a week in a calendar month.
 
@@ -12,7 +12,7 @@ A `CalendarWeek` contains the days within the week and the week number.
 
 > **new CalendarWeek**(`weekNumber`, `days`): `CalendarWeek`
 
-Defined in: [packages/react-day-picker/src/classes/CalendarWeek.ts:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/CalendarWeek.ts#L9)
+Defined in: [packages/react-day-picker/src/classes/CalendarWeek.ts:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/CalendarWeek.ts#L9)
 
 #### Parameters
 
@@ -31,7 +31,7 @@ Defined in: [packages/react-day-picker/src/classes/CalendarWeek.ts:9](https://gi
 
 > **days**: [`CalendarDay`](CalendarDay.md)[]
 
-Defined in: [packages/react-day-picker/src/classes/CalendarWeek.ts:18](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/CalendarWeek.ts#L18)
+Defined in: [packages/react-day-picker/src/classes/CalendarWeek.ts:18](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/CalendarWeek.ts#L18)
 
 The days that belong to this week.
 
@@ -41,6 +41,6 @@ The days that belong to this week.
 
 > **weekNumber**: `number`
 
-Defined in: [packages/react-day-picker/src/classes/CalendarWeek.ts:15](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/CalendarWeek.ts#L15)
+Defined in: [packages/react-day-picker/src/classes/CalendarWeek.ts:15](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/CalendarWeek.ts#L15)
 
 The number of the week within the year.

--- a/apps/website/versioned_docs/version-next/api/react/classes/DateLib.md
+++ b/apps/website/versioned_docs/version-next/api/react/classes/DateLib.md
@@ -1,6 +1,6 @@
 # Class: DateLib
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:116](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L116)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:117](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L117)
 
 A wrapper class around [date-fns](http://date-fns.org) that provides utility
 methods for date manipulation and formatting.
@@ -22,7 +22,7 @@ const dateLib = new DateLib({ locale: es });
 
 > **new DateLib**(`options?`, `overrides?`): `DateLib`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:129](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L129)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:130](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L130)
 
 Creates an instance of `DateLib`.
 
@@ -43,7 +43,7 @@ Creates an instance of `DateLib`.
 
 > **addDays**(`date`, `amount`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:287](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L287)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:288](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L288)
 
 Adds the specified number of days to the given date.
 
@@ -66,7 +66,7 @@ The new date with the days added.
 
 > **addMonths**(`date`, `amount`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:300](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L300)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:301](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L301)
 
 Adds the specified number of months to the given date.
 
@@ -89,7 +89,7 @@ The new date with the months added.
 
 > **addWeeks**(`date`, `amount`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:313](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L313)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:314](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L314)
 
 Adds the specified number of weeks to the given date.
 
@@ -112,7 +112,7 @@ The new date with the weeks added.
 
 > **addYears**(`date`, `amount`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:326](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L326)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:327](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L327)
 
 Adds the specified number of years to the given date.
 
@@ -135,7 +135,7 @@ The new date with the years added.
 
 > **differenceInCalendarDays**(`dateLeft`, `dateRight`): `number`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:339](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L339)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:340](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L340)
 
 Returns the number of calendar days between the given dates.
 
@@ -158,7 +158,7 @@ The number of calendar days between the dates.
 
 > **differenceInCalendarMonths**(`dateLeft`, `dateRight`): `number`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:352](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L352)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:353](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L353)
 
 Returns the number of calendar months between the given dates.
 
@@ -181,7 +181,7 @@ The number of calendar months between the dates.
 
 > **eachMonthOfInterval**(`interval`): `Date`[]
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:363](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L363)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:364](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L364)
 
 Returns the months between the given dates.
 
@@ -201,7 +201,7 @@ Returns the months between the given dates.
 
 > **eachYearOfInterval**(`interval`): `Date`[]
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:376](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L376)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:377](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L377)
 
 Returns the years between the given dates.
 
@@ -227,7 +227,7 @@ The array of years in the interval.
 
 > **endOfBroadcastWeek**(`date`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:401](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L401)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:402](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L402)
 
 Returns the end of the broadcast week for the given date.
 
@@ -249,7 +249,7 @@ The end of the broadcast week.
 
 > **endOfISOWeek**(`date`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:413](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L413)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:414](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L414)
 
 Returns the end of the ISO week for the given date.
 
@@ -271,7 +271,7 @@ The end of the ISO week.
 
 > **endOfMonth**(`date`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:425](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L425)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:426](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L426)
 
 Returns the end of the month for the given date.
 
@@ -293,7 +293,7 @@ The end of the month.
 
 > **endOfWeek**(`date`, `options?`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:437](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L437)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:438](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L438)
 
 Returns the end of the week for the given date.
 
@@ -316,7 +316,7 @@ The end of the week.
 
 > **endOfYear**(`date`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:449](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L449)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:450](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L450)
 
 Returns the end of the year for the given date.
 
@@ -338,7 +338,7 @@ The end of the year.
 
 > **format**(`date`, `formatStr`, `_options?`): `string`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:462](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L462)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:463](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L463)
 
 Formats the given date using the specified format string.
 
@@ -362,7 +362,7 @@ The formatted date string.
 
 > **formatMonthYear**(`date`): `string`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:201](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L201)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:202](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L202)
 
 Formats the month/year pair respecting locale conventions.
 
@@ -386,7 +386,7 @@ Formats the month/year pair respecting locale conventions.
 
 > **formatNumber**(`value`): `string`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:180](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L180)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:181](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L181)
 
 Formats a number using the configured numbering system.
 
@@ -412,7 +412,7 @@ The formatted number as a string.
 
 > **getISOWeek**(`date`): `number`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:482](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L482)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:483](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L483)
 
 Returns the ISO week number for the given date.
 
@@ -434,7 +434,7 @@ The ISO week number.
 
 > **getMonth**(`date`, `_options?`): `number`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:494](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L494)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:495](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L495)
 
 Returns the month of the given date.
 
@@ -457,7 +457,7 @@ The month.
 
 > **getMonthYearOrder**(): [`MonthYearOrder`](../type-aliases/MonthYearOrder.md)
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:188](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L188)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:189](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L189)
 
 Returns the preferred ordering for month and year labels for the current
 locale.
@@ -472,7 +472,7 @@ locale.
 
 > **getWeek**(`date`, `_options?`): `number`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:518](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L518)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:519](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L519)
 
 Returns the local week number for the given date.
 
@@ -495,7 +495,7 @@ The week number.
 
 > **getYear**(`date`, `_options?`): `number`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:506](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L506)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:507](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L507)
 
 Returns the year of the given date.
 
@@ -518,7 +518,7 @@ The year.
 
 > **isAfter**(`date`, `dateToCompare`): `boolean`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:531](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L531)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:532](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L532)
 
 Checks if the first date is after the second date.
 
@@ -541,7 +541,7 @@ True if the first date is after the second date.
 
 > **isBefore**(`date`, `dateToCompare`): `boolean`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:544](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L544)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:545](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L545)
 
 Checks if the first date is before the second date.
 
@@ -564,7 +564,7 @@ True if the first date is before the second date.
 
 > **isSameDay**(`dateLeft`, `dateRight`): `boolean`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:569](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L569)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:570](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L570)
 
 Checks if the given dates are on the same day.
 
@@ -587,7 +587,7 @@ True if the dates are on the same day.
 
 > **isSameMonth**(`dateLeft`, `dateRight`): `boolean`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:582](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L582)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:583](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L583)
 
 Checks if the given dates are in the same month.
 
@@ -610,7 +610,7 @@ True if the dates are in the same month.
 
 > **isSameYear**(`dateLeft`, `dateRight`): `boolean`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:595](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L595)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:596](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L596)
 
 Checks if the given dates are in the same year.
 
@@ -633,7 +633,7 @@ True if the dates are in the same year.
 
 > **max**(`dates`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:607](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L607)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:608](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L608)
 
 Returns the latest date in the given array of dates.
 
@@ -655,7 +655,7 @@ The latest date.
 
 > **min**(`dates`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:617](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L617)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:618](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L618)
 
 Returns the earliest date in the given array of dates.
 
@@ -677,7 +677,7 @@ The earliest date.
 
 > **newDate**(`year`, `monthIndex`, `date`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:270](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L270)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:271](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L271)
 
 Creates a new `Date` object with the specified year, month, and day.
 
@@ -705,7 +705,7 @@ A new `Date` object.
 
 > **setMonth**(`date`, `month`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:628](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L628)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:629](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L629)
 
 Sets the month of the given date.
 
@@ -728,7 +728,7 @@ The new date with the month set.
 
 > **setYear**(`date`, `year`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:641](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L641)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:642](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L642)
 
 Sets the year of the given date.
 
@@ -751,7 +751,7 @@ The new date with the year set.
 
 > **startOfBroadcastWeek**(`date`, `_dateLib`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:653](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L653)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:654](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L654)
 
 Returns the start of the broadcast week for the given date.
 
@@ -774,7 +774,7 @@ The start of the broadcast week.
 
 > **startOfDay**(`date`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:665](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L665)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:666](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L666)
 
 Returns the start of the day for the given date.
 
@@ -796,7 +796,7 @@ The start of the day.
 
 > **startOfISOWeek**(`date`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:677](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L677)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:678](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L678)
 
 Returns the start of the ISO week for the given date.
 
@@ -818,7 +818,7 @@ The start of the ISO week.
 
 > **startOfMonth**(`date`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:689](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L689)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:690](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L690)
 
 Returns the start of the month for the given date.
 
@@ -840,7 +840,7 @@ The start of the month.
 
 > **startOfWeek**(`date`, `_options?`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:701](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L701)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:702](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L702)
 
 Returns the start of the week for the given date.
 
@@ -863,7 +863,7 @@ The start of the week.
 
 > **startOfYear**(`date`): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:713](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L713)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:714](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L714)
 
 Returns the start of the year for the given date.
 
@@ -885,7 +885,7 @@ The start of the year.
 
 > **today**(): `Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:250](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L250)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:251](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L251)
 
 Creates a new `Date` object representing today's date.
 
@@ -905,7 +905,7 @@ A `Date` object for today's date.
 
 > **isDate**: (`value`) => `value is Date`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:556](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L556)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:557](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L557)
 
 Checks if the given value is a Date object.
 
@@ -927,7 +927,7 @@ True if the value is a Date object.
 
 > `readonly` **options**: [`DateLibOptions`](../interfaces/DateLibOptions.md)
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:118](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L118)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:119](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L119)
 
 The options for configuring the date library.
 
@@ -937,6 +937,6 @@ The options for configuring the date library.
 
 > `readonly` `optional` **overrides?**: `Partial`\<`DateLib`\>
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:121](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L121)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:122](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L122)
 
 Overrides for the default date library functions.

--- a/apps/website/versioned_docs/version-next/api/react/enumerations/Animation.md
+++ b/apps/website/versioned_docs/version-next/api/react/enumerations/Animation.md
@@ -1,6 +1,6 @@
 # Enumeration: Animation
 
-Defined in: [packages/react-day-picker/src/UI.ts:104](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/UI.ts#L104)
+Defined in: [packages/react-day-picker/src/UI.ts:104](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/UI.ts#L104)
 
 Enum representing different animation states for transitioning between
 months.

--- a/apps/website/versioned_docs/version-next/api/react/enumerations/DayFlag.md
+++ b/apps/website/versioned_docs/version-next/api/react/enumerations/DayFlag.md
@@ -1,6 +1,6 @@
 # Enumeration: DayFlag
 
-Defined in: [packages/react-day-picker/src/UI.ts:72](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/UI.ts#L72)
+Defined in: [packages/react-day-picker/src/UI.ts:72](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/UI.ts#L72)
 
 Enum representing flags for the [UI.Day](UI.md) element.
 

--- a/apps/website/versioned_docs/version-next/api/react/enumerations/SelectionState.md
+++ b/apps/website/versioned_docs/version-next/api/react/enumerations/SelectionState.md
@@ -1,6 +1,6 @@
 # Enumeration: SelectionState
 
-Defined in: [packages/react-day-picker/src/UI.ts:89](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/UI.ts#L89)
+Defined in: [packages/react-day-picker/src/UI.ts:89](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/UI.ts#L89)
 
 Enum representing selection states that can be applied to the
 [UI.Day](UI.md) element in selection mode.

--- a/apps/website/versioned_docs/version-next/api/react/enumerations/UI.md
+++ b/apps/website/versioned_docs/version-next/api/react/enumerations/UI.md
@@ -1,6 +1,6 @@
 # Enumeration: UI
 
-Defined in: [packages/react-day-picker/src/UI.ts:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/UI.ts#L9)
+Defined in: [packages/react-day-picker/src/UI.ts:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/UI.ts#L9)
 
 Enum representing the UI elements composing DayPicker. These elements are
 mapped to [CustomComponents](../type-aliases/CustomComponents.md), [ClassNames](../type-aliases/ClassNames.md), and [Styles](../type-aliases/Styles.md).

--- a/apps/website/versioned_docs/version-next/api/react/functions/CaptionLabel.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/CaptionLabel.md
@@ -2,7 +2,7 @@
 
 > **CaptionLabel**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/CaptionLabel.tsx:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/CaptionLabel.tsx#L9)
+Defined in: [packages/react-day-picker/src/components/CaptionLabel.tsx:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/CaptionLabel.tsx#L9)
 
 Render the label in the month caption.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/Chevron.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/Chevron.md
@@ -2,7 +2,7 @@
 
 > **Chevron**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/Chevron.tsx:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Chevron.tsx#L9)
+Defined in: [packages/react-day-picker/src/components/Chevron.tsx:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Chevron.tsx#L9)
 
 Render the chevron icon used in the navigation buttons and dropdowns.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/Day.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/Day.md
@@ -2,7 +2,7 @@
 
 > **Day**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/Day.tsx:16](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Day.tsx#L16)
+Defined in: [packages/react-day-picker/src/components/Day.tsx:16](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Day.tsx#L16)
 
 Render a grid cell for a specific day in the calendar.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/DayButton.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/DayButton.md
@@ -2,7 +2,7 @@
 
 > **DayButton**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/DayButton.tsx:12](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/DayButton.tsx#L12)
+Defined in: [packages/react-day-picker/src/components/DayButton.tsx:12](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/DayButton.tsx#L12)
 
 Render a button for a specific day in the calendar.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/DayPicker.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/DayPicker.md
@@ -2,7 +2,7 @@
 
 > **DayPicker**(`initialProps`): `Element`
 
-Defined in: [packages/react-day-picker/src/DayPicker.tsx:44](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/DayPicker.tsx#L44)
+Defined in: [packages/react-day-picker/src/DayPicker.tsx:44](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/DayPicker.tsx#L44)
 
 Renders the DayPicker calendar component.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/Dropdown.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/Dropdown.md
@@ -2,7 +2,7 @@
 
 > **Dropdown**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/Dropdown.tsx:21](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Dropdown.tsx#L21)
+Defined in: [packages/react-day-picker/src/components/Dropdown.tsx:21](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Dropdown.tsx#L21)
 
 Render a dropdown component for navigation in the calendar.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/DropdownNav.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/DropdownNav.md
@@ -2,7 +2,7 @@
 
 > **DropdownNav**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/DropdownNav.tsx:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/DropdownNav.tsx#L9)
+Defined in: [packages/react-day-picker/src/components/DropdownNav.tsx:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/DropdownNav.tsx#L9)
 
 Render the navigation dropdowns for the calendar.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/Footer.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/Footer.md
@@ -2,7 +2,7 @@
 
 > **Footer**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/Footer.tsx:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Footer.tsx#L9)
+Defined in: [packages/react-day-picker/src/components/Footer.tsx:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Footer.tsx#L9)
 
 Render the footer of the calendar.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/Month.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/Month.md
@@ -2,7 +2,7 @@
 
 > **Month**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/Month.tsx:12](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Month.tsx#L12)
+Defined in: [packages/react-day-picker/src/components/Month.tsx:12](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Month.tsx#L12)
 
 Render the grid with the weekday header row and the weeks for a specific
 month.

--- a/apps/website/versioned_docs/version-next/api/react/functions/MonthCaption.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/MonthCaption.md
@@ -2,7 +2,7 @@
 
 > **MonthCaption**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/MonthCaption.tsx:11](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/MonthCaption.tsx#L11)
+Defined in: [packages/react-day-picker/src/components/MonthCaption.tsx:11](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/MonthCaption.tsx#L11)
 
 Render the caption for a month in the calendar.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/MonthGrid.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/MonthGrid.md
@@ -2,7 +2,7 @@
 
 > **MonthGrid**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/MonthGrid.tsx:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/MonthGrid.tsx#L9)
+Defined in: [packages/react-day-picker/src/components/MonthGrid.tsx:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/MonthGrid.tsx#L9)
 
 Render the grid of days for a specific month.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/Months.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/Months.md
@@ -2,7 +2,7 @@
 
 > **Months**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/Months.tsx:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Months.tsx#L9)
+Defined in: [packages/react-day-picker/src/components/Months.tsx:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Months.tsx#L9)
 
 Render a container wrapping the month grids.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/MonthsDropdown.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/MonthsDropdown.md
@@ -2,7 +2,7 @@
 
 > **MonthsDropdown**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/MonthsDropdown.tsx:13](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/MonthsDropdown.tsx#L13)
+Defined in: [packages/react-day-picker/src/components/MonthsDropdown.tsx:13](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/MonthsDropdown.tsx#L13)
 
 Render a dropdown to navigate between months in the calendar.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/Nav.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/Nav.md
@@ -2,7 +2,7 @@
 
 > **Nav**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/Nav.tsx:16](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Nav.tsx#L16)
+Defined in: [packages/react-day-picker/src/components/Nav.tsx:16](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Nav.tsx#L16)
 
 Render the navigation toolbar with buttons to navigate between months.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/NextMonthButton.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/NextMonthButton.md
@@ -2,7 +2,7 @@
 
 > **NextMonthButton**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/NextMonthButton.tsx:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/NextMonthButton.tsx#L9)
+Defined in: [packages/react-day-picker/src/components/NextMonthButton.tsx:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/NextMonthButton.tsx#L9)
 
 Render the button to navigate to the next month in the calendar.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/Option.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/Option.md
@@ -2,7 +2,7 @@
 
 > **Option**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/Option.tsx:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Option.tsx#L9)
+Defined in: [packages/react-day-picker/src/components/Option.tsx:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Option.tsx#L9)
 
 Render an `option` element.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/PreviousMonthButton.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/PreviousMonthButton.md
@@ -2,7 +2,7 @@
 
 > **PreviousMonthButton**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/PreviousMonthButton.tsx:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/PreviousMonthButton.tsx#L9)
+Defined in: [packages/react-day-picker/src/components/PreviousMonthButton.tsx:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/PreviousMonthButton.tsx#L9)
 
 Render the button to navigate to the previous month in the calendar.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/Root.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/Root.md
@@ -2,7 +2,7 @@
 
 > **Root**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/Root.tsx:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Root.tsx#L9)
+Defined in: [packages/react-day-picker/src/components/Root.tsx:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Root.tsx#L9)
 
 Render the root element of the calendar.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/Select.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/Select.md
@@ -2,7 +2,7 @@
 
 > **Select**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/Select.tsx:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Select.tsx#L9)
+Defined in: [packages/react-day-picker/src/components/Select.tsx:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Select.tsx#L9)
 
 Render a `select` element.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/Week.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/Week.md
@@ -2,7 +2,7 @@
 
 > **Week**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/Week.tsx:11](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Week.tsx#L11)
+Defined in: [packages/react-day-picker/src/components/Week.tsx:11](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Week.tsx#L11)
 
 Render a table row representing a week in the calendar.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/WeekNumber.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/WeekNumber.md
@@ -2,7 +2,7 @@
 
 > **WeekNumber**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/WeekNumber.tsx:11](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/WeekNumber.tsx#L11)
+Defined in: [packages/react-day-picker/src/components/WeekNumber.tsx:11](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/WeekNumber.tsx#L11)
 
 Render a table cell displaying the number of the week.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/WeekNumberHeader.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/WeekNumberHeader.md
@@ -2,7 +2,7 @@
 
 > **WeekNumberHeader**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/WeekNumberHeader.tsx:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/WeekNumberHeader.tsx#L9)
+Defined in: [packages/react-day-picker/src/components/WeekNumberHeader.tsx:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/WeekNumberHeader.tsx#L9)
 
 Render the header cell for the week numbers column.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/Weekday.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/Weekday.md
@@ -2,7 +2,7 @@
 
 > **Weekday**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/Weekday.tsx:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Weekday.tsx#L9)
+Defined in: [packages/react-day-picker/src/components/Weekday.tsx:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Weekday.tsx#L9)
 
 Render a table header cell with the name of a weekday (e.g., "Mo", "Tu").
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/Weekdays.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/Weekdays.md
@@ -2,7 +2,7 @@
 
 > **Weekdays**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/Weekdays.tsx:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Weekdays.tsx#L9)
+Defined in: [packages/react-day-picker/src/components/Weekdays.tsx:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Weekdays.tsx#L9)
 
 Render the table row containing the weekday names.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/Weeks.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/Weeks.md
@@ -2,7 +2,7 @@
 
 > **Weeks**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/Weeks.tsx:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Weeks.tsx#L9)
+Defined in: [packages/react-day-picker/src/components/Weeks.tsx:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Weeks.tsx#L9)
 
 Render the container for the weeks in the month grid.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/YearsDropdown.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/YearsDropdown.md
@@ -2,7 +2,7 @@
 
 > **YearsDropdown**(`props`): `Element`
 
-Defined in: [packages/react-day-picker/src/components/YearsDropdown.tsx:13](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/YearsDropdown.tsx#L13)
+Defined in: [packages/react-day-picker/src/components/YearsDropdown.tsx:13](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/YearsDropdown.tsx#L13)
 
 Render a dropdown to navigate between years in the calendar.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/addToRange.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/addToRange.md
@@ -2,7 +2,7 @@
 
 > **addToRange**(`date`, `initialRange`, `min?`, `max?`, `required?`, `dateLib?`): [`DateRange`](../type-aliases/DateRange.md) \| `undefined`
 
-Defined in: [packages/react-day-picker/src/utils/addToRange.ts:17](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/utils/addToRange.ts#L17)
+Defined in: [packages/react-day-picker/src/utils/addToRange.ts:17](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/utils/addToRange.ts#L17)
 
 Adds a date to an existing range, considering constraints like minimum and
 maximum range size.

--- a/apps/website/versioned_docs/version-next/api/react/functions/dateMatchModifiers.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/dateMatchModifiers.md
@@ -2,7 +2,7 @@
 
 > **dateMatchModifiers**(`date`, `matchers`, `dateLib?`): `boolean`
 
-Defined in: [packages/react-day-picker/src/utils/dateMatchModifiers.ts:23](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/utils/dateMatchModifiers.ts#L23)
+Defined in: [packages/react-day-picker/src/utils/dateMatchModifiers.ts:23](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/utils/dateMatchModifiers.ts#L23)
 
 Checks if a given date matches at least one of the specified [Matcher](../type-aliases/Matcher.md).
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/formatCaption.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/formatCaption.md
@@ -2,7 +2,7 @@
 
 > **formatCaption**(`month`, `options?`, `dateLib?`): `string`
 
-Defined in: [packages/react-day-picker/src/formatters/formatCaption.ts:15](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/formatters/formatCaption.ts#L15)
+Defined in: [packages/react-day-picker/src/formatters/formatCaption.ts:15](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/formatters/formatCaption.ts#L15)
 
 Formats the caption of the month.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/formatDay.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/formatDay.md
@@ -2,7 +2,7 @@
 
 > **formatDay**(`date`, `options?`, `dateLib?`): `string`
 
-Defined in: [packages/react-day-picker/src/formatters/formatDay.ts:15](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/formatters/formatDay.ts#L15)
+Defined in: [packages/react-day-picker/src/formatters/formatDay.ts:15](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/formatters/formatDay.ts#L15)
 
 Formats the day date shown in the day cell.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/formatMonthDropdown.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/formatMonthDropdown.md
@@ -2,7 +2,7 @@
 
 > **formatMonthDropdown**(`month`, `dateLib?`): `string`
 
-Defined in: [packages/react-day-picker/src/formatters/formatMonthDropdown.ts:14](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/formatters/formatMonthDropdown.ts#L14)
+Defined in: [packages/react-day-picker/src/formatters/formatMonthDropdown.ts:14](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/formatters/formatMonthDropdown.ts#L14)
 
 Formats the month for the dropdown option label.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/formatWeekNumber.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/formatWeekNumber.md
@@ -2,7 +2,7 @@
 
 > **formatWeekNumber**(`weekNumber`, `dateLib?`): `string`
 
-Defined in: [packages/react-day-picker/src/formatters/formatWeekNumber.ts:14](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/formatters/formatWeekNumber.ts#L14)
+Defined in: [packages/react-day-picker/src/formatters/formatWeekNumber.ts:14](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/formatters/formatWeekNumber.ts#L14)
 
 Formats the week number.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/formatWeekNumberHeader.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/formatWeekNumberHeader.md
@@ -2,7 +2,7 @@
 
 > **formatWeekNumberHeader**(): `string`
 
-Defined in: [packages/react-day-picker/src/formatters/formatWeekNumberHeader.ts:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/formatters/formatWeekNumberHeader.ts#L9)
+Defined in: [packages/react-day-picker/src/formatters/formatWeekNumberHeader.ts:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/formatters/formatWeekNumberHeader.ts#L9)
 
 Formats the header for the week number column.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/formatWeekdayName.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/formatWeekdayName.md
@@ -2,7 +2,7 @@
 
 > **formatWeekdayName**(`weekday`, `options?`, `dateLib?`): `string`
 
-Defined in: [packages/react-day-picker/src/formatters/formatWeekdayName.ts:15](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/formatters/formatWeekdayName.ts#L15)
+Defined in: [packages/react-day-picker/src/formatters/formatWeekdayName.ts:15](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/formatters/formatWeekdayName.ts#L15)
 
 Formats the name of a weekday to be displayed in the weekdays header.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/formatYearDropdown.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/formatYearDropdown.md
@@ -2,7 +2,7 @@
 
 > **formatYearDropdown**(`year`, `dateLib?`): `string`
 
-Defined in: [packages/react-day-picker/src/formatters/formatYearDropdown.ts:13](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/formatters/formatYearDropdown.ts#L13)
+Defined in: [packages/react-day-picker/src/formatters/formatYearDropdown.ts:13](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/formatters/formatYearDropdown.ts#L13)
 
 Formats the year for the dropdown option label.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/getDefaultClassNames.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/getDefaultClassNames.md
@@ -2,7 +2,7 @@
 
 > **getDefaultClassNames**(): [`ClassNames`](../type-aliases/ClassNames.md)
 
-Defined in: [packages/react-day-picker/src/helpers/getDefaultClassNames.ts:13](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/helpers/getDefaultClassNames.ts#L13)
+Defined in: [packages/react-day-picker/src/helpers/getDefaultClassNames.ts:13](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/helpers/getDefaultClassNames.ts#L13)
 
 Returns the default class names for the UI elements.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/isDateAfterType.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/isDateAfterType.md
@@ -2,7 +2,7 @@
 
 > **isDateAfterType**(`value`): `value is DateAfter`
 
-Defined in: [packages/react-day-picker/src/utils/typeguards.ts:44](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/utils/typeguards.ts#L44)
+Defined in: [packages/react-day-picker/src/utils/typeguards.ts:44](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/utils/typeguards.ts#L44)
 
 Checks if the given value is of type [DateAfter](../type-aliases/DateAfter.md).
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/isDateBeforeType.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/isDateBeforeType.md
@@ -2,7 +2,7 @@
 
 > **isDateBeforeType**(`value`): `value is DateBefore`
 
-Defined in: [packages/react-day-picker/src/utils/typeguards.ts:55](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/utils/typeguards.ts#L55)
+Defined in: [packages/react-day-picker/src/utils/typeguards.ts:55](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/utils/typeguards.ts#L55)
 
 Checks if the given value is of type [DateBefore](../type-aliases/DateBefore.md).
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/isDateInterval.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/isDateInterval.md
@@ -2,7 +2,7 @@
 
 > **isDateInterval**(`matcher`): `matcher is DateInterval`
 
-Defined in: [packages/react-day-picker/src/utils/typeguards.ts:17](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/utils/typeguards.ts#L17)
+Defined in: [packages/react-day-picker/src/utils/typeguards.ts:17](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/utils/typeguards.ts#L17)
 
 Checks if the given value is of type [DateInterval](../type-aliases/DateInterval.md).
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/isDateRange.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/isDateRange.md
@@ -2,7 +2,7 @@
 
 > **isDateRange**(`value`): `value is DateRange`
 
-Defined in: [packages/react-day-picker/src/utils/typeguards.ts:33](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/utils/typeguards.ts#L33)
+Defined in: [packages/react-day-picker/src/utils/typeguards.ts:33](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/utils/typeguards.ts#L33)
 
 Checks if the given value is of type [DateRange](../type-aliases/DateRange.md).
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/isDayOfWeekType.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/isDayOfWeekType.md
@@ -2,7 +2,7 @@
 
 > **isDayOfWeekType**(`value`): `value is DayOfWeek`
 
-Defined in: [packages/react-day-picker/src/utils/typeguards.ts:66](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/utils/typeguards.ts#L66)
+Defined in: [packages/react-day-picker/src/utils/typeguards.ts:66](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/utils/typeguards.ts#L66)
 
 Checks if the given value is of type [DayOfWeek](../type-aliases/DayOfWeek.md).
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/labelDayButton.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/labelDayButton.md
@@ -2,7 +2,7 @@
 
 > **labelDayButton**(`date`, `modifiers`, `options?`, `dateLib?`): `string`
 
-Defined in: [packages/react-day-picker/src/labels/labelDayButton.ts:19](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/labels/labelDayButton.ts#L19)
+Defined in: [packages/react-day-picker/src/labels/labelDayButton.ts:19](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/labels/labelDayButton.ts#L19)
 
 Generates the ARIA label for a day button.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/labelGrid.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/labelGrid.md
@@ -2,7 +2,7 @@
 
 > **labelGrid**(`date`, `options?`, `dateLib?`): `string`
 
-Defined in: [packages/react-day-picker/src/labels/labelGrid.ts:15](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/labels/labelGrid.ts#L15)
+Defined in: [packages/react-day-picker/src/labels/labelGrid.ts:15](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/labels/labelGrid.ts#L15)
 
 Generates the ARIA label for the month grid, which is announced when entering
 the grid.

--- a/apps/website/versioned_docs/version-next/api/react/functions/labelGridcell.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/labelGridcell.md
@@ -2,7 +2,7 @@
 
 > **labelGridcell**(`date`, `modifiers?`, `options?`, `dateLib?`): `string`
 
-Defined in: [packages/react-day-picker/src/labels/labelGridcell.ts:15](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/labels/labelGridcell.ts#L15)
+Defined in: [packages/react-day-picker/src/labels/labelGridcell.ts:15](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/labels/labelGridcell.ts#L15)
 
 Generates the label for a day grid cell when the calendar is not interactive.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/labelMonthDropdown.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/labelMonthDropdown.md
@@ -2,7 +2,7 @@
 
 > **labelMonthDropdown**(`_options?`): `string`
 
-Defined in: [packages/react-day-picker/src/labels/labelMonthDropdown.ts:12](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/labels/labelMonthDropdown.ts#L12)
+Defined in: [packages/react-day-picker/src/labels/labelMonthDropdown.ts:12](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/labels/labelMonthDropdown.ts#L12)
 
 Generates the ARIA label for the months dropdown.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/labelNav.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/labelNav.md
@@ -2,7 +2,7 @@
 
 > **labelNav**(): `string`
 
-Defined in: [packages/react-day-picker/src/labels/labelNav.ts:9](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/labels/labelNav.ts#L9)
+Defined in: [packages/react-day-picker/src/labels/labelNav.ts:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/labels/labelNav.ts#L9)
 
 Generates the ARIA label for the navigation toolbar.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/labelNext.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/labelNext.md
@@ -2,7 +2,7 @@
 
 > **labelNext**(`_month`, `_options?`): `string`
 
-Defined in: [packages/react-day-picker/src/labels/labelNext.ts:15](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/labels/labelNext.ts#L15)
+Defined in: [packages/react-day-picker/src/labels/labelNext.ts:15](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/labels/labelNext.ts#L15)
 
 Generates the ARIA label for the "next month" button.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/labelPrevious.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/labelPrevious.md
@@ -2,7 +2,7 @@
 
 > **labelPrevious**(`_month`): `string`
 
-Defined in: [packages/react-day-picker/src/labels/labelPrevious.ts:11](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/labels/labelPrevious.ts#L11)
+Defined in: [packages/react-day-picker/src/labels/labelPrevious.ts:11](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/labels/labelPrevious.ts#L11)
 
 Generates the ARIA label for the "previous month" button.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/labelWeekNumber.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/labelWeekNumber.md
@@ -2,7 +2,7 @@
 
 > **labelWeekNumber**(`weekNumber`, `_options?`): `string`
 
-Defined in: [packages/react-day-picker/src/labels/labelWeekNumber.ts:13](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/labels/labelWeekNumber.ts#L13)
+Defined in: [packages/react-day-picker/src/labels/labelWeekNumber.ts:13](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/labels/labelWeekNumber.ts#L13)
 
 Generates the ARIA label for the week number cell (the first cell in a row).
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/labelWeekNumberHeader.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/labelWeekNumberHeader.md
@@ -2,7 +2,7 @@
 
 > **labelWeekNumberHeader**(`_options?`): `string`
 
-Defined in: [packages/react-day-picker/src/labels/labelWeekNumberHeader.ts:12](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/labels/labelWeekNumberHeader.ts#L12)
+Defined in: [packages/react-day-picker/src/labels/labelWeekNumberHeader.ts:12](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/labels/labelWeekNumberHeader.ts#L12)
 
 Generates the ARIA label for the week number header element.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/labelWeekday.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/labelWeekday.md
@@ -2,7 +2,7 @@
 
 > **labelWeekday**(`date`, `options?`, `dateLib?`): `string`
 
-Defined in: [packages/react-day-picker/src/labels/labelWeekday.ts:14](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/labels/labelWeekday.ts#L14)
+Defined in: [packages/react-day-picker/src/labels/labelWeekday.ts:14](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/labels/labelWeekday.ts#L14)
 
 Generates the ARIA label for a weekday column header.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/labelYearDropdown.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/labelYearDropdown.md
@@ -2,7 +2,7 @@
 
 > **labelYearDropdown**(`_options?`): `string`
 
-Defined in: [packages/react-day-picker/src/labels/labelYearDropdown.ts:12](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/labels/labelYearDropdown.ts#L12)
+Defined in: [packages/react-day-picker/src/labels/labelYearDropdown.ts:12](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/labels/labelYearDropdown.ts#L12)
 
 Generates the ARIA label for the years dropdown.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/rangeContainsDayOfWeek.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/rangeContainsDayOfWeek.md
@@ -2,7 +2,7 @@
 
 > **rangeContainsDayOfWeek**(`range`, `dayOfWeek`, `dateLib?`): `boolean`
 
-Defined in: [packages/react-day-picker/src/utils/rangeContainsDayOfWeek.ts:15](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/utils/rangeContainsDayOfWeek.ts#L15)
+Defined in: [packages/react-day-picker/src/utils/rangeContainsDayOfWeek.ts:15](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/utils/rangeContainsDayOfWeek.ts#L15)
 
 Checks if a date range contains one or more specified days of the week.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/rangeContainsModifiers.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/rangeContainsModifiers.md
@@ -2,7 +2,7 @@
 
 > **rangeContainsModifiers**(`range`, `modifiers`, `dateLib?`): `boolean`
 
-Defined in: [packages/react-day-picker/src/utils/rangeContainsModifiers.ts:27](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/utils/rangeContainsModifiers.ts#L27)
+Defined in: [packages/react-day-picker/src/utils/rangeContainsModifiers.ts:27](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/utils/rangeContainsModifiers.ts#L27)
 
 Checks if a date range contains dates that match the given modifiers.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/rangeIncludesDate.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/rangeIncludesDate.md
@@ -2,7 +2,7 @@
 
 > **rangeIncludesDate**(`range`, `date`, `excludeEnds?`, `dateLib?`): `boolean`
 
-Defined in: [packages/react-day-picker/src/utils/rangeIncludesDate.ts:15](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/utils/rangeIncludesDate.ts#L15)
+Defined in: [packages/react-day-picker/src/utils/rangeIncludesDate.ts:15](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/utils/rangeIncludesDate.ts#L15)
 
 Checks if a given date is within a specified date range.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/rangeOverlaps.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/rangeOverlaps.md
@@ -2,7 +2,7 @@
 
 > **rangeOverlaps**(`rangeLeft`, `rangeRight`, `dateLib?`): `boolean`
 
-Defined in: [packages/react-day-picker/src/utils/rangeOverlaps.ts:15](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/utils/rangeOverlaps.ts#L15)
+Defined in: [packages/react-day-picker/src/utils/rangeOverlaps.ts:15](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/utils/rangeOverlaps.ts#L15)
 
 Determines if two date ranges overlap.
 

--- a/apps/website/versioned_docs/version-next/api/react/functions/useDayPicker.md
+++ b/apps/website/versioned_docs/version-next/api/react/functions/useDayPicker.md
@@ -2,7 +2,7 @@
 
 > **useDayPicker**\<`T`\>(): [`DayPickerContext`](../type-aliases/DayPickerContext.md)\<`T`\>
 
-Defined in: [packages/react-day-picker/src/useDayPicker.ts:83](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/useDayPicker.ts#L83)
+Defined in: [packages/react-day-picker/src/useDayPicker.ts:83](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/useDayPicker.ts#L83)
 
 Provides access to the DayPicker context, which includes properties and
 methods to interact with the DayPicker component. This hook must be used

--- a/apps/website/versioned_docs/version-next/api/react/index.md
+++ b/apps/website/versioned_docs/version-next/api/react/index.md
@@ -1,4 +1,4 @@
-# `@daypicker/react` v10.0.0-next.5
+# `@daypicker/react` v10.0.0-next.6
 
 ## DayPicker
 
@@ -124,64 +124,64 @@
 
 | Type Alias | Description |
 | ------ | ------ |
-| [CaptionLabelProps](type-aliases/CaptionLabelProps.md) | - |
-| [ChevronProps](type-aliases/ChevronProps.md) | - |
+| [CaptionLabelProps](type-aliases/CaptionLabelProps.md) | Props accepted by the [CaptionLabel](functions/CaptionLabel.md) component. |
+| [ChevronProps](type-aliases/ChevronProps.md) | Props accepted by the [Chevron](functions/Chevron.md) component. |
 | [ClassNames](type-aliases/ClassNames.md) | The CSS classnames to use for the [UI](enumerations/UI.md) elements, the [SelectionState](enumerations/SelectionState.md) and the [DayFlag](enumerations/DayFlag.md). |
 | [CustomComponents](type-aliases/CustomComponents.md) | The components that can be customized using the `components` prop. |
 | [DateAfter](type-aliases/DateAfter.md) | Match a day falling after the specified date (exclusive). |
 | [DateBefore](type-aliases/DateBefore.md) | Match a day falling before the specified date (exclusive). |
 | [DateInterval](type-aliases/DateInterval.md) | An interval of dates. Unlike [DateRange](type-aliases/DateRange.md), the range ends are not included. |
 | [DateRange](type-aliases/DateRange.md) | A range of dates. Unlike [DateInterval](type-aliases/DateInterval.md), the range ends are included. |
-| [DayButtonProps](type-aliases/DayButtonProps.md) | - |
+| [DayButtonProps](type-aliases/DayButtonProps.md) | Props accepted by the [DayButton](functions/DayButton.md) component. |
 | [DayEventHandler](type-aliases/DayEventHandler.md) | The event handler triggered when clicking or interacting with a day. |
 | [DayOfWeek](type-aliases/DayOfWeek.md) | Match days of the week (`0-6`, where `0` is Sunday). |
 | [DayPickerContext](type-aliases/DayPickerContext.md) | Represents the context for the DayPicker component, providing various properties and methods to interact with the calendar. |
 | [DayPickerLocaleLabels](type-aliases/DayPickerLocaleLabels.md) | Translations for DayPicker-specific labels. |
-| [DayProps](type-aliases/DayProps.md) | - |
-| [DropdownNavProps](type-aliases/DropdownNavProps.md) | - |
+| [DayProps](type-aliases/DayProps.md) | Props accepted by the [Day](functions/Day.md) component. |
+| [DropdownNavProps](type-aliases/DropdownNavProps.md) | Props accepted by the [DropdownNav](functions/DropdownNav.md) component. |
 | [DropdownOption](type-aliases/DropdownOption.md) | An option to use in the dropdown. Maps to the `<option>` HTML element. |
-| [DropdownProps](type-aliases/DropdownProps.md) | - |
-| [FooterProps](type-aliases/FooterProps.md) | - |
+| [DropdownProps](type-aliases/DropdownProps.md) | Props accepted by the [Dropdown](functions/Dropdown.md) component. |
+| [FooterProps](type-aliases/FooterProps.md) | Props accepted by the [Footer](functions/Footer.md) component. |
 | [Formatters](type-aliases/Formatters.md) | Represents a map of formatters used to render localized content. |
 | [Labels](type-aliases/Labels.md) | A map of functions to translate ARIA labels for various elements. |
-| [Locale](type-aliases/Locale.md) | - |
+| [Locale](type-aliases/Locale.md) | Alias for the locale shape accepted by DayPicker APIs. |
 | [Matcher](type-aliases/Matcher.md) | A value or a function that matches specific days. |
 | [Mode](type-aliases/Mode.md) | Selection modes supported by DayPicker. |
 | [Modifiers](type-aliases/Modifiers.md) | Represents the modifiers that match a specific day in the calendar. |
 | [ModifiersClassNames](type-aliases/ModifiersClassNames.md) | The classnames to assign to each day element matching a modifier. |
 | [ModifiersStyles](type-aliases/ModifiersStyles.md) | The style to apply to each day element matching a modifier. |
-| [MonthCaptionProps](type-aliases/MonthCaptionProps.md) | - |
+| [MonthCaptionProps](type-aliases/MonthCaptionProps.md) | Props accepted by the [MonthCaption](functions/MonthCaption.md) component. |
 | [MonthChangeEventHandler](type-aliases/MonthChangeEventHandler.md) | The event handler when a month is changed in the calendar. |
-| [MonthGridProps](type-aliases/MonthGridProps.md) | - |
-| [MonthProps](type-aliases/MonthProps.md) | - |
-| [MonthsProps](type-aliases/MonthsProps.md) | - |
+| [MonthGridProps](type-aliases/MonthGridProps.md) | Props accepted by the [MonthGrid](functions/MonthGrid.md) component. |
+| [MonthProps](type-aliases/MonthProps.md) | Props accepted by the [Month](functions/Month.md) component. |
+| [MonthsProps](type-aliases/MonthsProps.md) | Props accepted by the [Months](functions/Months.md) component. |
 | [MonthYearOrder](type-aliases/MonthYearOrder.md) | Indicates the preferred ordering of month and year for localized labels. |
 | [MoveFocusBy](type-aliases/MoveFocusBy.md) | The temporal unit to move the focus by. |
 | [MoveFocusDir](type-aliases/MoveFocusDir.md) | The direction to move the focus relative to the current focused date. |
-| [NavProps](type-aliases/NavProps.md) | - |
-| [NextMonthButtonProps](type-aliases/NextMonthButtonProps.md) | - |
+| [NavProps](type-aliases/NavProps.md) | Props accepted by the [Nav](functions/Nav.md) component. |
+| [NextMonthButtonProps](type-aliases/NextMonthButtonProps.md) | Props accepted by the [NextMonthButton](functions/NextMonthButton.md) component. |
 | [Numerals](type-aliases/Numerals.md) | The numbering system supported by DayPicker. |
 | [OnSelectHandler](type-aliases/OnSelectHandler.md) | Shared handler type for `onSelect` callback when a selection mode is set. |
-| [OptionProps](type-aliases/OptionProps.md) | - |
-| [PreviousMonthButtonProps](type-aliases/PreviousMonthButtonProps.md) | - |
-| [RootProps](type-aliases/RootProps.md) | - |
-| [SelectedMulti](type-aliases/SelectedMulti.md) | - |
-| [SelectedRange](type-aliases/SelectedRange.md) | - |
-| [SelectedSingle](type-aliases/SelectedSingle.md) | - |
+| [OptionProps](type-aliases/OptionProps.md) | Props accepted by the [Option](functions/Option.md) component. |
+| [PreviousMonthButtonProps](type-aliases/PreviousMonthButtonProps.md) | Props accepted by the [PreviousMonthButton](functions/PreviousMonthButton.md) component. |
+| [RootProps](type-aliases/RootProps.md) | Props accepted by the [Root](functions/Root.md) component. |
+| [SelectedMulti](type-aliases/SelectedMulti.md) | Selected value for multiple selection mode, respecting required selections. |
+| [SelectedRange](type-aliases/SelectedRange.md) | Selected value for range selection mode, respecting required selections. |
+| [SelectedSingle](type-aliases/SelectedSingle.md) | Selected value for single selection mode, respecting required selections. |
 | [SelectedValue](type-aliases/SelectedValue.md) | Represents the selected value based on the selection mode. |
 | [SelectHandler](type-aliases/SelectHandler.md) | The handler to set a selection based on the mode. |
-| [SelectHandlerMulti](type-aliases/SelectHandlerMulti.md) | - |
-| [SelectHandlerRange](type-aliases/SelectHandlerRange.md) | - |
-| [SelectHandlerSingle](type-aliases/SelectHandlerSingle.md) | - |
-| [Selection](type-aliases/Selection.md) | - |
-| [SelectProps](type-aliases/SelectProps.md) | - |
+| [SelectHandlerMulti](type-aliases/SelectHandlerMulti.md) | Selection handler for multiple selection mode. |
+| [SelectHandlerRange](type-aliases/SelectHandlerRange.md) | Selection handler for range selection mode. |
+| [SelectHandlerSingle](type-aliases/SelectHandlerSingle.md) | Selection handler for single selection mode. |
+| [Selection](type-aliases/Selection.md) | Selection state and helpers for the active selection mode. |
+| [SelectProps](type-aliases/SelectProps.md) | Props accepted by the [Select](functions/Select.md) component. |
 | [Styles](type-aliases/Styles.md) | The CSS styles to use for the [UI](enumerations/UI.md) elements, the [SelectionState](enumerations/SelectionState.md) and the [DayFlag](enumerations/DayFlag.md). |
-| [WeekdayProps](type-aliases/WeekdayProps.md) | - |
-| [WeekdaysProps](type-aliases/WeekdaysProps.md) | - |
-| [WeekNumberHeaderProps](type-aliases/WeekNumberHeaderProps.md) | - |
-| [WeekNumberProps](type-aliases/WeekNumberProps.md) | - |
-| [WeekProps](type-aliases/WeekProps.md) | - |
-| [WeeksProps](type-aliases/WeeksProps.md) | - |
+| [WeekdayProps](type-aliases/WeekdayProps.md) | Props accepted by the [Weekday](functions/Weekday.md) component. |
+| [WeekdaysProps](type-aliases/WeekdaysProps.md) | Props accepted by the [Weekdays](functions/Weekdays.md) component. |
+| [WeekNumberHeaderProps](type-aliases/WeekNumberHeaderProps.md) | Props accepted by the [WeekNumberHeader](functions/WeekNumberHeader.md) component. |
+| [WeekNumberProps](type-aliases/WeekNumberProps.md) | Props accepted by the [WeekNumber](functions/WeekNumber.md) component. |
+| [WeekProps](type-aliases/WeekProps.md) | Props accepted by the [Week](functions/Week.md) component. |
+| [WeeksProps](type-aliases/WeeksProps.md) | Props accepted by the [Weeks](functions/Weeks.md) component. |
 
 ## Variables
 

--- a/apps/website/versioned_docs/version-next/api/react/interfaces/DateLibOptions.md
+++ b/apps/website/versioned_docs/version-next/api/react/interfaces/DateLibOptions.md
@@ -1,6 +1,6 @@
 # Interface: DateLibOptions
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:85](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L85)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:86](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L86)
 
 The options for the `DateLib` class.
 
@@ -22,7 +22,7 @@ Extends `date-fns` [format](https://date-fns.org/docs/format),
 
 > `optional` **Date?**: `DateConstructor`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:90](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L90)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:91](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L91)
 
 A constructor for the `Date` object.
 
@@ -32,7 +32,7 @@ A constructor for the `Date` object.
 
 > `optional` **locale?**: [`DayPickerLocale`](DayPickerLocale.md)
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:92](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L92)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:93](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L93)
 
 A locale to use for formatting dates.
 
@@ -46,7 +46,7 @@ A locale to use for formatting dates.
 
 > `optional` **numerals?**: [`Numerals`](../type-aliases/Numerals.md)
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:104](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L104)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:105](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L105)
 
 The numbering system to use for formatting numbers.
 
@@ -60,7 +60,7 @@ The numbering system to use for formatting numbers.
 
 > `optional` **timeZone?**: `string`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:98](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L98)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:99](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L99)
 
 A time zone to use for dates.
 

--- a/apps/website/versioned_docs/version-next/api/react/interfaces/DayPickerLocale.md
+++ b/apps/website/versioned_docs/version-next/api/react/interfaces/DayPickerLocale.md
@@ -1,6 +1,6 @@
 # Interface: DayPickerLocale
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:67](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L67)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:67](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L67)
 
 Locale type used by DayPicker.
 
@@ -18,6 +18,6 @@ V9.12.0
 
 > `optional` **labels?**: [`DayPickerLocaleLabels`](../type-aliases/DayPickerLocaleLabels.md)
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:69](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L69)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:69](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L69)
 
 Localized DayPicker-specific labels.

--- a/apps/website/versioned_docs/version-next/api/react/interfaces/PropsBase.md
+++ b/apps/website/versioned_docs/version-next/api/react/interfaces/PropsBase.md
@@ -1,6 +1,6 @@
 # Interface: PropsBase
 
-Defined in: [packages/react-day-picker/src/types/props.ts:44](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L44)
+Defined in: [packages/react-day-picker/src/types/props.ts:44](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L44)
 
 Props for customizing the calendar, handling localization, and managing
 events. These exclude the selection mode props.
@@ -15,7 +15,7 @@ https://daypicker.dev/next/api/interfaces/PropsBase
 
 > `optional` **animate?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:235](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L235)
+Defined in: [packages/react-day-picker/src/types/props.ts:235](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L235)
 
 Animate navigating between months.
 
@@ -33,7 +33,7 @@ https://daypicker.dev/docs/navigation#animate
 
 > `optional` **aria-label?**: `string`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:362](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L362)
+Defined in: [packages/react-day-picker/src/types/props.ts:362](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L362)
 
 The aria-label attribute to add to the container element.
 
@@ -51,7 +51,7 @@ https://daypicker.dev/guides/accessibility
 
 > `optional` **aria-labelledby?**: `string`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:369](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L369)
+Defined in: [packages/react-day-picker/src/types/props.ts:369](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L369)
 
 The aria-labelledby attribute to add to the container element.
 
@@ -69,7 +69,7 @@ https://daypicker.dev/guides/accessibility
 
 > `optional` **autoFocus?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:300](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L300)
+Defined in: [packages/react-day-picker/src/types/props.ts:300](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L300)
 
 When a selection mode is set, DayPicker will focus the first selected day
 (if set) or today's date (if not disabled).
@@ -87,7 +87,7 @@ https://daypicker.dev/guides/accessibility#autofocus
 
 > `optional` **broadcastCalendar?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:245](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L245)
+Defined in: [packages/react-day-picker/src/types/props.ts:245](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L245)
 
 Display the weeks in the month following the broadcast calendar. Setting
 this prop will ignore [weekStartsOn](#weekstartson) (always Monday) and
@@ -108,7 +108,7 @@ this prop will ignore [weekStartsOn](#weekstartson) (always Monday) and
 
 > `optional` **captionLayout?**: `"dropdown"` \| `"label"` \| `"dropdown-months"` \| `"dropdown-years"`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:175](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L175)
+Defined in: [packages/react-day-picker/src/types/props.ts:175](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L175)
 
 Show dropdowns to navigate between months or years.
 
@@ -132,7 +132,7 @@ https://daypicker.dev/docs/customization#caption-layouts
 
 > `optional` **className?**: `string`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:59](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L59)
+Defined in: [packages/react-day-picker/src/types/props.ts:59](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L59)
 
 Class name to add to the root element.
 
@@ -142,7 +142,7 @@ Class name to add to the root element.
 
 > `optional` **classNames?**: `Partial`\<[`ClassNames`](../type-aliases/ClassNames.md)\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:69](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L69)
+Defined in: [packages/react-day-picker/src/types/props.ts:69](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L69)
 
 Change the class names used by DayPicker.
 
@@ -160,7 +160,7 @@ https://daypicker.dev/docs/styling
 
 > `optional` **components?**: `Partial`\<[`CustomComponents`](../type-aliases/CustomComponents.md)\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:281](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L281)
+Defined in: [packages/react-day-picker/src/types/props.ts:281](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L281)
 
 Change the components used for rendering the calendar elements.
 
@@ -174,7 +174,7 @@ https://daypicker.dev/guides/custom-components
 
 > `optional` **dateLib?**: `Partial`\<[`DateLib`](../classes/DateLib.md)\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:491](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L491)
+Defined in: [packages/react-day-picker/src/types/props.ts:491](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L491)
 
 **`Experimental`**
 
@@ -191,7 +191,7 @@ guaranteed to be stable (may not respect semver).
 
 > `optional` **defaultMonth?**: `Date`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:101](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L101)
+Defined in: [packages/react-day-picker/src/types/props.ts:101](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L101)
 
 The initial month to show in the calendar.
 
@@ -214,7 +214,7 @@ https://daypicker.dev/docs/navigation
 
 > `optional` **dir?**: `string`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:355](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L355)
+Defined in: [packages/react-day-picker/src/types/props.ts:355](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L355)
 
 The text direction of the calendar. Use `ltr` for left-to-right (default)
 or `rtl` for right-to-left.
@@ -229,7 +229,7 @@ https://daypicker.dev/docs/translation#rtl-text-direction
 
 > `optional` **disabled?**: [`Matcher`](../type-aliases/Matcher.md) \| [`Matcher`](../type-aliases/Matcher.md)[]
 
-Defined in: [packages/react-day-picker/src/types/props.ts:307](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L307)
+Defined in: [packages/react-day-picker/src/types/props.ts:307](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L307)
 
 Apply the `disabled` modifier to the matching days. Disabled days cannot be
 selected when in a selection mode is set.
@@ -244,7 +244,7 @@ https://daypicker.dev/docs/selection-modes#disabled
 
 > `optional` **disableNavigation?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:159](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L159)
+Defined in: [packages/react-day-picker/src/types/props.ts:159](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L159)
 
 Disable the navigation between months. This prop won't hide the navigation:
 to hide the navigation, use [hideNavigation](#hidenavigation).
@@ -259,7 +259,7 @@ https://daypicker.dev/docs/navigation#disablenavigation
 
 > `optional` **endMonth?**: `Date`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:131](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L131)
+Defined in: [packages/react-day-picker/src/types/props.ts:131](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L131)
 
 The latest month to end the month navigation.
 
@@ -277,7 +277,7 @@ https://daypicker.dev/docs/navigation#start-and-end-dates
 
 > `optional` **firstWeekContainsDate?**: `4` \| `1`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:436](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L436)
+Defined in: [packages/react-day-picker/src/types/props.ts:436](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L436)
 
 The day of January that is always in the first week of the year.
 
@@ -291,7 +291,7 @@ https://daypicker.dev/docs/localization#first-week-contains-date
 
 > `optional` **fixedWeeks?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:206](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L206)
+Defined in: [packages/react-day-picker/src/types/props.ts:206](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L206)
 
 Display always 6 weeks per each month, regardless of the month’s number of
 weeks. Weeks will be filled with the days from the next month.
@@ -306,7 +306,7 @@ https://daypicker.dev/docs/customization#fixed-weeks
 
 > `optional` **footer?**: `ReactNode`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:290](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L290)
+Defined in: [packages/react-day-picker/src/types/props.ts:290](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L290)
 
 Add a footer to the calendar, acting as a live region.
 
@@ -323,7 +323,7 @@ https://daypicker.dev/guides/accessibility#footer
 
 > `optional` **formatters?**: `Partial`\<[`Formatters`](../type-aliases/Formatters.md)\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:348](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L348)
+Defined in: [packages/react-day-picker/src/types/props.ts:348](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L348)
 
 Formatters used to format dates to strings. Use this prop to override the
 default functions.
@@ -338,7 +338,7 @@ https://daypicker.dev/docs/translation#custom-formatters
 
 > `optional` **hidden?**: [`Matcher`](../type-aliases/Matcher.md) \| [`Matcher`](../type-aliases/Matcher.md)[]
 
-Defined in: [packages/react-day-picker/src/types/props.ts:314](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L314)
+Defined in: [packages/react-day-picker/src/types/props.ts:314](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L314)
 
 Apply the `hidden` modifier to the matching days. Will hide them from the
 calendar.
@@ -353,7 +353,7 @@ https://daypicker.dev/guides/custom-modifiers#hidden-modifier
 
 > `optional` **hideNavigation?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:152](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L152)
+Defined in: [packages/react-day-picker/src/types/props.ts:152](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L152)
 
 Hide the navigation buttons. This prop won't disable the navigation: to
 disable the navigation, use [disableNavigation](#disablenavigation).
@@ -372,7 +372,7 @@ https://daypicker.dev/docs/navigation#hidenavigation
 
 > `optional` **hideWeekdays?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:212](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L212)
+Defined in: [packages/react-day-picker/src/types/props.ts:212](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L212)
 
 Hide the row displaying the weekday row header.
 
@@ -386,7 +386,7 @@ Hide the row displaying the weekday row header.
 
 > `optional` **id?**: `string`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:91](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L91)
+Defined in: [packages/react-day-picker/src/types/props.ts:91](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L91)
 
 A unique id to add to the root element.
 
@@ -396,7 +396,7 @@ A unique id to add to the root element.
 
 > `optional` **ISOWeek?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:253](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L253)
+Defined in: [packages/react-day-picker/src/types/props.ts:253](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L253)
 
 Use ISO week dates instead of the locale setting. Setting this prop will
 ignore `weekStartsOn` and `firstWeekContainsDate`.
@@ -412,7 +412,7 @@ ignore `weekStartsOn` and `firstWeekContainsDate`.
 
 > `optional` **labels?**: `Partial`\<[`Labels`](../type-aliases/Labels.md)\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:341](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L341)
+Defined in: [packages/react-day-picker/src/types/props.ts:341](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L341)
 
 Labels creators to override the defaults. Use this prop to customize the
 aria-label attributes in DayPicker.
@@ -427,7 +427,7 @@ https://daypicker.dev/docs/translation#aria-labels
 
 > `optional` **lang?**: `string`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:390](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L390)
+Defined in: [packages/react-day-picker/src/types/props.ts:390](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L390)
 
 Add the language tag to the container element.
 
@@ -440,7 +440,7 @@ this prop to override the language tag.
 
 > `optional` **locale?**: `Partial`\<[`DayPickerLocale`](DayPickerLocale.md)\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:403](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L403)
+Defined in: [packages/react-day-picker/src/types/props.ts:403](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L403)
 
 The locale object used to localize dates. Pass a locale from
 `react-day-picker/locale` to localize the calendar.
@@ -467,7 +467,7 @@ enUS - The English locale default of `date-fns`.
 
 > `optional` **mode?**: [`Mode`](../type-aliases/Mode.md)
 
-Defined in: [packages/react-day-picker/src/types/props.ts:50](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L50)
+Defined in: [packages/react-day-picker/src/types/props.ts:50](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L50)
 
 Enable the selection of a single day, multiple days, or a range of days.
 
@@ -481,7 +481,7 @@ https://daypicker.dev/docs/selection-modes
 
 > `optional` **modifiers?**: `Record`\<`string`, [`Matcher`](../type-aliases/Matcher.md) \| [`Matcher`](../type-aliases/Matcher.md)[] \| `undefined`\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:334](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L334)
+Defined in: [packages/react-day-picker/src/types/props.ts:334](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L334)
 
 Add modifiers to the matching days.
 
@@ -505,7 +505,7 @@ https://daypicker.dev/guides/custom-modifiers
 
 > `optional` **modifiersClassNames?**: [`ModifiersClassNames`](../type-aliases/ModifiersClassNames.md)
 
-Defined in: [packages/react-day-picker/src/types/props.ts:75](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L75)
+Defined in: [packages/react-day-picker/src/types/props.ts:75](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L75)
 
 Change the class name for the day matching the `modifiers`.
 
@@ -519,7 +519,7 @@ https://daypicker.dev/guides/custom-modifiers
 
 > `optional` **modifiersStyles?**: [`ModifiersStyles`](../type-aliases/ModifiersStyles.md)
 
-Defined in: [packages/react-day-picker/src/types/props.ts:89](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L89)
+Defined in: [packages/react-day-picker/src/types/props.ts:89](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L89)
 
 Change the class name for the day matching the [modifiers](#modifiers).
 
@@ -533,7 +533,7 @@ https://daypicker.dev/guides/custom-modifiers
 
 > `optional` **month?**: `Date`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:110](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L110)
+Defined in: [packages/react-day-picker/src/types/props.ts:110](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L110)
 
 The month displayed in the calendar.
 
@@ -550,7 +550,7 @@ https://daypicker.dev/docs/navigation
 
 > `optional` **navLayout?**: `"after"` \| `"around"`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:199](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L199)
+Defined in: [packages/react-day-picker/src/types/props.ts:199](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L199)
 
 Adjust the positioning of the navigation buttons.
 
@@ -575,7 +575,7 @@ https://daypicker.dev/docs/customization#navigation-layouts
 
 > `optional` **nonce?**: `string`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:381](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L381)
+Defined in: [packages/react-day-picker/src/types/props.ts:381](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L381)
 
 A cryptographic nonce ("number used once") which can be used by Content
 Security Policy for the inline `style` attributes.
@@ -586,7 +586,7 @@ Security Policy for the inline `style` attributes.
 
 > `optional` **noonSafe?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:275](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L275)
+Defined in: [packages/react-day-picker/src/types/props.ts:275](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L275)
 
 **`Experimental`**
 
@@ -609,7 +609,7 @@ https://daypicker.dev/localization/setting-time-zone#noonsafe
 
 > `optional` **numberOfMonths?**: `number`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:117](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L117)
+Defined in: [packages/react-day-picker/src/types/props.ts:117](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L117)
 
 The number of displayed months.
 
@@ -629,7 +629,7 @@ https://daypicker.dev/docs/customization#multiplemonths
 
 > `optional` **numerals?**: [`Numerals`](../type-aliases/Numerals.md)
 
-Defined in: [packages/react-day-picker/src/types/props.ts:423](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L423)
+Defined in: [packages/react-day-picker/src/types/props.ts:423](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L423)
 
 The numeral system to use when formatting dates.
 
@@ -660,7 +660,7 @@ https://daypicker.dev/docs/translation#numeral-systems
 
 > `optional` **onDayBlur?**: [`DayEventHandler`](../type-aliases/DayEventHandler.md)\<`FocusEvent`\<`Element`, `Element`\>\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:476](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L476)
+Defined in: [packages/react-day-picker/src/types/props.ts:476](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L476)
 
 Event handler when a day is blurred.
 
@@ -670,7 +670,7 @@ Event handler when a day is blurred.
 
 > `optional` **onDayClick?**: [`DayEventHandler`](../type-aliases/DayEventHandler.md)\<`MouseEvent`\<`Element`, `MouseEvent`\>\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:472](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L472)
+Defined in: [packages/react-day-picker/src/types/props.ts:472](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L472)
 
 Event handler when a day is clicked.
 
@@ -680,7 +680,7 @@ Event handler when a day is clicked.
 
 > `optional` **onDayFocus?**: [`DayEventHandler`](../type-aliases/DayEventHandler.md)\<`FocusEvent`\<`Element`, `Element`\>\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:474](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L474)
+Defined in: [packages/react-day-picker/src/types/props.ts:474](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L474)
 
 Event handler when a day is focused.
 
@@ -690,7 +690,7 @@ Event handler when a day is focused.
 
 > `optional` **onDayKeyDown?**: [`DayEventHandler`](../type-aliases/DayEventHandler.md)\<`KeyboardEvent`\<`Element`\>\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:478](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L478)
+Defined in: [packages/react-day-picker/src/types/props.ts:478](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L478)
 
 Event handler when a key is pressed on a day.
 
@@ -700,7 +700,7 @@ Event handler when a key is pressed on a day.
 
 > `optional` **onDayMouseEnter?**: [`DayEventHandler`](../type-aliases/DayEventHandler.md)\<`MouseEvent`\<`Element`, `MouseEvent`\>\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:480](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L480)
+Defined in: [packages/react-day-picker/src/types/props.ts:480](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L480)
 
 Event handler when the mouse enters a day.
 
@@ -710,7 +710,7 @@ Event handler when the mouse enters a day.
 
 > `optional` **onDayMouseLeave?**: [`DayEventHandler`](../type-aliases/DayEventHandler.md)\<`MouseEvent`\<`Element`, `MouseEvent`\>\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:482](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L482)
+Defined in: [packages/react-day-picker/src/types/props.ts:482](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L482)
 
 Event handler when the mouse leaves a day.
 
@@ -720,7 +720,7 @@ Event handler when the mouse leaves a day.
 
 > `optional` **onMonthChange?**: [`MonthChangeEventHandler`](../type-aliases/MonthChangeEventHandler.md)
 
-Defined in: [packages/react-day-picker/src/types/props.ts:457](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L457)
+Defined in: [packages/react-day-picker/src/types/props.ts:457](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L457)
 
 Event fired when the user navigates between months.
 
@@ -734,7 +734,7 @@ https://daypicker.dev/docs/navigation#onmonthchange
 
 > `optional` **onNextClick?**: [`MonthChangeEventHandler`](../type-aliases/MonthChangeEventHandler.md)
 
-Defined in: [packages/react-day-picker/src/types/props.ts:464](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L464)
+Defined in: [packages/react-day-picker/src/types/props.ts:464](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L464)
 
 Event handler when the next month button is clicked.
 
@@ -748,7 +748,7 @@ https://daypicker.dev/docs/navigation
 
 > `optional` **onPrevClick?**: [`MonthChangeEventHandler`](../type-aliases/MonthChangeEventHandler.md)
 
-Defined in: [packages/react-day-picker/src/types/props.ts:470](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L470)
+Defined in: [packages/react-day-picker/src/types/props.ts:470](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L470)
 
 Event handler when the previous month button is clicked.
 
@@ -762,7 +762,7 @@ https://daypicker.dev/docs/navigation
 
 > `optional` **pagedNavigation?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:137](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L137)
+Defined in: [packages/react-day-picker/src/types/props.ts:137](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L137)
 
 Paginate the month navigation displaying the `numberOfMonths` at a time.
 
@@ -776,7 +776,7 @@ https://daypicker.dev/docs/customization#multiplemonths
 
 > `optional` **required?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:56](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L56)
+Defined in: [packages/react-day-picker/src/types/props.ts:56](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L56)
 
 Whether the selection is required.
 
@@ -790,7 +790,7 @@ https://daypicker.dev/docs/selection-modes
 
 > `optional` **reverseMonths?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:144](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L144)
+Defined in: [packages/react-day-picker/src/types/props.ts:144](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L144)
 
 Render the months in reversed order (when [numberOfMonths](#numberofmonths) is set) to
 display the most recent month first.
@@ -805,7 +805,7 @@ https://daypicker.dev/docs/customization#multiplemonths
 
 > `optional` **reverseYears?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:184](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L184)
+Defined in: [packages/react-day-picker/src/types/props.ts:184](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L184)
 
 Reverse the order of years in the dropdown when using
 `captionLayout="dropdown"` or `captionLayout="dropdown-years"`.
@@ -824,7 +824,7 @@ https://daypicker.dev/docs/customization#caption-layouts
 
 > `optional` **role?**: `"application"` \| `"dialog"`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:376](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L376)
+Defined in: [packages/react-day-picker/src/types/props.ts:376](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L376)
 
 The role attribute to add to the container element.
 
@@ -842,7 +842,7 @@ https://daypicker.dev/guides/accessibility
 
 > `optional` **showOutsideDays?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:221](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L221)
+Defined in: [packages/react-day-picker/src/types/props.ts:221](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L221)
 
 Show the outside days (days falling in the next or the previous month).
 
@@ -859,7 +859,7 @@ https://daypicker.dev/docs/customization#outside-days
 
 > `optional` **showWeekNumber?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:228](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L228)
+Defined in: [packages/react-day-picker/src/types/props.ts:228](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L228)
 
 Show the week numbers column. Weeks are numbered according to the local
 week index.
@@ -874,7 +874,7 @@ https://daypicker.dev/docs/customization#showweeknumber
 
 > `optional` **startMonth?**: `Date`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:124](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L124)
+Defined in: [packages/react-day-picker/src/types/props.ts:124](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L124)
 
 The earliest month to start the month navigation.
 
@@ -892,7 +892,7 @@ https://daypicker.dev/docs/navigation#start-and-end-dates
 
 > `optional` **style?**: `CSSProperties`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:77](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L77)
+Defined in: [packages/react-day-picker/src/types/props.ts:77](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L77)
 
 Style to apply to the root element.
 
@@ -902,7 +902,7 @@ Style to apply to the root element.
 
 > `optional` **styles?**: `Partial`\<[`Styles`](../type-aliases/Styles.md)\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:83](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L83)
+Defined in: [packages/react-day-picker/src/types/props.ts:83](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L83)
 
 Change the inline styles of the HTML elements.
 
@@ -916,7 +916,7 @@ https://daypicker.dev/docs/styling
 
 > `optional` **timeZone?**: `string`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:264](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L264)
+Defined in: [packages/react-day-picker/src/types/props.ts:264](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L264)
 
 The time zone (IANA or UTC offset) to use in the calendar (experimental).
 
@@ -938,7 +938,7 @@ https://daypicker.dev/localization/setting-time-zone
 
 > `optional` **title?**: `string`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:383](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L383)
+Defined in: [packages/react-day-picker/src/types/props.ts:383](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L383)
 
 Add a `title` attribute to the container element.
 
@@ -948,7 +948,7 @@ Add a `title` attribute to the container element.
 
 > `optional` **today?**: `Date`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:321](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L321)
+Defined in: [packages/react-day-picker/src/types/props.ts:321](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L321)
 
 The today’s date. Default is the current date. This date will get the
 `today` modifier to style the day.
@@ -963,7 +963,7 @@ https://daypicker.dev/guides/custom-modifiers#today-modifier
 
 > `optional` **useAdditionalDayOfYearTokens?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:450](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L450)
+Defined in: [packages/react-day-picker/src/types/props.ts:450](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L450)
 
 Enable `YY` and `YYYY` for day of year tokens when formatting or parsing
 dates.
@@ -978,7 +978,7 @@ https://date-fns.org/docs/Unicode-Tokens
 
 > `optional` **useAdditionalWeekYearTokens?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:443](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L443)
+Defined in: [packages/react-day-picker/src/types/props.ts:443](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L443)
 
 Enable `DD` and `DDDD` for week year tokens when formatting or parsing
 dates.
@@ -993,7 +993,7 @@ https://date-fns.org/docs/Unicode-Tokens
 
 > `optional` **weekStartsOn?**: `0` \| `5` \| `4` \| `1` \| `6` \| `2` \| `3`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:430](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L430)
+Defined in: [packages/react-day-picker/src/types/props.ts:430](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L430)
 
 The index of the first day of the week (0 - Sunday). Overrides the locale's
 default.

--- a/apps/website/versioned_docs/version-next/api/react/interfaces/PropsMulti.md
+++ b/apps/website/versioned_docs/version-next/api/react/interfaces/PropsMulti.md
@@ -1,6 +1,6 @@
 # Interface: PropsMulti
 
-Defined in: [packages/react-day-picker/src/types/props.ts:578](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L578)
+Defined in: [packages/react-day-picker/src/types/props.ts:578](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L578)
 
 The props when the multiple selection is optional.
 
@@ -14,7 +14,7 @@ https://daypicker.dev/docs/selection-modes#multiple-mode
 
 > `optional` **max?**: `number`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:588](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L588)
+Defined in: [packages/react-day-picker/src/types/props.ts:588](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L588)
 
 The maximum number of selectable days.
 
@@ -24,7 +24,7 @@ The maximum number of selectable days.
 
 > `optional` **min?**: `number`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:586](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L586)
+Defined in: [packages/react-day-picker/src/types/props.ts:586](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L586)
 
 The minimum number of selectable days.
 
@@ -34,7 +34,7 @@ The minimum number of selectable days.
 
 > **mode**: `"multiple"`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:579](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L579)
+Defined in: [packages/react-day-picker/src/types/props.ts:579](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L579)
 
 ***
 
@@ -42,7 +42,7 @@ Defined in: [packages/react-day-picker/src/types/props.ts:579](https://github.co
 
 > `optional` **onSelect?**: [`OnSelectHandler`](../type-aliases/OnSelectHandler.md)\<`Date`[] \| `undefined`\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:584](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L584)
+Defined in: [packages/react-day-picker/src/types/props.ts:584](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L584)
 
 Event handler when days are selected.
 
@@ -52,7 +52,7 @@ Event handler when days are selected.
 
 > `optional` **required?**: `false`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:580](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L580)
+Defined in: [packages/react-day-picker/src/types/props.ts:580](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L580)
 
 ***
 
@@ -60,6 +60,6 @@ Defined in: [packages/react-day-picker/src/types/props.ts:580](https://github.co
 
 > `optional` **selected?**: `Date`[]
 
-Defined in: [packages/react-day-picker/src/types/props.ts:582](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L582)
+Defined in: [packages/react-day-picker/src/types/props.ts:582](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L582)
 
 The selected dates.

--- a/apps/website/versioned_docs/version-next/api/react/interfaces/PropsMultiRequired.md
+++ b/apps/website/versioned_docs/version-next/api/react/interfaces/PropsMultiRequired.md
@@ -1,6 +1,6 @@
 # Interface: PropsMultiRequired
 
-Defined in: [packages/react-day-picker/src/types/props.ts:559](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L559)
+Defined in: [packages/react-day-picker/src/types/props.ts:559](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L559)
 
 The props when the multiple selection is required.
 
@@ -14,7 +14,7 @@ https://daypicker.dev/docs/selection-modes#multiple-mode
 
 > `optional` **max?**: `number`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:569](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L569)
+Defined in: [packages/react-day-picker/src/types/props.ts:569](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L569)
 
 The maximum number of selectable days.
 
@@ -24,7 +24,7 @@ The maximum number of selectable days.
 
 > `optional` **min?**: `number`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:567](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L567)
+Defined in: [packages/react-day-picker/src/types/props.ts:567](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L567)
 
 The minimum number of selectable days.
 
@@ -34,7 +34,7 @@ The minimum number of selectable days.
 
 > **mode**: `"multiple"`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:560](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L560)
+Defined in: [packages/react-day-picker/src/types/props.ts:560](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L560)
 
 ***
 
@@ -42,7 +42,7 @@ Defined in: [packages/react-day-picker/src/types/props.ts:560](https://github.co
 
 > `optional` **onSelect?**: [`OnSelectHandler`](../type-aliases/OnSelectHandler.md)\<`Date`[]\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:565](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L565)
+Defined in: [packages/react-day-picker/src/types/props.ts:565](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L565)
 
 Event handler when days are selected.
 
@@ -52,7 +52,7 @@ Event handler when days are selected.
 
 > **required**: `true`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:561](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L561)
+Defined in: [packages/react-day-picker/src/types/props.ts:561](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L561)
 
 ***
 
@@ -60,6 +60,6 @@ Defined in: [packages/react-day-picker/src/types/props.ts:561](https://github.co
 
 > **selected**: `Date`[] \| `undefined`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:563](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L563)
+Defined in: [packages/react-day-picker/src/types/props.ts:563](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L563)
 
 The selected dates.

--- a/apps/website/versioned_docs/version-next/api/react/interfaces/PropsRange.md
+++ b/apps/website/versioned_docs/version-next/api/react/interfaces/PropsRange.md
@@ -1,6 +1,6 @@
 # Interface: PropsRange
 
-Defined in: [packages/react-day-picker/src/types/props.ts:636](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L636)
+Defined in: [packages/react-day-picker/src/types/props.ts:636](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L636)
 
 The props when the range selection is optional.
 
@@ -14,7 +14,7 @@ https://daypicker.dev/docs/selection-modes#range-mode
 
 > `optional` **disabled?**: [`Matcher`](../type-aliases/Matcher.md) \| [`Matcher`](../type-aliases/Matcher.md)[]
 
-Defined in: [packages/react-day-picker/src/types/props.ts:645](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L645)
+Defined in: [packages/react-day-picker/src/types/props.ts:645](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L645)
 
 Apply the `disabled` modifier to the matching days. Disabled days cannot be
 selected when in a selection mode is set.
@@ -29,7 +29,7 @@ https://daypicker.dev/docs/selection-modes#disabled
 
 > `optional` **excludeDisabled?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:652](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L652)
+Defined in: [packages/react-day-picker/src/types/props.ts:652](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L652)
 
 When `true`, the range will reset when including a disabled day.
 
@@ -47,7 +47,7 @@ https://daypicker.dev/docs/selection-modes#exclude-disabled
 
 > `optional` **max?**: `number`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:670](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L670)
+Defined in: [packages/react-day-picker/src/types/props.ts:670](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L670)
 
 The maximum number of days to include in the range.
 
@@ -57,7 +57,7 @@ The maximum number of days to include in the range.
 
 > `optional` **min?**: `number`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:668](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L668)
+Defined in: [packages/react-day-picker/src/types/props.ts:668](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L668)
 
 The minimum number of days to include in the range.
 
@@ -67,7 +67,7 @@ The minimum number of days to include in the range.
 
 > **mode**: `"range"`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:637](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L637)
+Defined in: [packages/react-day-picker/src/types/props.ts:637](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L637)
 
 ***
 
@@ -75,7 +75,7 @@ Defined in: [packages/react-day-picker/src/types/props.ts:637](https://github.co
 
 > `optional` **onSelect?**: [`OnSelectHandler`](../type-aliases/OnSelectHandler.md)\<[`DateRange`](../type-aliases/DateRange.md) \| `undefined`\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:666](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L666)
+Defined in: [packages/react-day-picker/src/types/props.ts:666](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L666)
 
 Event handler when the selection changes.
 
@@ -85,7 +85,7 @@ Event handler when the selection changes.
 
 > `optional` **required?**: `false`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:638](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L638)
+Defined in: [packages/react-day-picker/src/types/props.ts:638](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L638)
 
 ***
 
@@ -93,7 +93,7 @@ Defined in: [packages/react-day-picker/src/types/props.ts:638](https://github.co
 
 > `optional` **resetOnSelect?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:662](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L662)
+Defined in: [packages/react-day-picker/src/types/props.ts:662](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L662)
 
 When `true`, clicking a day starts a new range if there is no current start
 date or if a range is already complete. In those cases, the clicked day
@@ -114,6 +114,6 @@ https://daypicker.dev/selections/range-mode#reset-selection
 
 > `optional` **selected?**: [`DateRange`](../type-aliases/DateRange.md)
 
-Defined in: [packages/react-day-picker/src/types/props.ts:664](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L664)
+Defined in: [packages/react-day-picker/src/types/props.ts:664](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L664)
 
 The selected range.

--- a/apps/website/versioned_docs/version-next/api/react/interfaces/PropsRangeRequired.md
+++ b/apps/website/versioned_docs/version-next/api/react/interfaces/PropsRangeRequired.md
@@ -1,6 +1,6 @@
 # Interface: PropsRangeRequired
 
-Defined in: [packages/react-day-picker/src/types/props.ts:596](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L596)
+Defined in: [packages/react-day-picker/src/types/props.ts:596](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L596)
 
 The props when the range selection is required.
 
@@ -14,7 +14,7 @@ https://daypicker.dev/docs/selection-modes#range-mode
 
 > `optional` **disabled?**: [`Matcher`](../type-aliases/Matcher.md) \| [`Matcher`](../type-aliases/Matcher.md)[]
 
-Defined in: [packages/react-day-picker/src/types/props.ts:605](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L605)
+Defined in: [packages/react-day-picker/src/types/props.ts:605](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L605)
 
 Apply the `disabled` modifier to the matching days. Disabled days cannot be
 selected when in a selection mode is set.
@@ -29,7 +29,7 @@ https://daypicker.dev/docs/selection-modes#disabled
 
 > `optional` **excludeDisabled?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:611](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L611)
+Defined in: [packages/react-day-picker/src/types/props.ts:611](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L611)
 
 When `true`, the range will reset when including a disabled day.
 
@@ -43,7 +43,7 @@ When `true`, the range will reset when including a disabled day.
 
 > `optional` **max?**: `number`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:628](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L628)
+Defined in: [packages/react-day-picker/src/types/props.ts:628](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L628)
 
 The maximum number of days to include in the range.
 
@@ -53,7 +53,7 @@ The maximum number of days to include in the range.
 
 > `optional` **min?**: `number`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:626](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L626)
+Defined in: [packages/react-day-picker/src/types/props.ts:626](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L626)
 
 The minimum number of days to include in the range.
 
@@ -63,7 +63,7 @@ The minimum number of days to include in the range.
 
 > **mode**: `"range"`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:597](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L597)
+Defined in: [packages/react-day-picker/src/types/props.ts:597](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L597)
 
 ***
 
@@ -71,7 +71,7 @@ Defined in: [packages/react-day-picker/src/types/props.ts:597](https://github.co
 
 > `optional` **onSelect?**: [`OnSelectHandler`](../type-aliases/OnSelectHandler.md)\<[`DateRange`](../type-aliases/DateRange.md)\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:624](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L624)
+Defined in: [packages/react-day-picker/src/types/props.ts:624](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L624)
 
 Event handler when a range is selected.
 
@@ -81,7 +81,7 @@ Event handler when a range is selected.
 
 > **required**: `true`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:598](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L598)
+Defined in: [packages/react-day-picker/src/types/props.ts:598](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L598)
 
 ***
 
@@ -89,7 +89,7 @@ Defined in: [packages/react-day-picker/src/types/props.ts:598](https://github.co
 
 > `optional` **resetOnSelect?**: `boolean`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:620](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L620)
+Defined in: [packages/react-day-picker/src/types/props.ts:620](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L620)
 
 When `true`, clicking a day starts a new range if there is no current start
 date or if a range is already complete. In those cases, the clicked day
@@ -109,6 +109,6 @@ https://daypicker.dev/selections/range-mode#reset-selection
 
 > **selected**: [`DateRange`](../type-aliases/DateRange.md) \| `undefined`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:622](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L622)
+Defined in: [packages/react-day-picker/src/types/props.ts:622](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L622)
 
 The selected range.

--- a/apps/website/versioned_docs/version-next/api/react/interfaces/PropsSingle.md
+++ b/apps/website/versioned_docs/version-next/api/react/interfaces/PropsSingle.md
@@ -1,6 +1,6 @@
 # Interface: PropsSingle
 
-Defined in: [packages/react-day-picker/src/types/props.ts:544](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L544)
+Defined in: [packages/react-day-picker/src/types/props.ts:544](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L544)
 
 The props when the single selection is optional.
 
@@ -14,7 +14,7 @@ https://daypicker.dev/docs/selection-modes#single-mode
 
 > **mode**: `"single"`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:545](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L545)
+Defined in: [packages/react-day-picker/src/types/props.ts:545](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L545)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [packages/react-day-picker/src/types/props.ts:545](https://github.co
 
 > `optional` **onSelect?**: [`OnSelectHandler`](../type-aliases/OnSelectHandler.md)\<`Date` \| `undefined`\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:550](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L550)
+Defined in: [packages/react-day-picker/src/types/props.ts:550](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L550)
 
 Event handler when a day is selected.
 
@@ -32,7 +32,7 @@ Event handler when a day is selected.
 
 > `optional` **required?**: `false`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:546](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L546)
+Defined in: [packages/react-day-picker/src/types/props.ts:546](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L546)
 
 ***
 
@@ -40,6 +40,6 @@ Defined in: [packages/react-day-picker/src/types/props.ts:546](https://github.co
 
 > `optional` **selected?**: `Date`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:548](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L548)
+Defined in: [packages/react-day-picker/src/types/props.ts:548](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L548)
 
 The selected date.

--- a/apps/website/versioned_docs/version-next/api/react/interfaces/PropsSingleRequired.md
+++ b/apps/website/versioned_docs/version-next/api/react/interfaces/PropsSingleRequired.md
@@ -1,6 +1,6 @@
 # Interface: PropsSingleRequired
 
-Defined in: [packages/react-day-picker/src/types/props.ts:529](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L529)
+Defined in: [packages/react-day-picker/src/types/props.ts:529](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L529)
 
 The props when the single selection is required.
 
@@ -14,7 +14,7 @@ https://daypicker.dev/docs/selection-modes#single-mode
 
 > **mode**: `"single"`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:530](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L530)
+Defined in: [packages/react-day-picker/src/types/props.ts:530](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L530)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [packages/react-day-picker/src/types/props.ts:530](https://github.co
 
 > `optional` **onSelect?**: [`OnSelectHandler`](../type-aliases/OnSelectHandler.md)\<`Date`\>
 
-Defined in: [packages/react-day-picker/src/types/props.ts:535](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L535)
+Defined in: [packages/react-day-picker/src/types/props.ts:535](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L535)
 
 Event handler when a day is selected.
 
@@ -32,7 +32,7 @@ Event handler when a day is selected.
 
 > **required**: `true`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:531](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L531)
+Defined in: [packages/react-day-picker/src/types/props.ts:531](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L531)
 
 ***
 
@@ -40,6 +40,6 @@ Defined in: [packages/react-day-picker/src/types/props.ts:531](https://github.co
 
 > **selected**: `Date` \| `undefined`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:533](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L533)
+Defined in: [packages/react-day-picker/src/types/props.ts:533](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L533)
 
 The selected date.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/CaptionLabelProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/CaptionLabelProps.md
@@ -2,4 +2,6 @@
 
 > **CaptionLabelProps** = `Parameters`\<*typeof* [`CaptionLabel`](../functions/CaptionLabel.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/CaptionLabel.tsx:13](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/CaptionLabel.tsx#L13)
+Defined in: [packages/react-day-picker/src/components/CaptionLabel.tsx:14](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/CaptionLabel.tsx#L14)
+
+Props accepted by the [CaptionLabel](../functions/CaptionLabel.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/ChevronProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/ChevronProps.md
@@ -2,4 +2,6 @@
 
 > **ChevronProps** = `Parameters`\<*typeof* [`Chevron`](../functions/Chevron.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/Chevron.tsx:43](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Chevron.tsx#L43)
+Defined in: [packages/react-day-picker/src/components/Chevron.tsx:44](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Chevron.tsx#L44)
+
+Props accepted by the [Chevron](../functions/Chevron.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/ClassNames.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/ClassNames.md
@@ -2,7 +2,7 @@
 
 > **ClassNames** = \{ \[key in UI \| SelectionState \| DayFlag \| Animation\]: string \}
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:253](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L253)
+Defined in: [packages/react-day-picker/src/types/shared.ts:253](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L253)
 
 The CSS classnames to use for the [UI](../enumerations/UI.md) elements, the
 [SelectionState](../enumerations/SelectionState.md) and the [DayFlag](../enumerations/DayFlag.md).

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/CustomComponents.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/CustomComponents.md
@@ -2,7 +2,7 @@
 
 > **CustomComponents** = \{ `CaptionLabel`: *typeof* [`CaptionLabel`](../functions/CaptionLabel.md); `Chevron`: *typeof* [`Chevron`](../functions/Chevron.md); `Day`: *typeof* [`Day`](../functions/Day.md); `DayButton`: *typeof* [`DayButton`](../functions/DayButton.md); `Dropdown`: *typeof* [`Dropdown`](../functions/Dropdown.md); `DropdownNav`: *typeof* [`DropdownNav`](../functions/DropdownNav.md); `Footer`: *typeof* [`Footer`](../functions/Footer.md); `Month`: *typeof* [`Month`](../functions/Month.md); `MonthCaption`: *typeof* [`MonthCaption`](../functions/MonthCaption.md); `MonthGrid`: *typeof* [`MonthGrid`](../functions/MonthGrid.md); `Months`: *typeof* [`Months`](../functions/Months.md); `MonthsDropdown`: *typeof* [`MonthsDropdown`](../functions/MonthsDropdown.md); `Nav`: *typeof* [`Nav`](../functions/Nav.md); `NextMonthButton`: *typeof* [`NextMonthButton`](../functions/NextMonthButton.md); `Option`: *typeof* [`Option`](../functions/Option.md); `PreviousMonthButton`: *typeof* [`PreviousMonthButton`](../functions/PreviousMonthButton.md); `Root`: *typeof* [`Root`](../functions/Root.md); `Select`: *typeof* [`Select`](../functions/Select.md); `Week`: *typeof* [`Week`](../functions/Week.md); `Weekday`: *typeof* [`Weekday`](../functions/Weekday.md); `Weekdays`: *typeof* [`Weekdays`](../functions/Weekdays.md); `WeekNumber`: *typeof* [`WeekNumber`](../functions/WeekNumber.md); `WeekNumberHeader`: *typeof* [`WeekNumberHeader`](../functions/WeekNumberHeader.md); `Weeks`: *typeof* [`Weeks`](../functions/Weeks.md); `YearsDropdown`: *typeof* [`YearsDropdown`](../functions/YearsDropdown.md); \}
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:43](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L43)
+Defined in: [packages/react-day-picker/src/types/shared.ts:43](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L43)
 
 The components that can be customized using the `components` prop.
 
@@ -16,7 +16,7 @@ https://daypicker.dev/guides/custom-components
 
 > **CaptionLabel**: *typeof* [`CaptionLabel`](../functions/CaptionLabel.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:47](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L47)
+Defined in: [packages/react-day-picker/src/types/shared.ts:47](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L47)
 
 Render the caption label of the month grid.
 
@@ -26,7 +26,7 @@ Render the caption label of the month grid.
 
 > **Chevron**: *typeof* [`Chevron`](../functions/Chevron.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:45](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L45)
+Defined in: [packages/react-day-picker/src/types/shared.ts:45](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L45)
 
 Render the chevron icon used in the navigation buttons and dropdowns.
 
@@ -36,7 +36,7 @@ Render the chevron icon used in the navigation buttons and dropdowns.
 
 > **Day**: *typeof* [`Day`](../functions/Day.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:49](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L49)
+Defined in: [packages/react-day-picker/src/types/shared.ts:49](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L49)
 
 Render the day cell in the month grid.
 
@@ -46,7 +46,7 @@ Render the day cell in the month grid.
 
 > **DayButton**: *typeof* [`DayButton`](../functions/DayButton.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:51](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L51)
+Defined in: [packages/react-day-picker/src/types/shared.ts:51](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L51)
 
 Render the button containing the day in the day cell.
 
@@ -56,7 +56,7 @@ Render the button containing the day in the day cell.
 
 > **Dropdown**: *typeof* [`Dropdown`](../functions/Dropdown.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:53](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L53)
+Defined in: [packages/react-day-picker/src/types/shared.ts:53](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L53)
 
 Render the dropdown element to select years and months.
 
@@ -66,7 +66,7 @@ Render the dropdown element to select years and months.
 
 > **DropdownNav**: *typeof* [`DropdownNav`](../functions/DropdownNav.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:55](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L55)
+Defined in: [packages/react-day-picker/src/types/shared.ts:55](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L55)
 
 Render the container of the dropdowns.
 
@@ -76,7 +76,7 @@ Render the container of the dropdowns.
 
 > **Footer**: *typeof* [`Footer`](../functions/Footer.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:57](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L57)
+Defined in: [packages/react-day-picker/src/types/shared.ts:57](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L57)
 
 Render the footer element announced by screen readers.
 
@@ -86,7 +86,7 @@ Render the footer element announced by screen readers.
 
 > **Month**: *typeof* [`Month`](../functions/Month.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:59](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L59)
+Defined in: [packages/react-day-picker/src/types/shared.ts:59](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L59)
 
 Render the container of the MonthGrid.
 
@@ -96,7 +96,7 @@ Render the container of the MonthGrid.
 
 > **MonthCaption**: *typeof* [`MonthCaption`](../functions/MonthCaption.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:61](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L61)
+Defined in: [packages/react-day-picker/src/types/shared.ts:61](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L61)
 
 Render the caption of the month grid.
 
@@ -106,7 +106,7 @@ Render the caption of the month grid.
 
 > **MonthGrid**: *typeof* [`MonthGrid`](../functions/MonthGrid.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:63](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L63)
+Defined in: [packages/react-day-picker/src/types/shared.ts:63](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L63)
 
 Render the grid of days in a month.
 
@@ -116,7 +116,7 @@ Render the grid of days in a month.
 
 > **Months**: *typeof* [`Months`](../functions/Months.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:65](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L65)
+Defined in: [packages/react-day-picker/src/types/shared.ts:65](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L65)
 
 Wrapper of the month grids.
 
@@ -126,7 +126,7 @@ Wrapper of the month grids.
 
 > **MonthsDropdown**: *typeof* [`MonthsDropdown`](../functions/MonthsDropdown.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:91](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L91)
+Defined in: [packages/react-day-picker/src/types/shared.ts:91](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L91)
 
 Render the dropdown for selecting months.
 
@@ -136,7 +136,7 @@ Render the dropdown for selecting months.
 
 > **Nav**: *typeof* [`Nav`](../functions/Nav.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:67](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L67)
+Defined in: [packages/react-day-picker/src/types/shared.ts:67](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L67)
 
 Render the navigation element with the next and previous buttons.
 
@@ -146,7 +146,7 @@ Render the navigation element with the next and previous buttons.
 
 > **NextMonthButton**: *typeof* [`NextMonthButton`](../functions/NextMonthButton.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:73](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L73)
+Defined in: [packages/react-day-picker/src/types/shared.ts:73](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L73)
 
 Render the next month button element in the navigation.
 
@@ -156,7 +156,7 @@ Render the next month button element in the navigation.
 
 > **Option**: *typeof* [`Option`](../functions/Option.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:69](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L69)
+Defined in: [packages/react-day-picker/src/types/shared.ts:69](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L69)
 
 Render the `<option>` HTML element in the dropdown.
 
@@ -166,7 +166,7 @@ Render the `<option>` HTML element in the dropdown.
 
 > **PreviousMonthButton**: *typeof* [`PreviousMonthButton`](../functions/PreviousMonthButton.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:71](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L71)
+Defined in: [packages/react-day-picker/src/types/shared.ts:71](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L71)
 
 Render the previous month button element in the navigation.
 
@@ -176,7 +176,7 @@ Render the previous month button element in the navigation.
 
 > **Root**: *typeof* [`Root`](../functions/Root.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:75](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L75)
+Defined in: [packages/react-day-picker/src/types/shared.ts:75](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L75)
 
 Render the root element of the calendar.
 
@@ -186,7 +186,7 @@ Render the root element of the calendar.
 
 > **Select**: *typeof* [`Select`](../functions/Select.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:77](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L77)
+Defined in: [packages/react-day-picker/src/types/shared.ts:77](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L77)
 
 Render the select element in the dropdowns.
 
@@ -196,7 +196,7 @@ Render the select element in the dropdowns.
 
 > **Week**: *typeof* [`Week`](../functions/Week.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:81](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L81)
+Defined in: [packages/react-day-picker/src/types/shared.ts:81](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L81)
 
 Render the week rows.
 
@@ -206,7 +206,7 @@ Render the week rows.
 
 > **Weekday**: *typeof* [`Weekday`](../functions/Weekday.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:83](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L83)
+Defined in: [packages/react-day-picker/src/types/shared.ts:83](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L83)
 
 Render the weekday name in the header.
 
@@ -216,7 +216,7 @@ Render the weekday name in the header.
 
 > **Weekdays**: *typeof* [`Weekdays`](../functions/Weekdays.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:85](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L85)
+Defined in: [packages/react-day-picker/src/types/shared.ts:85](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L85)
 
 Render the row containing the week days.
 
@@ -226,7 +226,7 @@ Render the row containing the week days.
 
 > **WeekNumber**: *typeof* [`WeekNumber`](../functions/WeekNumber.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:87](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L87)
+Defined in: [packages/react-day-picker/src/types/shared.ts:87](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L87)
 
 Render the cell with the number of the week.
 
@@ -236,7 +236,7 @@ Render the cell with the number of the week.
 
 > **WeekNumberHeader**: *typeof* [`WeekNumberHeader`](../functions/WeekNumberHeader.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:89](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L89)
+Defined in: [packages/react-day-picker/src/types/shared.ts:89](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L89)
 
 Render the header of the week number column.
 
@@ -246,7 +246,7 @@ Render the header of the week number column.
 
 > **Weeks**: *typeof* [`Weeks`](../functions/Weeks.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:79](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L79)
+Defined in: [packages/react-day-picker/src/types/shared.ts:79](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L79)
 
 Render the weeks section in the month grid.
 
@@ -256,6 +256,6 @@ Render the weeks section in the month grid.
 
 > **YearsDropdown**: *typeof* [`YearsDropdown`](../functions/YearsDropdown.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:93](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L93)
+Defined in: [packages/react-day-picker/src/types/shared.ts:93](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L93)
 
 Render the dropdown for selecting years.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/DateAfter.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/DateAfter.md
@@ -2,7 +2,7 @@
 
 > **DateAfter** = \{ `after`: `Date`; \}
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:168](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L168)
+Defined in: [packages/react-day-picker/src/types/shared.ts:168](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L168)
 
 Match a day falling after the specified date (exclusive).
 
@@ -19,4 +19,4 @@ Match a day falling after the specified date (exclusive).
 
 > **after**: `Date`
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:168](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L168)
+Defined in: [packages/react-day-picker/src/types/shared.ts:168](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L168)

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/DateBefore.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/DateBefore.md
@@ -2,7 +2,7 @@
 
 > **DateBefore** = \{ `before`: `Date`; \}
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:177](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L177)
+Defined in: [packages/react-day-picker/src/types/shared.ts:177](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L177)
 
 Match a day falling before the specified date (exclusive).
 
@@ -19,4 +19,4 @@ Match a day falling before the specified date (exclusive).
 
 > **before**: `Date`
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:177](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L177)
+Defined in: [packages/react-day-picker/src/types/shared.ts:177](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L177)

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/DateInterval.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/DateInterval.md
@@ -2,7 +2,7 @@
 
 > **DateInterval** = \{ `after`: `Date`; `before`: `Date`; \}
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:190](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L190)
+Defined in: [packages/react-day-picker/src/types/shared.ts:190](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L190)
 
 An interval of dates. Unlike [DateRange](DateRange.md), the range ends are not
 included.
@@ -23,7 +23,7 @@ included.
 
 > **after**: `Date`
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:190](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L190)
+Defined in: [packages/react-day-picker/src/types/shared.ts:190](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L190)
 
 ***
 
@@ -31,4 +31,4 @@ Defined in: [packages/react-day-picker/src/types/shared.ts:190](https://github.c
 
 > **before**: `Date`
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:190](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L190)
+Defined in: [packages/react-day-picker/src/types/shared.ts:190](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L190)

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/DateRange.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/DateRange.md
@@ -2,7 +2,7 @@
 
 > **DateRange** = \{ `from`: `Date` \| `undefined`; `to?`: `Date`; \}
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:202](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L202)
+Defined in: [packages/react-day-picker/src/types/shared.ts:202](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L202)
 
 A range of dates. Unlike [DateInterval](DateInterval.md), the range ends are included.
 
@@ -22,7 +22,7 @@ A range of dates. Unlike [DateInterval](DateInterval.md), the range ends are inc
 
 > **from**: `Date` \| `undefined`
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:202](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L202)
+Defined in: [packages/react-day-picker/src/types/shared.ts:202](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L202)
 
 ***
 
@@ -30,4 +30,4 @@ Defined in: [packages/react-day-picker/src/types/shared.ts:202](https://github.c
 
 > `optional` **to?**: `Date`
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:202](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L202)
+Defined in: [packages/react-day-picker/src/types/shared.ts:202](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L202)

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/DayButtonProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/DayButtonProps.md
@@ -2,4 +2,6 @@
 
 > **DayButtonProps** = `Parameters`\<*typeof* [`DayButton`](../functions/DayButton.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/DayButton.tsx:29](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/DayButton.tsx#L29)
+Defined in: [packages/react-day-picker/src/components/DayButton.tsx:30](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/DayButton.tsx#L30)
+
+Props accepted by the [DayButton](../functions/DayButton.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/DayEventHandler.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/DayEventHandler.md
@@ -2,7 +2,7 @@
 
 > **DayEventHandler**\<`EventType`\> = (`date`, `modifiers`, `e`) => `void`
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:224](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L224)
+Defined in: [packages/react-day-picker/src/types/shared.ts:224](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L224)
 
 The event handler triggered when clicking or interacting with a day.
 

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/DayOfWeek.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/DayOfWeek.md
@@ -2,7 +2,7 @@
 
 > **DayOfWeek** = \{ `dayOfWeek`: `number` \| `number`[]; \}
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:213](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L213)
+Defined in: [packages/react-day-picker/src/types/shared.ts:213](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L213)
 
 Match days of the week (`0-6`, where `0` is Sunday).
 
@@ -21,4 +21,4 @@ Match days of the week (`0-6`, where `0` is Sunday).
 
 > **dayOfWeek**: `number` \| `number`[]
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:213](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L213)
+Defined in: [packages/react-day-picker/src/types/shared.ts:213](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L213)

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/DayPickerContext.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/DayPickerContext.md
@@ -2,7 +2,7 @@
 
 > **DayPickerContext**\<`T`\> = \{ `classNames`: [`ClassNames`](ClassNames.md); `components`: [`CustomComponents`](CustomComponents.md); `dayPickerProps`: [`DayPickerProps`](DayPickerProps.md); `formatters`: [`Formatters`](Formatters.md); `getModifiers`: (`day`) => [`Modifiers`](Modifiers.md); `goToMonth`: (`month`) => `void`; `isSelected`: ((`date`) => `boolean`) \| `undefined`; `labels`: [`Labels`](Labels.md); `months`: [`CalendarMonth`](../classes/CalendarMonth.md)[]; `nextMonth`: `Date` \| `undefined`; `previousMonth`: `Date` \| `undefined`; `select`: [`SelectHandler`](SelectHandler.md)\<`T`\> \| `undefined`; `selected`: [`SelectedValue`](SelectedValue.md)\<`T`\> \| `undefined`; `styles`: `Partial`\<[`Styles`](Styles.md)\> \| `undefined`; \}
 
-Defined in: [packages/react-day-picker/src/useDayPicker.ts:34](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/useDayPicker.ts#L34)
+Defined in: [packages/react-day-picker/src/useDayPicker.ts:34](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/useDayPicker.ts#L34)
 
 Represents the context for the DayPicker component, providing various
 properties and methods to interact with the calendar.
@@ -19,7 +19,7 @@ properties and methods to interact with the calendar.
 
 > **classNames**: [`ClassNames`](ClassNames.md)
 
-Defined in: [packages/react-day-picker/src/useDayPicker.ts:56](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/useDayPicker.ts#L56)
+Defined in: [packages/react-day-picker/src/useDayPicker.ts:56](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/useDayPicker.ts#L56)
 
 The class names for the UI elements.
 
@@ -29,7 +29,7 @@ The class names for the UI elements.
 
 > **components**: [`CustomComponents`](CustomComponents.md)
 
-Defined in: [packages/react-day-picker/src/useDayPicker.ts:54](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/useDayPicker.ts#L54)
+Defined in: [packages/react-day-picker/src/useDayPicker.ts:54](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/useDayPicker.ts#L54)
 
 The components used internally by DayPicker.
 
@@ -39,7 +39,7 @@ The components used internally by DayPicker.
 
 > **dayPickerProps**: [`DayPickerProps`](DayPickerProps.md)
 
-Defined in: [packages/react-day-picker/src/useDayPicker.ts:68](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/useDayPicker.ts#L68)
+Defined in: [packages/react-day-picker/src/useDayPicker.ts:68](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/useDayPicker.ts#L68)
 
 The props as passed to the DayPicker component.
 
@@ -53,7 +53,7 @@ The props as passed to the DayPicker component.
 
 > **formatters**: [`Formatters`](Formatters.md)
 
-Defined in: [packages/react-day-picker/src/useDayPicker.ts:62](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/useDayPicker.ts#L62)
+Defined in: [packages/react-day-picker/src/useDayPicker.ts:62](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/useDayPicker.ts#L62)
 
 The formatters used to format the UI elements.
 
@@ -63,7 +63,7 @@ The formatters used to format the UI elements.
 
 > **getModifiers**: (`day`) => [`Modifiers`](Modifiers.md)
 
-Defined in: [packages/react-day-picker/src/useDayPicker.ts:46](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/useDayPicker.ts#L46)
+Defined in: [packages/react-day-picker/src/useDayPicker.ts:46](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/useDayPicker.ts#L46)
 
 Returns the modifiers for the given day.
 
@@ -83,7 +83,7 @@ Returns the modifiers for the given day.
 
 > **goToMonth**: (`month`) => `void`
 
-Defined in: [packages/react-day-picker/src/useDayPicker.ts:44](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/useDayPicker.ts#L44)
+Defined in: [packages/react-day-picker/src/useDayPicker.ts:44](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/useDayPicker.ts#L44)
 
 Navigate to the specified month. Will fire the `onMonthChange` callback.
 
@@ -103,7 +103,7 @@ Navigate to the specified month. Will fire the `onMonthChange` callback.
 
 > **isSelected**: ((`date`) => `boolean`) \| `undefined`
 
-Defined in: [packages/react-day-picker/src/useDayPicker.ts:52](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/useDayPicker.ts#L52)
+Defined in: [packages/react-day-picker/src/useDayPicker.ts:52](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/useDayPicker.ts#L52)
 
 Whether the given date is selected.
 
@@ -113,7 +113,7 @@ Whether the given date is selected.
 
 > **labels**: [`Labels`](Labels.md)
 
-Defined in: [packages/react-day-picker/src/useDayPicker.ts:60](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/useDayPicker.ts#L60)
+Defined in: [packages/react-day-picker/src/useDayPicker.ts:60](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/useDayPicker.ts#L60)
 
 The labels used in the user interface.
 
@@ -123,7 +123,7 @@ The labels used in the user interface.
 
 > **months**: [`CalendarMonth`](../classes/CalendarMonth.md)[]
 
-Defined in: [packages/react-day-picker/src/useDayPicker.ts:38](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/useDayPicker.ts#L38)
+Defined in: [packages/react-day-picker/src/useDayPicker.ts:38](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/useDayPicker.ts#L38)
 
 The months displayed in the calendar.
 
@@ -133,7 +133,7 @@ The months displayed in the calendar.
 
 > **nextMonth**: `Date` \| `undefined`
 
-Defined in: [packages/react-day-picker/src/useDayPicker.ts:40](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/useDayPicker.ts#L40)
+Defined in: [packages/react-day-picker/src/useDayPicker.ts:40](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/useDayPicker.ts#L40)
 
 The next month to display.
 
@@ -143,7 +143,7 @@ The next month to display.
 
 > **previousMonth**: `Date` \| `undefined`
 
-Defined in: [packages/react-day-picker/src/useDayPicker.ts:42](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/useDayPicker.ts#L42)
+Defined in: [packages/react-day-picker/src/useDayPicker.ts:42](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/useDayPicker.ts#L42)
 
 The previous month to display.
 
@@ -153,7 +153,7 @@ The previous month to display.
 
 > **select**: [`SelectHandler`](SelectHandler.md)\<`T`\> \| `undefined`
 
-Defined in: [packages/react-day-picker/src/useDayPicker.ts:50](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/useDayPicker.ts#L50)
+Defined in: [packages/react-day-picker/src/useDayPicker.ts:50](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/useDayPicker.ts#L50)
 
 Set a selection.
 
@@ -163,7 +163,7 @@ Set a selection.
 
 > **selected**: [`SelectedValue`](SelectedValue.md)\<`T`\> \| `undefined`
 
-Defined in: [packages/react-day-picker/src/useDayPicker.ts:48](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/useDayPicker.ts#L48)
+Defined in: [packages/react-day-picker/src/useDayPicker.ts:48](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/useDayPicker.ts#L48)
 
 The selected date(s).
 
@@ -173,6 +173,6 @@ The selected date(s).
 
 > **styles**: `Partial`\<[`Styles`](Styles.md)\> \| `undefined`
 
-Defined in: [packages/react-day-picker/src/useDayPicker.ts:58](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/useDayPicker.ts#L58)
+Defined in: [packages/react-day-picker/src/useDayPicker.ts:58](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/useDayPicker.ts#L58)
 
 The styles for the UI elements.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/DayPickerLocaleLabels.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/DayPickerLocaleLabels.md
@@ -2,7 +2,7 @@
 
 > **DayPickerLocaleLabels** = \{ \[K in keyof Labels\]?: string \| Labels\[K\] \}
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:58](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L58)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:58](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L58)
 
 Translations for DayPicker-specific labels.
 

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/DayPickerProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/DayPickerProps.md
@@ -2,6 +2,6 @@
 
 > **DayPickerProps** = [`PropsBase`](../interfaces/PropsBase.md) & [`PropsSingle`](../interfaces/PropsSingle.md) \| [`PropsSingleRequired`](../interfaces/PropsSingleRequired.md) \| [`PropsMulti`](../interfaces/PropsMulti.md) \| [`PropsMultiRequired`](../interfaces/PropsMultiRequired.md) \| [`PropsRange`](../interfaces/PropsRange.md) \| [`PropsRangeRequired`](../interfaces/PropsRangeRequired.md) \| \{ `mode?`: `undefined`; `required?`: `undefined`; \}
 
-Defined in: [packages/react-day-picker/src/types/props.ts:26](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L26)
+Defined in: [packages/react-day-picker/src/types/props.ts:26](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L26)
 
 The props for the `<DayPicker />` component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/DayProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/DayProps.md
@@ -2,4 +2,6 @@
 
 > **DayProps** = `Parameters`\<*typeof* [`Day`](../functions/Day.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/Day.tsx:28](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Day.tsx#L28)
+Defined in: [packages/react-day-picker/src/components/Day.tsx:29](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Day.tsx#L29)
+
+Props accepted by the [Day](../functions/Day.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/DropdownNavProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/DropdownNavProps.md
@@ -2,4 +2,6 @@
 
 > **DropdownNavProps** = `Parameters`\<*typeof* [`DropdownNav`](../functions/DropdownNav.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/DropdownNav.tsx:13](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/DropdownNav.tsx#L13)
+Defined in: [packages/react-day-picker/src/components/DropdownNav.tsx:14](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/DropdownNav.tsx#L14)
+
+Props accepted by the [DropdownNav](../functions/DropdownNav.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/DropdownOption.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/DropdownOption.md
@@ -2,7 +2,7 @@
 
 > **DropdownOption** = \{ `disabled`: `boolean`; `label`: `string`; `value`: `number`; \}
 
-Defined in: [packages/react-day-picker/src/components/Dropdown.tsx:6](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Dropdown.tsx#L6)
+Defined in: [packages/react-day-picker/src/components/Dropdown.tsx:6](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Dropdown.tsx#L6)
 
 An option to use in the dropdown. Maps to the `<option>` HTML element.
 
@@ -12,7 +12,7 @@ An option to use in the dropdown. Maps to the `<option>` HTML element.
 
 > **disabled**: `boolean`
 
-Defined in: [packages/react-day-picker/src/components/Dropdown.tsx:12](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Dropdown.tsx#L12)
+Defined in: [packages/react-day-picker/src/components/Dropdown.tsx:12](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Dropdown.tsx#L12)
 
 Whether the dropdown option is disabled (e.g., out of the calendar range).
 
@@ -22,7 +22,7 @@ Whether the dropdown option is disabled (e.g., out of the calendar range).
 
 > **label**: `string`
 
-Defined in: [packages/react-day-picker/src/components/Dropdown.tsx:10](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Dropdown.tsx#L10)
+Defined in: [packages/react-day-picker/src/components/Dropdown.tsx:10](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Dropdown.tsx#L10)
 
 The label of the option.
 
@@ -32,6 +32,6 @@ The label of the option.
 
 > **value**: `number`
 
-Defined in: [packages/react-day-picker/src/components/Dropdown.tsx:8](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Dropdown.tsx#L8)
+Defined in: [packages/react-day-picker/src/components/Dropdown.tsx:8](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Dropdown.tsx#L8)
 
 The value of the option.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/DropdownProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/DropdownProps.md
@@ -2,4 +2,6 @@
 
 > **DropdownProps** = `Parameters`\<*typeof* [`Dropdown`](../functions/Dropdown.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/Dropdown.tsx:59](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Dropdown.tsx#L59)
+Defined in: [packages/react-day-picker/src/components/Dropdown.tsx:60](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Dropdown.tsx#L60)
+
+Props accepted by the [Dropdown](../functions/Dropdown.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/FooterProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/FooterProps.md
@@ -2,4 +2,6 @@
 
 > **FooterProps** = `Parameters`\<*typeof* [`Footer`](../functions/Footer.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/Footer.tsx:13](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Footer.tsx#L13)
+Defined in: [packages/react-day-picker/src/components/Footer.tsx:14](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Footer.tsx#L14)
+
+Props accepted by the [Footer](../functions/Footer.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/Formatters.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/Formatters.md
@@ -2,7 +2,7 @@
 
 > **Formatters** = \{ `formatCaption`: *typeof* [`formatCaption`](../functions/formatCaption.md); `formatDay`: *typeof* [`formatDay`](../functions/formatDay.md); `formatMonthDropdown`: *typeof* [`formatMonthDropdown`](../functions/formatMonthDropdown.md); `formatWeekdayName`: *typeof* [`formatWeekdayName`](../functions/formatWeekdayName.md); `formatWeekNumber`: *typeof* [`formatWeekNumber`](../functions/formatWeekNumber.md); `formatWeekNumberHeader`: *typeof* [`formatWeekNumberHeader`](../functions/formatWeekNumberHeader.md); `formatYearDropdown`: *typeof* [`formatYearDropdown`](../functions/formatYearDropdown.md); \}
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:97](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L97)
+Defined in: [packages/react-day-picker/src/types/shared.ts:97](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L97)
 
 Represents a map of formatters used to render localized content.
 
@@ -12,7 +12,7 @@ Represents a map of formatters used to render localized content.
 
 > **formatCaption**: *typeof* [`formatCaption`](../functions/formatCaption.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:99](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L99)
+Defined in: [packages/react-day-picker/src/types/shared.ts:99](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L99)
 
 Format the caption of a month grid.
 
@@ -22,7 +22,7 @@ Format the caption of a month grid.
 
 > **formatDay**: *typeof* [`formatDay`](../functions/formatDay.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:101](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L101)
+Defined in: [packages/react-day-picker/src/types/shared.ts:101](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L101)
 
 Format the day in the day cell.
 
@@ -32,7 +32,7 @@ Format the day in the day cell.
 
 > **formatMonthDropdown**: *typeof* [`formatMonthDropdown`](../functions/formatMonthDropdown.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:103](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L103)
+Defined in: [packages/react-day-picker/src/types/shared.ts:103](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L103)
 
 Format the label in the month dropdown.
 
@@ -42,7 +42,7 @@ Format the label in the month dropdown.
 
 > **formatWeekdayName**: *typeof* [`formatWeekdayName`](../functions/formatWeekdayName.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:109](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L109)
+Defined in: [packages/react-day-picker/src/types/shared.ts:109](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L109)
 
 Format the week day name in the header.
 
@@ -52,7 +52,7 @@ Format the week day name in the header.
 
 > **formatWeekNumber**: *typeof* [`formatWeekNumber`](../functions/formatWeekNumber.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:105](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L105)
+Defined in: [packages/react-day-picker/src/types/shared.ts:105](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L105)
 
 Format the week number.
 
@@ -62,7 +62,7 @@ Format the week number.
 
 > **formatWeekNumberHeader**: *typeof* [`formatWeekNumberHeader`](../functions/formatWeekNumberHeader.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:107](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L107)
+Defined in: [packages/react-day-picker/src/types/shared.ts:107](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L107)
 
 Format the header of the week number column.
 
@@ -72,6 +72,6 @@ Format the header of the week number column.
 
 > **formatYearDropdown**: *typeof* [`formatYearDropdown`](../functions/formatYearDropdown.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:111](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L111)
+Defined in: [packages/react-day-picker/src/types/shared.ts:111](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L111)
 
 Format the label in the year dropdown.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/Labels.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/Labels.md
@@ -2,7 +2,7 @@
 
 > **Labels** = \{ `labelDayButton`: *typeof* [`labelDayButton`](../functions/labelDayButton.md); `labelGrid`: *typeof* [`labelGrid`](../functions/labelGrid.md); `labelGridcell`: *typeof* [`labelGridcell`](../functions/labelGridcell.md); `labelMonthDropdown`: *typeof* [`labelMonthDropdown`](../functions/labelMonthDropdown.md); `labelNav`: *typeof* [`labelNav`](../functions/labelNav.md); `labelNext`: *typeof* [`labelNext`](../functions/labelNext.md); `labelPrevious`: *typeof* [`labelPrevious`](../functions/labelPrevious.md); `labelWeekday`: *typeof* [`labelWeekday`](../functions/labelWeekday.md); `labelWeekNumber`: *typeof* [`labelWeekNumber`](../functions/labelWeekNumber.md); `labelWeekNumberHeader`: *typeof* [`labelWeekNumberHeader`](../functions/labelWeekNumberHeader.md); `labelYearDropdown`: *typeof* [`labelYearDropdown`](../functions/labelYearDropdown.md); \}
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:115](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L115)
+Defined in: [packages/react-day-picker/src/types/shared.ts:115](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L115)
 
 A map of functions to translate ARIA labels for various elements.
 
@@ -12,7 +12,7 @@ A map of functions to translate ARIA labels for various elements.
 
 > **labelDayButton**: *typeof* [`labelDayButton`](../functions/labelDayButton.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:131](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L131)
+Defined in: [packages/react-day-picker/src/types/shared.ts:131](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L131)
 
 The label for the day button.
 
@@ -22,7 +22,7 @@ The label for the day button.
 
 > **labelGrid**: *typeof* [`labelGrid`](../functions/labelGrid.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:119](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L119)
+Defined in: [packages/react-day-picker/src/types/shared.ts:119](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L119)
 
 The label for the month grid.
 
@@ -32,7 +32,7 @@ The label for the month grid.
 
 > **labelGridcell**: *typeof* [`labelGridcell`](../functions/labelGridcell.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:121](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L121)
+Defined in: [packages/react-day-picker/src/types/shared.ts:121](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L121)
 
 The label for the gridcell, when the calendar is not interactive.
 
@@ -42,7 +42,7 @@ The label for the gridcell, when the calendar is not interactive.
 
 > **labelMonthDropdown**: *typeof* [`labelMonthDropdown`](../functions/labelMonthDropdown.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:123](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L123)
+Defined in: [packages/react-day-picker/src/types/shared.ts:123](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L123)
 
 The label for the month dropdown.
 
@@ -52,7 +52,7 @@ The label for the month dropdown.
 
 > **labelNav**: *typeof* [`labelNav`](../functions/labelNav.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:117](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L117)
+Defined in: [packages/react-day-picker/src/types/shared.ts:117](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L117)
 
 The label for the navigation toolbar.
 
@@ -62,7 +62,7 @@ The label for the navigation toolbar.
 
 > **labelNext**: *typeof* [`labelNext`](../functions/labelNext.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:127](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L127)
+Defined in: [packages/react-day-picker/src/types/shared.ts:127](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L127)
 
 The label for the "next month" button.
 
@@ -72,7 +72,7 @@ The label for the "next month" button.
 
 > **labelPrevious**: *typeof* [`labelPrevious`](../functions/labelPrevious.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:129](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L129)
+Defined in: [packages/react-day-picker/src/types/shared.ts:129](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L129)
 
 The label for the "previous month" button.
 
@@ -82,7 +82,7 @@ The label for the "previous month" button.
 
 > **labelWeekday**: *typeof* [`labelWeekday`](../functions/labelWeekday.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:133](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L133)
+Defined in: [packages/react-day-picker/src/types/shared.ts:133](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L133)
 
 The label for the weekday.
 
@@ -92,7 +92,7 @@ The label for the weekday.
 
 > **labelWeekNumber**: *typeof* [`labelWeekNumber`](../functions/labelWeekNumber.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:135](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L135)
+Defined in: [packages/react-day-picker/src/types/shared.ts:135](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L135)
 
 The label for the week number.
 
@@ -102,7 +102,7 @@ The label for the week number.
 
 > **labelWeekNumberHeader**: *typeof* [`labelWeekNumberHeader`](../functions/labelWeekNumberHeader.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:137](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L137)
+Defined in: [packages/react-day-picker/src/types/shared.ts:137](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L137)
 
 The label for the column of week numbers.
 
@@ -112,6 +112,6 @@ The label for the column of week numbers.
 
 > **labelYearDropdown**: *typeof* [`labelYearDropdown`](../functions/labelYearDropdown.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:125](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L125)
+Defined in: [packages/react-day-picker/src/types/shared.ts:125](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L125)
 
 The label for the year dropdown.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/Locale.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/Locale.md
@@ -2,4 +2,6 @@
 
 > **Locale** = [`DayPickerLocale`](../interfaces/DayPickerLocale.md)
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:71](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L71)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:72](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L72)
+
+Alias for the locale shape accepted by DayPicker APIs.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/Matcher.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/Matcher.md
@@ -2,7 +2,7 @@
 
 > **Matcher** = `boolean` \| ((`date`) => `boolean`) \| `Date` \| `Date`[] \| [`DateRange`](DateRange.md) \| [`DateBefore`](DateBefore.md) \| [`DateAfter`](DateAfter.md) \| [`DateInterval`](DateInterval.md) \| [`DayOfWeek`](DayOfWeek.md)
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:150](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L150)
+Defined in: [packages/react-day-picker/src/types/shared.ts:150](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L150)
 
 A value or a function that matches specific days.
 

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/Mode.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/Mode.md
@@ -2,7 +2,7 @@
 
 > **Mode** = `"single"` \| `"multiple"` \| `"range"`
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:36](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L36)
+Defined in: [packages/react-day-picker/src/types/shared.ts:36](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L36)
 
 Selection modes supported by DayPicker.
 

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/Modifiers.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/Modifiers.md
@@ -2,7 +2,7 @@
 
 > **Modifiers** = `Record`\<`string`, `boolean`\>
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:277](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L277)
+Defined in: [packages/react-day-picker/src/types/shared.ts:277](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L277)
 
 Represents the modifiers that match a specific day in the calendar.
 

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/ModifiersClassNames.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/ModifiersClassNames.md
@@ -2,7 +2,7 @@
 
 > **ModifiersClassNames** = `Record`\<`string`, `string`\>
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:301](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L301)
+Defined in: [packages/react-day-picker/src/types/shared.ts:301](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L301)
 
 The classnames to assign to each day element matching a modifier.
 

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/ModifiersStyles.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/ModifiersStyles.md
@@ -2,7 +2,7 @@
 
 > **ModifiersStyles** = `Record`\<`string`, `CSSProperties`\>
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:289](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L289)
+Defined in: [packages/react-day-picker/src/types/shared.ts:289](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L289)
 
 The style to apply to each day element matching a modifier.
 

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/MonthCaptionProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/MonthCaptionProps.md
@@ -2,4 +2,6 @@
 
 > **MonthCaptionProps** = `Parameters`\<*typeof* [`MonthCaption`](../functions/MonthCaption.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/MonthCaption.tsx:23](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/MonthCaption.tsx#L23)
+Defined in: [packages/react-day-picker/src/components/MonthCaption.tsx:24](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/MonthCaption.tsx#L24)
+
+Props accepted by the [MonthCaption](../functions/MonthCaption.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/MonthChangeEventHandler.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/MonthChangeEventHandler.md
@@ -2,7 +2,7 @@
 
 > **MonthChangeEventHandler** = (`month`) => `void`
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:239](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L239)
+Defined in: [packages/react-day-picker/src/types/shared.ts:239](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L239)
 
 The event handler when a month is changed in the calendar.
 

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/MonthGridProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/MonthGridProps.md
@@ -2,4 +2,6 @@
 
 > **MonthGridProps** = `Parameters`\<*typeof* [`MonthGrid`](../functions/MonthGrid.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/MonthGrid.tsx:13](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/MonthGrid.tsx#L13)
+Defined in: [packages/react-day-picker/src/components/MonthGrid.tsx:14](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/MonthGrid.tsx#L14)
+
+Props accepted by the [MonthGrid](../functions/MonthGrid.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/MonthProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/MonthProps.md
@@ -2,4 +2,6 @@
 
 > **MonthProps** = `Parameters`\<*typeof* [`Month`](../functions/Month.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/Month.tsx:24](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Month.tsx#L24)
+Defined in: [packages/react-day-picker/src/components/Month.tsx:25](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Month.tsx#L25)
+
+Props accepted by the [Month](../functions/Month.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/MonthYearOrder.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/MonthYearOrder.md
@@ -2,6 +2,6 @@
 
 > **MonthYearOrder** = `"month-first"` \| `"year-first"`
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:74](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L74)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:75](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L75)
 
 Indicates the preferred ordering of month and year for localized labels.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/MonthsProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/MonthsProps.md
@@ -2,4 +2,6 @@
 
 > **MonthsProps** = `Parameters`\<*typeof* [`Months`](../functions/Months.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/Months.tsx:13](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Months.tsx#L13)
+Defined in: [packages/react-day-picker/src/components/Months.tsx:14](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Months.tsx#L14)
+
+Props accepted by the [Months](../functions/Months.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/MoveFocusBy.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/MoveFocusBy.md
@@ -2,6 +2,6 @@
 
 > **MoveFocusBy** = `"day"` \| `"week"` \| `"startOfWeek"` \| `"endOfWeek"` \| `"month"` \| `"year"`
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:307](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L307)
+Defined in: [packages/react-day-picker/src/types/shared.ts:307](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L307)
 
 The temporal unit to move the focus by.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/MoveFocusDir.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/MoveFocusDir.md
@@ -2,6 +2,6 @@
 
 > **MoveFocusDir** = `"after"` \| `"before"`
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:304](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L304)
+Defined in: [packages/react-day-picker/src/types/shared.ts:304](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L304)
 
 The direction to move the focus relative to the current focused date.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/NavProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/NavProps.md
@@ -2,4 +2,6 @@
 
 > **NavProps** = `Parameters`\<*typeof* [`Nav`](../functions/Nav.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/Nav.tsx:94](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Nav.tsx#L94)
+Defined in: [packages/react-day-picker/src/components/Nav.tsx:95](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Nav.tsx#L95)
+
+Props accepted by the [Nav](../functions/Nav.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/NextMonthButtonProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/NextMonthButtonProps.md
@@ -2,4 +2,6 @@
 
 > **NextMonthButtonProps** = `Parameters`\<*typeof* [`NextMonthButton`](../functions/NextMonthButton.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/NextMonthButton.tsx:15](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/NextMonthButton.tsx#L15)
+Defined in: [packages/react-day-picker/src/components/NextMonthButton.tsx:16](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/NextMonthButton.tsx#L16)
+
+Props accepted by the [NextMonthButton](../functions/NextMonthButton.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/Numerals.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/Numerals.md
@@ -2,7 +2,7 @@
 
 > **Numerals** = `"latn"` \| `"arab"` \| `"arabext"` \| `"deva"` \| `"geez"` \| `"beng"` \| `"guru"` \| `"gujr"` \| `"orya"` \| `"tamldec"` \| `"telu"` \| `"knda"` \| `"mlym"` \| `"thai"` \| `"mymr"` \| `"khmr"` \| `"laoo"` \| `"tibt"`
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:338](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L338)
+Defined in: [packages/react-day-picker/src/types/shared.ts:338](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L338)
 
 The numbering system supported by DayPicker.
 

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/OnSelectHandler.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/OnSelectHandler.md
@@ -2,7 +2,7 @@
 
 > **OnSelectHandler**\<`T`\> = (`selected`, `triggerDate`, `modifiers`, `e`) => `void`
 
-Defined in: [packages/react-day-picker/src/types/props.ts:516](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/props.ts#L516)
+Defined in: [packages/react-day-picker/src/types/props.ts:516](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/props.ts#L516)
 
 Shared handler type for `onSelect` callback when a selection mode is set.
 

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/OptionProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/OptionProps.md
@@ -2,4 +2,6 @@
 
 > **OptionProps** = `Parameters`\<*typeof* [`Option`](../functions/Option.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/Option.tsx:13](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Option.tsx#L13)
+Defined in: [packages/react-day-picker/src/components/Option.tsx:14](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Option.tsx#L14)
+
+Props accepted by the [Option](../functions/Option.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/PreviousMonthButtonProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/PreviousMonthButtonProps.md
@@ -2,4 +2,6 @@
 
 > **PreviousMonthButtonProps** = `Parameters`\<*typeof* [`PreviousMonthButton`](../functions/PreviousMonthButton.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/PreviousMonthButton.tsx:15](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/PreviousMonthButton.tsx#L15)
+Defined in: [packages/react-day-picker/src/components/PreviousMonthButton.tsx:16](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/PreviousMonthButton.tsx#L16)
+
+Props accepted by the [PreviousMonthButton](../functions/PreviousMonthButton.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/RootProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/RootProps.md
@@ -2,4 +2,6 @@
 
 > **RootProps** = `Parameters`\<*typeof* [`Root`](../functions/Root.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/Root.tsx:19](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Root.tsx#L19)
+Defined in: [packages/react-day-picker/src/components/Root.tsx:20](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Root.tsx#L20)
+
+Props accepted by the [Root](../functions/Root.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/SelectHandler.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/SelectHandler.md
@@ -2,7 +2,7 @@
 
 > **SelectHandler**\<`T`\> = `T` *extends* \{ `mode`: `"single"`; \} ? [`SelectHandlerSingle`](SelectHandlerSingle.md)\<`T`\> : `T` *extends* \{ `mode`: `"multiple"`; \} ? [`SelectHandlerMulti`](SelectHandlerMulti.md)\<`T`\> : `T` *extends* \{ `mode`: `"range"`; \} ? [`SelectHandlerRange`](SelectHandlerRange.md)\<`T`\> : `undefined`
 
-Defined in: [packages/react-day-picker/src/types/selection.ts:78](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/selection.ts#L78)
+Defined in: [packages/react-day-picker/src/types/selection.ts:86](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/selection.ts#L86)
 
 The handler to set a selection based on the mode.
 

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/SelectHandlerMulti.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/SelectHandlerMulti.md
@@ -2,7 +2,9 @@
 
 > **SelectHandlerMulti**\<`T`\> = (`triggerDate`, `modifiers`, `e`) => `T`\[`"required"`\] *extends* `true` ? `Date`[] : `Date`[] \| `undefined`
 
-Defined in: [packages/react-day-picker/src/types/selection.ts:54](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/selection.ts#L54)
+Defined in: [packages/react-day-picker/src/types/selection.ts:61](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/selection.ts#L61)
+
+Selection handler for multiple selection mode.
 
 ## Type Parameters
 

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/SelectHandlerRange.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/SelectHandlerRange.md
@@ -2,7 +2,9 @@
 
 > **SelectHandlerRange**\<`T`\> = (`triggerDate`, `modifiers`, `e`) => `T`\[`"required"`\] *extends* `true` ? [`DateRange`](DateRange.md) : [`DateRange`](DateRange.md) \| `undefined`
 
-Defined in: [packages/react-day-picker/src/types/selection.ts:60](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/selection.ts#L60)
+Defined in: [packages/react-day-picker/src/types/selection.ts:68](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/selection.ts#L68)
+
+Selection handler for range selection mode.
 
 ## Type Parameters
 

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/SelectHandlerSingle.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/SelectHandlerSingle.md
@@ -2,7 +2,9 @@
 
 > **SelectHandlerSingle**\<`T`\> = (`triggerDate`, `modifiers`, `e`) => `T`\[`"required"`\] *extends* `true` ? `Date` : `Date` \| `undefined`
 
-Defined in: [packages/react-day-picker/src/types/selection.ts:47](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/selection.ts#L47)
+Defined in: [packages/react-day-picker/src/types/selection.ts:52](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/selection.ts#L52)
+
+Selection handler for single selection mode.
 
 ## Type Parameters
 

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/SelectProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/SelectProps.md
@@ -2,4 +2,6 @@
 
 > **SelectProps** = `Parameters`\<*typeof* [`Select`](../functions/Select.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/Select.tsx:13](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Select.tsx#L13)
+Defined in: [packages/react-day-picker/src/components/Select.tsx:14](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Select.tsx#L14)
+
+Props accepted by the [Select](../functions/Select.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/SelectedMulti.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/SelectedMulti.md
@@ -2,7 +2,9 @@
 
 > **SelectedMulti**\<`T`\> = `T`\[`"required"`\] *extends* `true` ? `Date`[] : `Date`[] \| `undefined`
 
-Defined in: [packages/react-day-picker/src/types/selection.ts:15](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/selection.ts#L15)
+Defined in: [packages/react-day-picker/src/types/selection.ts:18](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/selection.ts#L18)
+
+Selected value for multiple selection mode, respecting required selections.
 
 ## Type Parameters
 

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/SelectedRange.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/SelectedRange.md
@@ -2,7 +2,9 @@
 
 > **SelectedRange**\<`T`\> = `T`\[`"required"`\] *extends* `true` ? [`DateRange`](DateRange.md) : [`DateRange`](DateRange.md) \| `undefined`
 
-Defined in: [packages/react-day-picker/src/types/selection.ts:17](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/selection.ts#L17)
+Defined in: [packages/react-day-picker/src/types/selection.ts:21](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/selection.ts#L21)
+
+Selected value for range selection mode, respecting required selections.
 
 ## Type Parameters
 

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/SelectedSingle.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/SelectedSingle.md
@@ -2,7 +2,9 @@
 
 > **SelectedSingle**\<`T`\> = `T`\[`"required"`\] *extends* `true` ? `Date` : `Date` \| `undefined`
 
-Defined in: [packages/react-day-picker/src/types/selection.ts:13](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/selection.ts#L13)
+Defined in: [packages/react-day-picker/src/types/selection.ts:15](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/selection.ts#L15)
+
+Selected value for single selection mode, respecting required selections.
 
 ## Type Parameters
 

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/SelectedValue.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/SelectedValue.md
@@ -2,7 +2,7 @@
 
 > **SelectedValue**\<`T`\> = `T` *extends* \{ `mode`: `"single"`; `required?`: `boolean`; \} ? [`SelectedSingle`](SelectedSingle.md)\<`T`\> : `T` *extends* \{ `mode`: `"multiple"`; `required?`: `boolean`; \} ? [`SelectedMulti`](SelectedMulti.md)\<`T`\> : `T` *extends* \{ `mode`: `"range"`; `required?`: `boolean`; \} ? [`SelectedRange`](SelectedRange.md)\<`T`\> : `undefined`
 
-Defined in: [packages/react-day-picker/src/types/selection.ts:39](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/selection.ts#L39)
+Defined in: [packages/react-day-picker/src/types/selection.ts:43](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/selection.ts#L43)
 
 Represents the selected value based on the selection mode.
 

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/Selection.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/Selection.md
@@ -2,7 +2,9 @@
 
 > **Selection**\<`T`\> = \{ `isSelected`: (`date`) => `boolean`; `select`: [`SelectHandler`](SelectHandler.md)\<`T`\> \| `undefined`; `selected`: [`SelectedValue`](SelectedValue.md)\<`T`\> \| `undefined`; \}
 
-Defined in: [packages/react-day-picker/src/types/selection.ts:4](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/selection.ts#L4)
+Defined in: [packages/react-day-picker/src/types/selection.ts:5](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/selection.ts#L5)
+
+Selection state and helpers for the active selection mode.
 
 ## Type Parameters
 
@@ -16,7 +18,7 @@ Defined in: [packages/react-day-picker/src/types/selection.ts:4](https://github.
 
 > **isSelected**: (`date`) => `boolean`
 
-Defined in: [packages/react-day-picker/src/types/selection.ts:10](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/selection.ts#L10)
+Defined in: [packages/react-day-picker/src/types/selection.ts:11](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/selection.ts#L11)
 
 Whether the given date is selected.
 
@@ -36,7 +38,7 @@ Whether the given date is selected.
 
 > **select**: [`SelectHandler`](SelectHandler.md)\<`T`\> \| `undefined`
 
-Defined in: [packages/react-day-picker/src/types/selection.ts:8](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/selection.ts#L8)
+Defined in: [packages/react-day-picker/src/types/selection.ts:9](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/selection.ts#L9)
 
 Set a selection.
 
@@ -46,6 +48,6 @@ Set a selection.
 
 > **selected**: [`SelectedValue`](SelectedValue.md)\<`T`\> \| `undefined`
 
-Defined in: [packages/react-day-picker/src/types/selection.ts:6](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/selection.ts#L6)
+Defined in: [packages/react-day-picker/src/types/selection.ts:7](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/selection.ts#L7)
 
 The selected date(s).

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/Styles.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/Styles.md
@@ -2,7 +2,7 @@
 
 > **Styles** = \{ \[key in UI \| SelectionState \| DayFlag\]: CSSProperties \| undefined \}
 
-Defined in: [packages/react-day-picker/src/types/shared.ts:261](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/types/shared.ts#L261)
+Defined in: [packages/react-day-picker/src/types/shared.ts:261](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/types/shared.ts#L261)
 
 The CSS styles to use for the [UI](../enumerations/UI.md) elements, the [SelectionState](../enumerations/SelectionState.md)
 and the [DayFlag](../enumerations/DayFlag.md).

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/WeekNumberHeaderProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/WeekNumberHeaderProps.md
@@ -2,4 +2,6 @@
 
 > **WeekNumberHeaderProps** = `Parameters`\<*typeof* [`WeekNumberHeader`](../functions/WeekNumberHeader.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/WeekNumberHeader.tsx:15](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/WeekNumberHeader.tsx#L15)
+Defined in: [packages/react-day-picker/src/components/WeekNumberHeader.tsx:16](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/WeekNumberHeader.tsx#L16)
+
+Props accepted by the [WeekNumberHeader](../functions/WeekNumberHeader.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/WeekNumberProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/WeekNumberProps.md
@@ -2,4 +2,6 @@
 
 > **WeekNumberProps** = `Parameters`\<*typeof* [`WeekNumber`](../functions/WeekNumber.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/WeekNumber.tsx:21](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/WeekNumber.tsx#L21)
+Defined in: [packages/react-day-picker/src/components/WeekNumber.tsx:22](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/WeekNumber.tsx#L22)
+
+Props accepted by the [WeekNumber](../functions/WeekNumber.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/WeekProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/WeekProps.md
@@ -2,4 +2,6 @@
 
 > **WeekProps** = `Parameters`\<*typeof* [`Week`](../functions/Week.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/Week.tsx:21](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Week.tsx#L21)
+Defined in: [packages/react-day-picker/src/components/Week.tsx:22](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Week.tsx#L22)
+
+Props accepted by the [Week](../functions/Week.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/WeekdayProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/WeekdayProps.md
@@ -2,4 +2,6 @@
 
 > **WeekdayProps** = `Parameters`\<*typeof* [`Weekday`](../functions/Weekday.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/Weekday.tsx:13](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Weekday.tsx#L13)
+Defined in: [packages/react-day-picker/src/components/Weekday.tsx:14](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Weekday.tsx#L14)
+
+Props accepted by the [Weekday](../functions/Weekday.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/WeekdaysProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/WeekdaysProps.md
@@ -2,4 +2,6 @@
 
 > **WeekdaysProps** = `Parameters`\<*typeof* [`Weekdays`](../functions/Weekdays.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/Weekdays.tsx:17](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Weekdays.tsx#L17)
+Defined in: [packages/react-day-picker/src/components/Weekdays.tsx:18](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Weekdays.tsx#L18)
+
+Props accepted by the [Weekdays](../functions/Weekdays.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/type-aliases/WeeksProps.md
+++ b/apps/website/versioned_docs/version-next/api/react/type-aliases/WeeksProps.md
@@ -2,4 +2,6 @@
 
 > **WeeksProps** = `Parameters`\<*typeof* [`Weeks`](../functions/Weeks.md)\>\[`0`\]
 
-Defined in: [packages/react-day-picker/src/components/Weeks.tsx:13](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/components/Weeks.tsx#L13)
+Defined in: [packages/react-day-picker/src/components/Weeks.tsx:14](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/components/Weeks.tsx#L14)
+
+Props accepted by the [Weeks](../functions/Weeks.md) component.

--- a/apps/website/versioned_docs/version-next/api/react/variables/defaultDateLib.md
+++ b/apps/website/versioned_docs/version-next/api/react/variables/defaultDateLib.md
@@ -2,7 +2,7 @@
 
 > `const` **defaultDateLib**: [`DateLib`](../classes/DateLib.md)
 
-Defined in: [packages/react-day-picker/src/classes/DateLib.ts:727](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/classes/DateLib.ts#L727)
+Defined in: [packages/react-day-picker/src/classes/DateLib.ts:728](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/classes/DateLib.ts#L728)
 
 The default date library with English locale.
 

--- a/apps/website/versioned_docs/version-next/api/react/variables/defaultLocale.md
+++ b/apps/website/versioned_docs/version-next/api/react/variables/defaultLocale.md
@@ -2,6 +2,6 @@
 
 > `const` **defaultLocale**: [`DayPickerLocale`](../interfaces/DayPickerLocale.md)
 
-Defined in: [packages/react-day-picker/src/locale/en-US.ts:12](https://github.com/gpbl/react-day-picker/blob/f96815cbda74d7e7b588e8e7e32923ebd787cc35/packages/react-day-picker/src/locale/en-US.ts#L12)
+Defined in: [packages/react-day-picker/src/locale/en-US.ts:12](https://github.com/gpbl/react-day-picker/blob/4f05162215b4f525bb715406bc3c84dac5de42bb/packages/react-day-picker/src/locale/en-US.ts#L12)
 
 English (United States) locale extended with DayPicker-specific translations.

--- a/packages/react-day-picker/src/classes/DateLib.ts
+++ b/packages/react-day-picker/src/classes/DateLib.ts
@@ -68,6 +68,7 @@ export interface DayPickerLocale extends DateFnsLocale {
   /** Localized DayPicker-specific labels. */
   labels?: DayPickerLocaleLabels;
 }
+/** Alias for the locale shape accepted by DayPicker APIs. */
 export type Locale = DayPickerLocale;
 
 /** Indicates the preferred ordering of month and year for localized labels. */

--- a/packages/react-day-picker/src/components/CaptionLabel.tsx
+++ b/packages/react-day-picker/src/components/CaptionLabel.tsx
@@ -10,4 +10,5 @@ export function CaptionLabel(props: HTMLAttributes<HTMLSpanElement>) {
   return <span {...props} />;
 }
 
+/** Props accepted by the {@link CaptionLabel} component. */
 export type CaptionLabelProps = Parameters<typeof CaptionLabel>[0];

--- a/packages/react-day-picker/src/components/Chevron.tsx
+++ b/packages/react-day-picker/src/components/Chevron.tsx
@@ -40,4 +40,5 @@ export function Chevron(props: {
   );
 }
 
+/** Props accepted by the {@link Chevron} component. */
 export type ChevronProps = Parameters<typeof Chevron>[0];

--- a/packages/react-day-picker/src/components/Day.tsx
+++ b/packages/react-day-picker/src/components/Day.tsx
@@ -25,4 +25,5 @@ export function Day(
   return <td {...tdProps} />;
 }
 
+/** Props accepted by the {@link Day} component. */
 export type DayProps = Parameters<typeof Day>[0];

--- a/packages/react-day-picker/src/components/DayButton.tsx
+++ b/packages/react-day-picker/src/components/DayButton.tsx
@@ -26,4 +26,5 @@ export function DayButton(
   return <button ref={ref} {...buttonProps} />;
 }
 
+/** Props accepted by the {@link DayButton} component. */
 export type DayButtonProps = Parameters<typeof DayButton>[0];

--- a/packages/react-day-picker/src/components/Dropdown.tsx
+++ b/packages/react-day-picker/src/components/Dropdown.tsx
@@ -56,4 +56,5 @@ export function Dropdown(
   );
 }
 
+/** Props accepted by the {@link Dropdown} component. */
 export type DropdownProps = Parameters<typeof Dropdown>[0];

--- a/packages/react-day-picker/src/components/DropdownNav.tsx
+++ b/packages/react-day-picker/src/components/DropdownNav.tsx
@@ -10,4 +10,5 @@ export function DropdownNav(props: HTMLAttributes<HTMLDivElement>) {
   return <div {...props} />;
 }
 
+/** Props accepted by the {@link DropdownNav} component. */
 export type DropdownNavProps = Parameters<typeof DropdownNav>[0];

--- a/packages/react-day-picker/src/components/Footer.tsx
+++ b/packages/react-day-picker/src/components/Footer.tsx
@@ -10,4 +10,5 @@ export function Footer(props: HTMLAttributes<HTMLDivElement>) {
   return <div {...props} />;
 }
 
+/** Props accepted by the {@link Footer} component. */
 export type FooterProps = Parameters<typeof Footer>[0];

--- a/packages/react-day-picker/src/components/Month.tsx
+++ b/packages/react-day-picker/src/components/Month.tsx
@@ -21,4 +21,5 @@ export function Month(
   return <div {...divProps}>{props.children}</div>;
 }
 
+/** Props accepted by the {@link Month} component. */
 export type MonthProps = Parameters<typeof Month>[0];

--- a/packages/react-day-picker/src/components/MonthCaption.tsx
+++ b/packages/react-day-picker/src/components/MonthCaption.tsx
@@ -20,4 +20,5 @@ export function MonthCaption(
   return <div {...divProps} />;
 }
 
+/** Props accepted by the {@link MonthCaption} component. */
 export type MonthCaptionProps = Parameters<typeof MonthCaption>[0];

--- a/packages/react-day-picker/src/components/MonthGrid.tsx
+++ b/packages/react-day-picker/src/components/MonthGrid.tsx
@@ -10,4 +10,5 @@ export function MonthGrid(props: TableHTMLAttributes<HTMLTableElement>) {
   return <table {...props} />;
 }
 
+/** Props accepted by the {@link MonthGrid} component. */
 export type MonthGridProps = Parameters<typeof MonthGrid>[0];

--- a/packages/react-day-picker/src/components/Months.tsx
+++ b/packages/react-day-picker/src/components/Months.tsx
@@ -10,4 +10,5 @@ export function Months(props: HTMLAttributes<HTMLDivElement>) {
   return <div {...props} />;
 }
 
+/** Props accepted by the {@link Months} component. */
 export type MonthsProps = Parameters<typeof Months>[0];

--- a/packages/react-day-picker/src/components/Nav.tsx
+++ b/packages/react-day-picker/src/components/Nav.tsx
@@ -91,4 +91,5 @@ export function Nav(
   );
 }
 
+/** Props accepted by the {@link Nav} component. */
 export type NavProps = Parameters<typeof Nav>[0];

--- a/packages/react-day-picker/src/components/NextMonthButton.tsx
+++ b/packages/react-day-picker/src/components/NextMonthButton.tsx
@@ -12,4 +12,5 @@ export function NextMonthButton(
   return <button {...props} />;
 }
 
+/** Props accepted by the {@link NextMonthButton} component. */
 export type NextMonthButtonProps = Parameters<typeof NextMonthButton>[0];

--- a/packages/react-day-picker/src/components/Option.tsx
+++ b/packages/react-day-picker/src/components/Option.tsx
@@ -10,4 +10,5 @@ export function Option(props: OptionHTMLAttributes<HTMLOptionElement>) {
   return <option {...props} />;
 }
 
+/** Props accepted by the {@link Option} component. */
 export type OptionProps = Parameters<typeof Option>[0];

--- a/packages/react-day-picker/src/components/PreviousMonthButton.tsx
+++ b/packages/react-day-picker/src/components/PreviousMonthButton.tsx
@@ -12,6 +12,7 @@ export function PreviousMonthButton(
   return <button {...props} />;
 }
 
+/** Props accepted by the {@link PreviousMonthButton} component. */
 export type PreviousMonthButtonProps = Parameters<
   typeof PreviousMonthButton
 >[0];

--- a/packages/react-day-picker/src/components/Root.tsx
+++ b/packages/react-day-picker/src/components/Root.tsx
@@ -16,4 +16,5 @@ export function Root(
   return <div {...rest} ref={rootRef} />;
 }
 
+/** Props accepted by the {@link Root} component. */
 export type RootProps = Parameters<typeof Root>[0];

--- a/packages/react-day-picker/src/components/Select.tsx
+++ b/packages/react-day-picker/src/components/Select.tsx
@@ -10,4 +10,5 @@ export function Select(props: SelectHTMLAttributes<HTMLSelectElement>) {
   return <select {...props} />;
 }
 
+/** Props accepted by the {@link Select} component. */
 export type SelectProps = Parameters<typeof Select>[0];

--- a/packages/react-day-picker/src/components/Week.tsx
+++ b/packages/react-day-picker/src/components/Week.tsx
@@ -18,4 +18,5 @@ export function Week(
   return <tr {...trProps} />;
 }
 
+/** Props accepted by the {@link Week} component. */
 export type WeekProps = Parameters<typeof Week>[0];

--- a/packages/react-day-picker/src/components/WeekNumber.tsx
+++ b/packages/react-day-picker/src/components/WeekNumber.tsx
@@ -18,4 +18,5 @@ export function WeekNumber(
   return <th {...thProps} />;
 }
 
+/** Props accepted by the {@link WeekNumber} component. */
 export type WeekNumberProps = Parameters<typeof WeekNumber>[0];

--- a/packages/react-day-picker/src/components/WeekNumberHeader.tsx
+++ b/packages/react-day-picker/src/components/WeekNumberHeader.tsx
@@ -12,4 +12,5 @@ export function WeekNumberHeader(
   return <th {...props} />;
 }
 
+/** Props accepted by the {@link WeekNumberHeader} component. */
 export type WeekNumberHeaderProps = Parameters<typeof WeekNumberHeader>[0];

--- a/packages/react-day-picker/src/components/Weekday.tsx
+++ b/packages/react-day-picker/src/components/Weekday.tsx
@@ -10,4 +10,5 @@ export function Weekday(props: ThHTMLAttributes<HTMLTableCellElement>) {
   return <th {...props} />;
 }
 
+/** Props accepted by the {@link Weekday} component. */
 export type WeekdayProps = Parameters<typeof Weekday>[0];

--- a/packages/react-day-picker/src/components/Weekdays.tsx
+++ b/packages/react-day-picker/src/components/Weekdays.tsx
@@ -14,4 +14,5 @@ export function Weekdays(props: HTMLAttributes<HTMLTableRowElement>) {
   );
 }
 
+/** Props accepted by the {@link Weekdays} component. */
 export type WeekdaysProps = Parameters<typeof Weekdays>[0];

--- a/packages/react-day-picker/src/components/Weeks.tsx
+++ b/packages/react-day-picker/src/components/Weeks.tsx
@@ -10,4 +10,5 @@ export function Weeks(props: HTMLAttributes<HTMLTableSectionElement>) {
   return <tbody {...props} />;
 }
 
+/** Props accepted by the {@link Weeks} component. */
 export type WeeksProps = Parameters<typeof Weeks>[0];

--- a/packages/react-day-picker/src/types/selection.ts
+++ b/packages/react-day-picker/src/types/selection.ts
@@ -1,6 +1,7 @@
 import type { DayPickerProps } from "./props.js";
 import type { DateRange, Mode, Modifiers } from "./shared.js";
 
+/** Selection state and helpers for the active selection mode. */
 export type Selection<T extends DayPickerProps> = {
   /** The selected date(s). */
   selected: SelectedValue<T> | undefined;
@@ -10,10 +11,13 @@ export type Selection<T extends DayPickerProps> = {
   isSelected: (date: Date) => boolean;
 };
 
+/** Selected value for single selection mode, respecting required selections. */
 export type SelectedSingle<T extends { required?: boolean }> =
   T["required"] extends true ? Date : Date | undefined;
+/** Selected value for multiple selection mode, respecting required selections. */
 export type SelectedMulti<T extends { required?: boolean }> =
   T["required"] extends true ? Date[] : Date[] | undefined;
+/** Selected value for range selection mode, respecting required selections. */
 export type SelectedRange<T extends { required?: boolean }> =
   T["required"] extends true ? DateRange : DateRange | undefined;
 
@@ -44,6 +48,7 @@ export type SelectedValue<T> = T extends { mode: "single"; required?: boolean }
       ? SelectedRange<T>
       : undefined;
 
+/** Selection handler for single selection mode. */
 export type SelectHandlerSingle<T extends { required?: boolean | undefined }> =
   (
     triggerDate: Date,
@@ -51,12 +56,14 @@ export type SelectHandlerSingle<T extends { required?: boolean | undefined }> =
     e: React.MouseEvent | React.KeyboardEvent,
   ) => T["required"] extends true ? Date : Date | undefined;
 
+/** Selection handler for multiple selection mode. */
 export type SelectHandlerMulti<T extends { required?: boolean | undefined }> = (
   triggerDate: Date,
   modifiers: Modifiers,
   e: React.MouseEvent | React.KeyboardEvent,
 ) => T["required"] extends true ? Date[] : Date[] | undefined;
 
+/** Selection handler for range selection mode. */
 export type SelectHandlerRange<T extends { required?: boolean | undefined }> = (
   triggerDate: Date,
   modifiers: Modifiers,


### PR DESCRIPTION
## What Changed

- Added JSDoc descriptions for public type aliases that rendered with blank API descriptions.
- Regenerated the version-next API reference so /next/api/react shows descriptions in the Type Aliases table.

## Review Notes

No changeset: this is documentation-only and does not change runtime behavior or the public type shape.

Validated with:
- pnpm --filter website generate:api:next
- pnpm --filter react-day-picker typecheck
- git diff --check