### PR TITLE
fix: add `@types/react` as optional peer dependency

### DIFF
--- a/.changeset/public-moles-knock.md
+++ b/.changeset/public-moles-knock.md
@@ -1,0 +1,11 @@
+---
+"@daypicker/buddhist": patch
+"@daypicker/ethiopic": patch
+"@daypicker/hebrew": patch
+"@daypicker/hijri": patch
+"@daypicker/persian": patch
+"@daypicker/react": patch
+"react-day-picker": patch
+---
+
+Added `@types/react` as an optional peer dependency to fix type resolution under strict package managers.

--- a/packages/buddhist/package.json
+++ b/packages/buddhist/package.json
@@ -44,7 +44,13 @@
     "typecheck": "tsc --project ./tsconfig.json --noEmit"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": ">=16.8.0",
+    "@types/react": ">=16.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@daypicker/react": "10.0.0",

--- a/packages/ethiopic/package.json
+++ b/packages/ethiopic/package.json
@@ -44,7 +44,13 @@
     "typecheck": "tsc --project ./tsconfig.json --noEmit"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": ">=16.8.0",
+    "@types/react": ">=16.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@daypicker/react": "10.0.0",

--- a/packages/hebrew/package.json
+++ b/packages/hebrew/package.json
@@ -44,7 +44,13 @@
     "typecheck": "tsc --project ./tsconfig.json --noEmit"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": ">=16.8.0",
+    "@types/react": ">=16.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@daypicker/react": "10.0.0",

--- a/packages/hijri/package.json
+++ b/packages/hijri/package.json
@@ -44,7 +44,13 @@
     "typecheck": "tsc --project ./tsconfig.json --noEmit"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": ">=16.8.0",
+    "@types/react": ">=16.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@daypicker/react": "10.0.0",

--- a/packages/persian/package.json
+++ b/packages/persian/package.json
@@ -44,7 +44,13 @@
     "typecheck": "tsc --project ./tsconfig.json --noEmit"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": ">=16.8.0",
+    "@types/react": ">=16.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@daypicker/react": "10.0.0",

--- a/packages/react-day-picker/package.json
+++ b/packages/react-day-picker/package.json
@@ -168,7 +168,13 @@
     "date-fns": "^4.1.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": ">=16.8.0",
+    "@types/react": ">=16.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "funding": {
     "type": "individual",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -161,7 +161,13 @@
     "react-day-picker": "10.0.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": ">=16.8.0",
+    "@types/react": ">=16.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "funding": {
     "type": "individual",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,6 +387,9 @@ importers:
       '@daypicker/react':
         specifier: link:../react
         version: link:../react
+      '@types/react':
+        specifier: '>=16.8.0'
+        version: 19.2.14
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -399,6 +402,9 @@ importers:
       '@daypicker/react':
         specifier: link:../react
         version: link:../react
+      '@types/react':
+        specifier: '>=16.8.0'
+        version: 19.2.14
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -411,6 +417,9 @@ importers:
       '@daypicker/react':
         specifier: link:../react
         version: link:../react
+      '@types/react':
+        specifier: '>=16.8.0'
+        version: 19.2.14
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -426,6 +435,9 @@ importers:
       '@tabby_ai/hijri-converter':
         specifier: 1.0.5
         version: 1.0.5
+      '@types/react':
+        specifier: '>=16.8.0'
+        version: 19.2.14
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -441,6 +453,9 @@ importers:
       '@daypicker/react':
         specifier: link:../react
         version: link:../react
+      '@types/react':
+        specifier: '>=16.8.0'
+        version: 19.2.14
       date-fns-jalali:
         specifier: 4.1.0-0
         version: 4.1.0-0
@@ -450,6 +465,9 @@ importers:
 
   packages/react:
     dependencies:
+      '@types/react':
+        specifier: '>=16.8.0'
+        version: 19.2.14
       react:
         specifier: '>=16.8.0'
         version: 19.2.5
@@ -462,6 +480,9 @@ importers:
       '@date-fns/tz':
         specifier: ^1.4.1
         version: 1.4.1
+      '@types/react':
+        specifier: '>=16.8.0'
+        version: 19.2.14
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0


### PR DESCRIPTION
This PR adds `@types/react` as an optional peer dependency, satisfying the requirements of stricter package manager configurations.

Closes #2994

