### PR TITLE
fix: retry npm dist-tag verification

### DIFF
--- a/scripts/publish-packages.test.ts
+++ b/scripts/publish-packages.test.ts
@@ -84,6 +84,7 @@ beforeEach(function setupPublishPackagesTestState() {
 });
 
 afterEach(function restoreConsoleSpy() {
+  jest.useRealTimers();
   consoleLogSpy.mockRestore();
 });
 
@@ -207,7 +208,7 @@ describe("publishPackages", function describePublishPackages() {
 });
 
 describe("verifyPackageDistTags", function describeVerifyPackageDistTags() {
-  test("it accepts package dist-tags that point to the current versions", function testMatchingDistTags() {
+  test("it accepts package dist-tags that point to the current versions", async function testMatchingDistTags() {
     publishPackagesExecFileSyncMock.mockImplementation(
       function mockExecFile(command, args, options) {
         execCalls.push({
@@ -220,10 +221,55 @@ describe("verifyPackageDistTags", function describeVerifyPackageDistTags() {
       },
     );
 
-    expect(() => verifyPackageDistTags("next")).not.toThrow();
+    await expect(verifyPackageDistTags("next")).resolves.toBeUndefined();
   });
 
-  test("it explains how to repair mismatched package dist-tags", function testMismatchedDistTag() {
+  test("it retries stale package dist-tags until npm returns the current version", async function testStaleDistTagRetry() {
+    jest.useFakeTimers();
+
+    publishPackagesExecFileSyncMock.mockImplementation(
+      function mockExecFile(command, args, options) {
+        execCalls.push({
+          command: String(command),
+          args: Array.isArray(args) ? [...args] : [],
+          options,
+        });
+
+        if (
+          command === "npm" &&
+          Array.isArray(args) &&
+          args[1] === "@daypicker/react@next"
+        ) {
+          const packageReads = execCalls.filter(
+            (call) => call.args[1] === "@daypicker/react@next",
+          );
+          return packageReads.length < 3
+            ? "10.0.0-next.0\n"
+            : "10.0.0-next.1\n";
+        }
+
+        return "10.0.0-next.1\n";
+      },
+    );
+
+    const verification = verifyPackageDistTags("next");
+    await jest.advanceTimersByTimeAsync(10_000);
+    await verification;
+
+    expect(
+      execCalls
+        .filter((call) => call.args[1] === "@daypicker/react@next")
+        .map((call) => call.args),
+    ).toEqual([
+      ["view", "@daypicker/react@next", "version"],
+      ["view", "@daypicker/react@next", "version"],
+      ["view", "@daypicker/react@next", "version"],
+    ]);
+  });
+
+  test("it explains how to repair mismatched package dist-tags", async function testMismatchedDistTag() {
+    jest.useFakeTimers();
+
     publishPackagesExecFileSyncMock.mockImplementation(
       function mockExecFile(command, args, options) {
         execCalls.push({
@@ -244,8 +290,12 @@ describe("verifyPackageDistTags", function describeVerifyPackageDistTags() {
       },
     );
 
-    expect(() => verifyPackageDistTags("next")).toThrow(
+    const verification = verifyPackageDistTags("next");
+    const expectation = expect(verification).rejects.toThrow(
       "Expected npm dist-tag next for @daypicker/react to point to 10.0.0-next.1, got 10.0.0-next.0. Trusted publishing only authenticates npm publish, so repair the tag manually with: npm dist-tag add @daypicker/react@10.0.0-next.1 next",
     );
+
+    await jest.advanceTimersByTimeAsync(60_000);
+    await expectation;
   });
 });

--- a/scripts/publish-packages.ts
+++ b/scripts/publish-packages.ts
@@ -4,6 +4,8 @@ import process from "node:process";
 import { pathToFileURL } from "node:url";
 
 const repoRoot = new URL("../", import.meta.url);
+const distTagVerificationAttempts = 12;
+const distTagVerificationDelayMs = 5_000;
 
 export const publishablePackageDirs = [
   "packages/react-day-picker",
@@ -97,6 +99,35 @@ function readPackageVersionFromDistTag(
   }
 }
 
+async function waitForDistTagVerificationRetry(): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, distTagVerificationDelayMs);
+  });
+}
+
+async function readPackageVersionFromDistTagWithRetry(
+  packageInfo: {
+    name: string;
+    version: string;
+  },
+  tag: string,
+): Promise<string | undefined> {
+  let taggedVersion: string | undefined;
+
+  for (let attempt = 1; attempt <= distTagVerificationAttempts; attempt++) {
+    taggedVersion = readPackageVersionFromDistTag(packageInfo, tag);
+    if (taggedVersion === packageInfo.version) {
+      return taggedVersion;
+    }
+
+    if (attempt < distTagVerificationAttempts) {
+      await waitForDistTagVerificationRetry();
+    }
+  }
+
+  return taggedVersion;
+}
+
 export function getUnpublishedPackages(): Array<{
   packageDir: string;
   packageInfo: {
@@ -112,14 +143,17 @@ export function getUnpublishedPackages(): Array<{
   });
 }
 
-export function verifyPackageDistTags(tag: string): void {
+export async function verifyPackageDistTags(tag: string): Promise<void> {
   if (!tag) {
     throw new Error("Usage: verifyPackageDistTags <npm-tag>");
   }
 
   for (const packageDir of publishablePackageDirs) {
     const packageInfo = readPackageInfo(packageDir);
-    const taggedVersion = readPackageVersionFromDistTag(packageInfo, tag);
+    const taggedVersion = await readPackageVersionFromDistTagWithRetry(
+      packageInfo,
+      tag,
+    );
     if (taggedVersion === packageInfo.version) {
       continue;
     }

--- a/scripts/release-ci.ts
+++ b/scripts/release-ci.ts
@@ -96,7 +96,7 @@ export async function releaseCi(): Promise<{
 
     console.log(`Publishing ${packageInfo.version} with dist-tag ${npmTag}.`);
     publishPackages(npmTag);
-    verifyPackageDistTags(npmTag);
+    await verifyPackageDistTags(npmTag);
     publishedPackages = true;
   } else {
     console.log("All publishable package versions are already on npm.");


### PR DESCRIPTION
The v10 recovery showed that npm can briefly return stale dist-tag metadata immediately after a successful trusted publish. This keeps the release guard in place while allowing the registry time to converge before failing.

## What Changed

- Retry npm dist-tag verification for published packages before reporting a manual repair error.
- Await dist-tag verification from `release:ci` so the publish flow respects the retry window.
- Add script tests for immediate success, stale-then-success, and persistent stale-tag failure.

## Review Notes

This affects release automation only. The existing repair message is still used if npm never reports the expected tag after the retry window.

Validation:
- `pnpm test --selectProjects scripts --runTestsByPath scripts/publish-packages.test.ts scripts/release-ci.test.ts`
- `pnpm lint ci scripts/publish-packages.ts scripts/publish-packages.test.ts scripts/release-ci.ts scripts/release-ci.test.ts --reporter=github`
- `pnpm typecheck:root`
- `pnpm test --selectProjects scripts`