### PR TITLE
fix: import date-fns locales from subpaths

### DIFF
--- a/.changeset/fix-locale-subpath-imports.md
+++ b/.changeset/fix-locale-subpath-imports.md
@@ -1,0 +1,6 @@
+---
+"react-day-picker": patch
+"@daypicker/react": patch
+---
+
+fix: avoid loading all date-fns locales when importing a locale subpath.

--- a/biome.json
+++ b/biome.json
@@ -40,6 +40,23 @@
   },
   "overrides": [
     {
+      "includes": ["packages/react-day-picker/src/locale/*.ts"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "date-fns/locale": "Import each locale from its date-fns locale subpath."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
       "includes": ["**/*.test.ts", "**/*.test.tsx"],
       "linter": {
         "rules": {

--- a/packages/react-day-picker/src/locale/af.ts
+++ b/packages/react-day-picker/src/locale/af.ts
@@ -1,4 +1,4 @@
-import { af as dateFnsAf } from "date-fns/locale";
+import { af as dateFnsAf } from "date-fns/locale/af";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/ar-DZ.ts
+++ b/packages/react-day-picker/src/locale/ar-DZ.ts
@@ -1,4 +1,4 @@
-import { arDZ as dateFnsArDZ } from "date-fns/locale";
+import { arDZ as dateFnsArDZ } from "date-fns/locale/ar-DZ";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/ar-EG.ts
+++ b/packages/react-day-picker/src/locale/ar-EG.ts
@@ -1,4 +1,4 @@
-import { arEG as dateFnsArEG } from "date-fns/locale";
+import { arEG as dateFnsArEG } from "date-fns/locale/ar-EG";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/ar-MA.ts
+++ b/packages/react-day-picker/src/locale/ar-MA.ts
@@ -1,4 +1,4 @@
-import { arMA as dateFnsArMA } from "date-fns/locale";
+import { arMA as dateFnsArMA } from "date-fns/locale/ar-MA";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/ar-SA.ts
+++ b/packages/react-day-picker/src/locale/ar-SA.ts
@@ -1,4 +1,4 @@
-import { arSA as dateFnsArSA } from "date-fns/locale";
+import { arSA as dateFnsArSA } from "date-fns/locale/ar-SA";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/ar-TN.ts
+++ b/packages/react-day-picker/src/locale/ar-TN.ts
@@ -1,4 +1,4 @@
-import { arTN as dateFnsArTN } from "date-fns/locale";
+import { arTN as dateFnsArTN } from "date-fns/locale/ar-TN";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/ar.ts
+++ b/packages/react-day-picker/src/locale/ar.ts
@@ -1,4 +1,4 @@
-import { ar as dateFnsAr } from "date-fns/locale";
+import { ar as dateFnsAr } from "date-fns/locale/ar";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/az.ts
+++ b/packages/react-day-picker/src/locale/az.ts
@@ -1,4 +1,4 @@
-import { az as dateFnsAz } from "date-fns/locale";
+import { az as dateFnsAz } from "date-fns/locale/az";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/be-tarask.ts
+++ b/packages/react-day-picker/src/locale/be-tarask.ts
@@ -1,4 +1,4 @@
-import { beTarask as dateFnsBeTarask } from "date-fns/locale";
+import { beTarask as dateFnsBeTarask } from "date-fns/locale/be-tarask";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/be.ts
+++ b/packages/react-day-picker/src/locale/be.ts
@@ -1,4 +1,4 @@
-import { be as dateFnsBe } from "date-fns/locale";
+import { be as dateFnsBe } from "date-fns/locale/be";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/bg.ts
+++ b/packages/react-day-picker/src/locale/bg.ts
@@ -1,4 +1,4 @@
-import { bg as dateFnsBg } from "date-fns/locale";
+import { bg as dateFnsBg } from "date-fns/locale/bg";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/bn.ts
+++ b/packages/react-day-picker/src/locale/bn.ts
@@ -1,4 +1,4 @@
-import { bn as dateFnsBn } from "date-fns/locale";
+import { bn as dateFnsBn } from "date-fns/locale/bn";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/bs.ts
+++ b/packages/react-day-picker/src/locale/bs.ts
@@ -1,4 +1,4 @@
-import { bs as dateFnsBs } from "date-fns/locale";
+import { bs as dateFnsBs } from "date-fns/locale/bs";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/ca.ts
+++ b/packages/react-day-picker/src/locale/ca.ts
@@ -1,4 +1,4 @@
-import { ca as dateFnsCa } from "date-fns/locale";
+import { ca as dateFnsCa } from "date-fns/locale/ca";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/ckb.ts
+++ b/packages/react-day-picker/src/locale/ckb.ts
@@ -1,4 +1,4 @@
-import { ckb as dateFnsCkb } from "date-fns/locale";
+import { ckb as dateFnsCkb } from "date-fns/locale/ckb";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/cs.ts
+++ b/packages/react-day-picker/src/locale/cs.ts
@@ -1,4 +1,4 @@
-import { cs as dateFnsCs } from "date-fns/locale";
+import { cs as dateFnsCs } from "date-fns/locale/cs";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/cy.ts
+++ b/packages/react-day-picker/src/locale/cy.ts
@@ -1,4 +1,4 @@
-import { cy as dateFnsCy } from "date-fns/locale";
+import { cy as dateFnsCy } from "date-fns/locale/cy";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/da.ts
+++ b/packages/react-day-picker/src/locale/da.ts
@@ -1,4 +1,4 @@
-import { da as dateFnsDa } from "date-fns/locale";
+import { da as dateFnsDa } from "date-fns/locale/da";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/de-AT.ts
+++ b/packages/react-day-picker/src/locale/de-AT.ts
@@ -1,4 +1,4 @@
-import { deAT as dateFnsDeAT } from "date-fns/locale";
+import { deAT as dateFnsDeAT } from "date-fns/locale/de-AT";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/de.ts
+++ b/packages/react-day-picker/src/locale/de.ts
@@ -1,4 +1,4 @@
-import { de as dateFnsDe } from "date-fns/locale";
+import { de as dateFnsDe } from "date-fns/locale/de";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/el.ts
+++ b/packages/react-day-picker/src/locale/el.ts
@@ -1,4 +1,4 @@
-import { el as dateFnsEl } from "date-fns/locale";
+import { el as dateFnsEl } from "date-fns/locale/el";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/en-AU.ts
+++ b/packages/react-day-picker/src/locale/en-AU.ts
@@ -1,4 +1,4 @@
-import { enAU as dateFnsEnAU } from "date-fns/locale";
+import { enAU as dateFnsEnAU } from "date-fns/locale/en-AU";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/en-CA.ts
+++ b/packages/react-day-picker/src/locale/en-CA.ts
@@ -1,4 +1,4 @@
-import { enCA as dateFnsEnCA } from "date-fns/locale";
+import { enCA as dateFnsEnCA } from "date-fns/locale/en-CA";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/en-GB.ts
+++ b/packages/react-day-picker/src/locale/en-GB.ts
@@ -1,4 +1,4 @@
-import { enGB as dateFnsEnGB } from "date-fns/locale";
+import { enGB as dateFnsEnGB } from "date-fns/locale/en-GB";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/en-IE.ts
+++ b/packages/react-day-picker/src/locale/en-IE.ts
@@ -1,4 +1,4 @@
-import { enIE as dateFnsEnIE } from "date-fns/locale";
+import { enIE as dateFnsEnIE } from "date-fns/locale/en-IE";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/en-IN.ts
+++ b/packages/react-day-picker/src/locale/en-IN.ts
@@ -1,4 +1,4 @@
-import { enIN as dateFnsEnIN } from "date-fns/locale";
+import { enIN as dateFnsEnIN } from "date-fns/locale/en-IN";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/en-NZ.ts
+++ b/packages/react-day-picker/src/locale/en-NZ.ts
@@ -1,4 +1,4 @@
-import { enNZ as dateFnsEnNZ } from "date-fns/locale";
+import { enNZ as dateFnsEnNZ } from "date-fns/locale/en-NZ";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/en-US.ts
+++ b/packages/react-day-picker/src/locale/en-US.ts
@@ -1,5 +1,5 @@
 import { format } from "date-fns";
-import { enUS as dateFnsEnUS } from "date-fns/locale";
+import { enUS as dateFnsEnUS } from "date-fns/locale/en-US";
 
 import type {
   DateLib,

--- a/packages/react-day-picker/src/locale/en-ZA.ts
+++ b/packages/react-day-picker/src/locale/en-ZA.ts
@@ -1,4 +1,4 @@
-import { enZA as dateFnsEnZA } from "date-fns/locale";
+import { enZA as dateFnsEnZA } from "date-fns/locale/en-ZA";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/eo.ts
+++ b/packages/react-day-picker/src/locale/eo.ts
@@ -1,4 +1,4 @@
-import { eo as dateFnsEo } from "date-fns/locale";
+import { eo as dateFnsEo } from "date-fns/locale/eo";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/es.ts
+++ b/packages/react-day-picker/src/locale/es.ts
@@ -1,4 +1,4 @@
-import { es as dateFnsEs } from "date-fns/locale";
+import { es as dateFnsEs } from "date-fns/locale/es";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/et.ts
+++ b/packages/react-day-picker/src/locale/et.ts
@@ -1,4 +1,4 @@
-import { et as dateFnsEt } from "date-fns/locale";
+import { et as dateFnsEt } from "date-fns/locale/et";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/eu.ts
+++ b/packages/react-day-picker/src/locale/eu.ts
@@ -1,4 +1,4 @@
-import { eu as dateFnsEu } from "date-fns/locale";
+import { eu as dateFnsEu } from "date-fns/locale/eu";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/fa-IR.ts
+++ b/packages/react-day-picker/src/locale/fa-IR.ts
@@ -1,4 +1,4 @@
-import { faIR as dateFnsFaIR } from "date-fns/locale";
+import { faIR as dateFnsFaIR } from "date-fns/locale/fa-IR";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/fi.ts
+++ b/packages/react-day-picker/src/locale/fi.ts
@@ -1,4 +1,4 @@
-import { fi as dateFnsFi } from "date-fns/locale";
+import { fi as dateFnsFi } from "date-fns/locale/fi";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/fr-CA.ts
+++ b/packages/react-day-picker/src/locale/fr-CA.ts
@@ -1,4 +1,4 @@
-import { frCA as dateFnsFrCA } from "date-fns/locale";
+import { frCA as dateFnsFrCA } from "date-fns/locale/fr-CA";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/fr-CH.ts
+++ b/packages/react-day-picker/src/locale/fr-CH.ts
@@ -1,4 +1,4 @@
-import { frCH as dateFnsFrCH } from "date-fns/locale";
+import { frCH as dateFnsFrCH } from "date-fns/locale/fr-CH";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/fr.ts
+++ b/packages/react-day-picker/src/locale/fr.ts
@@ -1,4 +1,4 @@
-import { fr as dateFnsFr } from "date-fns/locale";
+import { fr as dateFnsFr } from "date-fns/locale/fr";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/fy.ts
+++ b/packages/react-day-picker/src/locale/fy.ts
@@ -1,4 +1,4 @@
-import { fy as dateFnsFy } from "date-fns/locale";
+import { fy as dateFnsFy } from "date-fns/locale/fy";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/gd.ts
+++ b/packages/react-day-picker/src/locale/gd.ts
@@ -1,4 +1,4 @@
-import { gd as dateFnsGd } from "date-fns/locale";
+import { gd as dateFnsGd } from "date-fns/locale/gd";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/gl.ts
+++ b/packages/react-day-picker/src/locale/gl.ts
@@ -1,4 +1,4 @@
-import { gl as dateFnsGl } from "date-fns/locale";
+import { gl as dateFnsGl } from "date-fns/locale/gl";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/gu.ts
+++ b/packages/react-day-picker/src/locale/gu.ts
@@ -1,4 +1,4 @@
-import { gu as dateFnsGu } from "date-fns/locale";
+import { gu as dateFnsGu } from "date-fns/locale/gu";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/he.ts
+++ b/packages/react-day-picker/src/locale/he.ts
@@ -1,4 +1,4 @@
-import { he as dateFnsHe } from "date-fns/locale";
+import { he as dateFnsHe } from "date-fns/locale/he";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/hi.ts
+++ b/packages/react-day-picker/src/locale/hi.ts
@@ -1,4 +1,4 @@
-import { hi as dateFnsHi } from "date-fns/locale";
+import { hi as dateFnsHi } from "date-fns/locale/hi";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/hr.ts
+++ b/packages/react-day-picker/src/locale/hr.ts
@@ -1,4 +1,4 @@
-import { hr as dateFnsHr } from "date-fns/locale";
+import { hr as dateFnsHr } from "date-fns/locale/hr";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/ht.ts
+++ b/packages/react-day-picker/src/locale/ht.ts
@@ -1,4 +1,4 @@
-import { ht as dateFnsHt } from "date-fns/locale";
+import { ht as dateFnsHt } from "date-fns/locale/ht";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/hu.ts
+++ b/packages/react-day-picker/src/locale/hu.ts
@@ -1,4 +1,4 @@
-import { hu as dateFnsHu } from "date-fns/locale";
+import { hu as dateFnsHu } from "date-fns/locale/hu";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/hy.ts
+++ b/packages/react-day-picker/src/locale/hy.ts
@@ -1,4 +1,4 @@
-import { hy as dateFnsHy } from "date-fns/locale";
+import { hy as dateFnsHy } from "date-fns/locale/hy";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/id.ts
+++ b/packages/react-day-picker/src/locale/id.ts
@@ -1,4 +1,4 @@
-import { id as dateFnsId } from "date-fns/locale";
+import { id as dateFnsId } from "date-fns/locale/id";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/is.ts
+++ b/packages/react-day-picker/src/locale/is.ts
@@ -1,4 +1,4 @@
-import { is as dateFnsIs } from "date-fns/locale";
+import { is as dateFnsIs } from "date-fns/locale/is";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/it-CH.ts
+++ b/packages/react-day-picker/src/locale/it-CH.ts
@@ -1,4 +1,4 @@
-import { itCH as dateFnsItCH } from "date-fns/locale";
+import { itCH as dateFnsItCH } from "date-fns/locale/it-CH";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/it.ts
+++ b/packages/react-day-picker/src/locale/it.ts
@@ -1,4 +1,4 @@
-import { it as dateFnsIt } from "date-fns/locale";
+import { it as dateFnsIt } from "date-fns/locale/it";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/ja-Hira.ts
+++ b/packages/react-day-picker/src/locale/ja-Hira.ts
@@ -1,4 +1,4 @@
-import { jaHira as dateFnsJaHira } from "date-fns/locale";
+import { jaHira as dateFnsJaHira } from "date-fns/locale/ja-Hira";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/ja.ts
+++ b/packages/react-day-picker/src/locale/ja.ts
@@ -1,4 +1,4 @@
-import { ja as dateFnsJa } from "date-fns/locale";
+import { ja as dateFnsJa } from "date-fns/locale/ja";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/ka.ts
+++ b/packages/react-day-picker/src/locale/ka.ts
@@ -1,4 +1,4 @@
-import { ka as dateFnsKa } from "date-fns/locale";
+import { ka as dateFnsKa } from "date-fns/locale/ka";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/kk.ts
+++ b/packages/react-day-picker/src/locale/kk.ts
@@ -1,4 +1,4 @@
-import { kk as dateFnsKk } from "date-fns/locale";
+import { kk as dateFnsKk } from "date-fns/locale/kk";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/km.ts
+++ b/packages/react-day-picker/src/locale/km.ts
@@ -1,4 +1,4 @@
-import { km as dateFnsKm } from "date-fns/locale";
+import { km as dateFnsKm } from "date-fns/locale/km";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/kn.ts
+++ b/packages/react-day-picker/src/locale/kn.ts
@@ -1,4 +1,4 @@
-import { kn as dateFnsKn } from "date-fns/locale";
+import { kn as dateFnsKn } from "date-fns/locale/kn";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/ko.ts
+++ b/packages/react-day-picker/src/locale/ko.ts
@@ -1,4 +1,4 @@
-import { ko as dateFnsKo } from "date-fns/locale";
+import { ko as dateFnsKo } from "date-fns/locale/ko";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/lb.ts
+++ b/packages/react-day-picker/src/locale/lb.ts
@@ -1,4 +1,4 @@
-import { lb as dateFnsLb } from "date-fns/locale";
+import { lb as dateFnsLb } from "date-fns/locale/lb";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/lt.ts
+++ b/packages/react-day-picker/src/locale/lt.ts
@@ -1,4 +1,4 @@
-import { lt as dateFnsLt } from "date-fns/locale";
+import { lt as dateFnsLt } from "date-fns/locale/lt";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/lv.ts
+++ b/packages/react-day-picker/src/locale/lv.ts
@@ -1,4 +1,4 @@
-import { lv as dateFnsLv } from "date-fns/locale";
+import { lv as dateFnsLv } from "date-fns/locale/lv";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/mk.ts
+++ b/packages/react-day-picker/src/locale/mk.ts
@@ -1,4 +1,4 @@
-import { mk as dateFnsMk } from "date-fns/locale";
+import { mk as dateFnsMk } from "date-fns/locale/mk";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/mn.ts
+++ b/packages/react-day-picker/src/locale/mn.ts
@@ -1,4 +1,4 @@
-import { mn as dateFnsMn } from "date-fns/locale";
+import { mn as dateFnsMn } from "date-fns/locale/mn";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/ms.ts
+++ b/packages/react-day-picker/src/locale/ms.ts
@@ -1,4 +1,4 @@
-import { ms as dateFnsMs } from "date-fns/locale";
+import { ms as dateFnsMs } from "date-fns/locale/ms";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/mt.ts
+++ b/packages/react-day-picker/src/locale/mt.ts
@@ -1,4 +1,4 @@
-import { mt as dateFnsMt } from "date-fns/locale";
+import { mt as dateFnsMt } from "date-fns/locale/mt";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/nb.ts
+++ b/packages/react-day-picker/src/locale/nb.ts
@@ -1,4 +1,4 @@
-import { nb as dateFnsNb } from "date-fns/locale";
+import { nb as dateFnsNb } from "date-fns/locale/nb";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/nl-BE.ts
+++ b/packages/react-day-picker/src/locale/nl-BE.ts
@@ -1,4 +1,4 @@
-import { nlBE as dateFnsNlBE } from "date-fns/locale";
+import { nlBE as dateFnsNlBE } from "date-fns/locale/nl-BE";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/nl.ts
+++ b/packages/react-day-picker/src/locale/nl.ts
@@ -1,4 +1,4 @@
-import { nl as dateFnsNl } from "date-fns/locale";
+import { nl as dateFnsNl } from "date-fns/locale/nl";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/nn.ts
+++ b/packages/react-day-picker/src/locale/nn.ts
@@ -1,4 +1,4 @@
-import { nn as dateFnsNn } from "date-fns/locale";
+import { nn as dateFnsNn } from "date-fns/locale/nn";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/oc.ts
+++ b/packages/react-day-picker/src/locale/oc.ts
@@ -1,4 +1,4 @@
-import { oc as dateFnsOc } from "date-fns/locale";
+import { oc as dateFnsOc } from "date-fns/locale/oc";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/pl.ts
+++ b/packages/react-day-picker/src/locale/pl.ts
@@ -1,4 +1,4 @@
-import { pl as dateFnsPl } from "date-fns/locale";
+import { pl as dateFnsPl } from "date-fns/locale/pl";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/pt-BR.ts
+++ b/packages/react-day-picker/src/locale/pt-BR.ts
@@ -1,4 +1,4 @@
-import { ptBR as dateFnsPtBR } from "date-fns/locale";
+import { ptBR as dateFnsPtBR } from "date-fns/locale/pt-BR";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/pt.ts
+++ b/packages/react-day-picker/src/locale/pt.ts
@@ -1,4 +1,4 @@
-import { pt as dateFnsPt } from "date-fns/locale";
+import { pt as dateFnsPt } from "date-fns/locale/pt";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/ro.ts
+++ b/packages/react-day-picker/src/locale/ro.ts
@@ -1,4 +1,4 @@
-import { ro as dateFnsRo } from "date-fns/locale";
+import { ro as dateFnsRo } from "date-fns/locale/ro";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/ru.ts
+++ b/packages/react-day-picker/src/locale/ru.ts
@@ -1,4 +1,4 @@
-import { ru as dateFnsRu } from "date-fns/locale";
+import { ru as dateFnsRu } from "date-fns/locale/ru";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/se.ts
+++ b/packages/react-day-picker/src/locale/se.ts
@@ -1,4 +1,4 @@
-import { se as dateFnsSe } from "date-fns/locale";
+import { se as dateFnsSe } from "date-fns/locale/se";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/sk.ts
+++ b/packages/react-day-picker/src/locale/sk.ts
@@ -1,4 +1,4 @@
-import { sk as dateFnsSk } from "date-fns/locale";
+import { sk as dateFnsSk } from "date-fns/locale/sk";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/sl.ts
+++ b/packages/react-day-picker/src/locale/sl.ts
@@ -1,4 +1,4 @@
-import { sl as dateFnsSl } from "date-fns/locale";
+import { sl as dateFnsSl } from "date-fns/locale/sl";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/sq.ts
+++ b/packages/react-day-picker/src/locale/sq.ts
@@ -1,4 +1,4 @@
-import { sq as dateFnsSq } from "date-fns/locale";
+import { sq as dateFnsSq } from "date-fns/locale/sq";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/sr-Latn.ts
+++ b/packages/react-day-picker/src/locale/sr-Latn.ts
@@ -1,4 +1,4 @@
-import { srLatn as dateFnsSrLatn } from "date-fns/locale";
+import { srLatn as dateFnsSrLatn } from "date-fns/locale/sr-Latn";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/sr.ts
+++ b/packages/react-day-picker/src/locale/sr.ts
@@ -1,4 +1,4 @@
-import { sr as dateFnsSr } from "date-fns/locale";
+import { sr as dateFnsSr } from "date-fns/locale/sr";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/sv.ts
+++ b/packages/react-day-picker/src/locale/sv.ts
@@ -1,4 +1,4 @@
-import { sv as dateFnsSv } from "date-fns/locale";
+import { sv as dateFnsSv } from "date-fns/locale/sv";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/ta.ts
+++ b/packages/react-day-picker/src/locale/ta.ts
@@ -1,4 +1,4 @@
-import { ta as dateFnsTa } from "date-fns/locale";
+import { ta as dateFnsTa } from "date-fns/locale/ta";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/te.ts
+++ b/packages/react-day-picker/src/locale/te.ts
@@ -1,4 +1,4 @@
-import { te as dateFnsTe } from "date-fns/locale";
+import { te as dateFnsTe } from "date-fns/locale/te";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/th.ts
+++ b/packages/react-day-picker/src/locale/th.ts
@@ -1,4 +1,4 @@
-import { th as dateFnsTh } from "date-fns/locale";
+import { th as dateFnsTh } from "date-fns/locale/th";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/tr.ts
+++ b/packages/react-day-picker/src/locale/tr.ts
@@ -1,4 +1,4 @@
-import { tr as dateFnsTr } from "date-fns/locale";
+import { tr as dateFnsTr } from "date-fns/locale/tr";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/ug.ts
+++ b/packages/react-day-picker/src/locale/ug.ts
@@ -1,4 +1,4 @@
-import { ug as dateFnsUg } from "date-fns/locale";
+import { ug as dateFnsUg } from "date-fns/locale/ug";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/uk.ts
+++ b/packages/react-day-picker/src/locale/uk.ts
@@ -1,4 +1,4 @@
-import { uk as dateFnsUk } from "date-fns/locale";
+import { uk as dateFnsUk } from "date-fns/locale/uk";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/uz-Cyrl.ts
+++ b/packages/react-day-picker/src/locale/uz-Cyrl.ts
@@ -1,4 +1,4 @@
-import { uzCyrl as dateFnsUzCyrl } from "date-fns/locale";
+import { uzCyrl as dateFnsUzCyrl } from "date-fns/locale/uz-Cyrl";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/uz.ts
+++ b/packages/react-day-picker/src/locale/uz.ts
@@ -1,4 +1,4 @@
-import { uz as dateFnsUz } from "date-fns/locale";
+import { uz as dateFnsUz } from "date-fns/locale/uz";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/vi.ts
+++ b/packages/react-day-picker/src/locale/vi.ts
@@ -1,4 +1,4 @@
-import { vi as dateFnsVi } from "date-fns/locale";
+import { vi as dateFnsVi } from "date-fns/locale/vi";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/zh-CN.ts
+++ b/packages/react-day-picker/src/locale/zh-CN.ts
@@ -1,4 +1,4 @@
-import { zhCN as dateFnsZhCN } from "date-fns/locale";
+import { zhCN as dateFnsZhCN } from "date-fns/locale/zh-CN";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/zh-HK.ts
+++ b/packages/react-day-picker/src/locale/zh-HK.ts
@@ -1,4 +1,4 @@
-import { zhHK as dateFnsZhHK } from "date-fns/locale";
+import { zhHK as dateFnsZhHK } from "date-fns/locale/zh-HK";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";

--- a/packages/react-day-picker/src/locale/zh-TW.ts
+++ b/packages/react-day-picker/src/locale/zh-TW.ts
@@ -1,4 +1,4 @@
-import { zhTW as dateFnsZhTW } from "date-fns/locale";
+import { zhTW as dateFnsZhTW } from "date-fns/locale/zh-TW";
 
 import type { DateLibOptions, DayPickerLocale } from "../classes/DateLib.js";
 import { DateLib } from "../classes/DateLib.js";


### PR DESCRIPTION
Thanks for maintaining DayPicker — we use it in an SSR app and traced part of our startup cost to the translated locale wrappers.

Each wrapper currently imports from `date-fns/locale`. That works after tree-shaking, but Node and SSR setups that keep DayPicker external evaluate the whole date-fns locale barrel. Importing the matching date-fns subpath keeps the exported locale and translated labels unchanged without loading that barrel.

With a fresh ESM build loaded directly by Node, importing `react-day-picker` went from 943 to 421 loaded files. Importing `react-day-picker/locale/ja` went from 841 to 325. The date-fns locale barrel is no longer resolved in either path.

This applies the same direct-locale pattern as #2717 to all 95 wrappers, adds a scoped lint guard, and leaves the public `react-day-picker/locale` barrel unchanged. The existing tests, timezone test, typecheck, build, built-package tests, and package dry run pass. One caveat: the built-package tests hit the existing 1880/1879 boundary assertion under my local Asia/Tokyo timezone; all 311 pass with `TZ=UTC`.

Would you be open to this change? Happy to adjust the shape if you would prefer a smaller guard.
