### PR TITLE
fix: clamp the displayed month when the navigation range changes

### DIFF
--- a/.changeset/olive-moons-smoke.md
+++ b/.changeset/olive-moons-smoke.md
@@ -1,0 +1,11 @@
+---
+"@daypicker/buddhist": patch
+"@daypicker/ethiopic": patch
+"@daypicker/hebrew": patch
+"@daypicker/hijri": patch
+"@daypicker/persian": patch
+"@daypicker/react": patch
+"react-day-picker": patch
+---
+
+Clamped the displayed month to the navigation range when `startMonth` or `endMonth` change after the calendar has been rendered. Narrowing the range past the current month no longer empties the month grid and the dropdowns.

--- a/packages/react-day-picker/src/DayPicker.test.tsx
+++ b/packages/react-day-picker/src/DayPicker.test.tsx
@@ -4,9 +4,11 @@ import {
   activeElement,
   dateButton,
   grid,
+  monthDropdown,
   nav,
   nextButton,
   previousButton,
+  yearDropdown,
 } from "@/test/elements";
 import { act, fireEvent, render, screen } from "@/test/render";
 import { setTestTime } from "@/test/setTestTime";
@@ -733,5 +735,80 @@ describe("when navLayout is set", () => {
     test("render the navigation after the month caption", () => {
       expect(nav().previousSibling).toHaveTextContent("February 2024");
     });
+  });
+});
+
+describe("when the navigation range changes after the calendar is rendered", () => {
+  test("clamps the displayed month to the new endMonth", () => {
+    const { rerender } = render(
+      <DayPicker
+        captionLayout="dropdown"
+        defaultMonth={new Date(2025, 5)}
+        startMonth={new Date(2024, 0)}
+        endMonth={new Date(2025, 11)}
+      />,
+    );
+    expect(grid("June 2025")).toBeInTheDocument();
+
+    rerender(
+      <DayPicker
+        captionLayout="dropdown"
+        defaultMonth={new Date(2025, 5)}
+        startMonth={new Date(2024, 0)}
+        endMonth={new Date(2025, 0)}
+      />,
+    );
+
+    expect(grid("January 2025")).toBeInTheDocument();
+    expect(monthDropdown()).toBeInTheDocument();
+    expect(yearDropdown()).toBeInTheDocument();
+  });
+
+  test("clamps the displayed month to the new startMonth", () => {
+    const { rerender } = render(
+      <DayPicker
+        captionLayout="dropdown"
+        defaultMonth={new Date(2025, 5)}
+        startMonth={new Date(2024, 0)}
+        endMonth={new Date(2025, 11)}
+      />,
+    );
+    expect(grid("June 2025")).toBeInTheDocument();
+
+    rerender(
+      <DayPicker
+        captionLayout="dropdown"
+        defaultMonth={new Date(2025, 5)}
+        startMonth={new Date(2025, 9)}
+        endMonth={new Date(2025, 11)}
+      />,
+    );
+
+    expect(grid("October 2025")).toBeInTheDocument();
+    expect(monthDropdown()).toBeInTheDocument();
+    expect(yearDropdown()).toBeInTheDocument();
+  });
+
+  test("keeps every month visible with numberOfMonths", () => {
+    const { rerender } = render(
+      <DayPicker
+        numberOfMonths={2}
+        defaultMonth={new Date(2025, 5)}
+        endMonth={new Date(2025, 11)}
+      />,
+    );
+    expect(grid("June 2025")).toBeInTheDocument();
+    expect(grid("July 2025")).toBeInTheDocument();
+
+    rerender(
+      <DayPicker
+        numberOfMonths={2}
+        defaultMonth={new Date(2025, 5)}
+        endMonth={new Date(2025, 2)}
+      />,
+    );
+
+    expect(grid("February 2025")).toBeInTheDocument();
+    expect(grid("March 2025")).toBeInTheDocument();
   });
 });

--- a/packages/react-day-picker/src/useCalendar.ts
+++ b/packages/react-day-picker/src/useCalendar.ts
@@ -102,6 +102,20 @@ export function useCalendar(
     props.month ? initialMonth : undefined,
   );
 
+  /**
+   * The first month to display, clamped to the navigable range.
+   *
+   * `startMonth` and `endMonth` can change after the calendar has been
+   * navigated, leaving the stored month out of range. When `month` is
+   * controlled, the clamping already happens in `initialMonth` above.
+   */
+  const displayMonth = getInitialMonth(
+    { ...props, month: firstMonth },
+    navStart,
+    navEnd,
+    dateLib,
+  );
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: change the initial month when the time zone changes.
   useEffect(() => {
     const newInitialMonth = getInitialMonth(props, navStart, navEnd, dateLib);
@@ -112,7 +126,7 @@ export function useCalendar(
   // biome-ignore lint/correctness/useExhaustiveDependencies: We want to recompute only when specific props change.
   const { months, weeks, days, previousMonth, nextMonth } = useMemo(() => {
     const displayMonths = getDisplayMonths(
-      firstMonth,
+      displayMonth,
       navEnd,
       { numberOfMonths: props.numberOfMonths },
       dateLib,
@@ -145,12 +159,12 @@ export function useCalendar(
     const days = getDays(months);
 
     const previousMonth = getPreviousMonth(
-      firstMonth,
+      displayMonth,
       navStart,
       props,
       dateLib,
     );
-    const nextMonth = getNextMonth(firstMonth, navEnd, props, dateLib);
+    const nextMonth = getNextMonth(displayMonth, navEnd, props, dateLib);
 
     return {
       months,
@@ -161,7 +175,7 @@ export function useCalendar(
     };
   }, [
     dateLib,
-    firstMonth.getTime(),
+    displayMonth.getTime(),
     navEnd?.getTime(),
     navStart?.getTime(),
     props.disableNavigation,


### PR DESCRIPTION
Closes #2912.

## The problem

When `endMonth` (or `startMonth`) changes to a range that no longer contains the month being displayed, the month grid and the dropdowns disappear.

`getDisplayMonths` breaks out of its loop as soon as the first month is past `calendarEndMonth`, so it returns an empty array and nothing is rendered:

```ts
for (let i = 0; i < numberOfMonths; i++) {
  const month = dateLib.addMonths(firstDisplayedMonth, i);
  if (calendarEndMonth && month > calendarEndMonth) break;
  months.push(month);
}
```

The displayed month is clamped to the navigation range by `getInitialMonth`, but that only happens when the calendar mounts (and when the time zone changes). The month stored by `useControlledValue` is then left out of range.

Worth noting: this does not reproduce when `month` is controlled, because in that case `initialMonth` is recomputed on every render and the clamping is applied again. The uncontrolled case was the one drifting out of range.

## The fix

Clamp the displayed month to the navigation range on every render, reusing the existing `getInitialMonth` logic so the rule lives in one place:

```ts
const displayMonth = getInitialMonth(
  { ...props, month: firstMonth },
  navStart,
  navEnd,
  dateLib,
);
```

`displayMonth` then feeds `getDisplayMonths`, `getPreviousMonth` and `getNextMonth`, so the grid, the dropdowns and the navigation buttons all stay consistent with the new range. This matches the behaviour suggested in the issue: the calendar switches to the closest month it can display. No state is written, so no extra render and no `onMonthChange` is fired.

## Tests

Three tests in `DayPicker.test.tsx` covering `endMonth` narrowing, `startMonth` moving forward, and `numberOfMonths={2}`. They fail on `main` and pass with the fix.

## Verification

- `pnpm test`: 221 suites, 1087 tests passing
- `pnpm test:tz`: 3 passing
- `pnpm typecheck` and `biome check`: clean
- Same results on `main` before the change, so no regressions
