### PR TITLE
fix: preserve focus after controlled month changes

### DIFF
--- a/.changeset/calm-calendars-focus.md
+++ b/.changeset/calm-calendars-focus.md
@@ -1,0 +1,6 @@
+---
+"react-day-picker": patch
+"@daypicker/react": patch
+---
+
+fix: preserve focus when controlled month changes replace the focused day.

--- a/examples/ControlledMonthFocus.test.tsx
+++ b/examples/ControlledMonthFocus.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+import { activeElement, dateButton, grid } from "@/test/elements";
+import { act, render, screen } from "@/test/render";
+import { user } from "@/test/user";
+import { ControlledMonthFocus } from "./ControlledMonthFocus";
+
+const march = new Date(2026, 2, 15);
+const november = new Date(2026, 10, 15);
+
+describe("when J changes the month while a day is focused", () => {
+  beforeEach(async () => {
+    render(<ControlledMonthFocus />);
+    act(() => dateButton(march).focus());
+    await user.keyboard("j");
+  });
+
+  test("displays the new month", () => {
+    expect(grid()).toHaveAccessibleName("November 2026");
+  });
+
+  test("focuses the selected day in the new month", () => {
+    expect(activeElement()).toBe(dateButton(november));
+  });
+});
+
+describe("when the external button changes the month", () => {
+  let jumpButton: HTMLButtonElement;
+
+  beforeEach(async () => {
+    render(<ControlledMonthFocus />);
+    jumpButton = screen.getByRole("button", { name: "Jump to November" });
+    await user.click(jumpButton);
+  });
+
+  test("displays the new month", () => {
+    expect(grid()).toHaveAccessibleName("November 2026");
+  });
+
+  test("keeps focus on the external button", () => {
+    expect(activeElement()).toBe(jumpButton);
+  });
+});

--- a/examples/ControlledMonthFocus.tsx
+++ b/examples/ControlledMonthFocus.tsx
@@ -1,0 +1,53 @@
+import { DayPicker } from "@daypicker/react";
+import { format, isSameMonth } from "date-fns";
+import React from "react";
+
+const march = new Date(2026, 2, 15);
+const november = new Date(2026, 10, 15);
+
+/** Demonstrates focus preservation across controlled month changes. */
+export function ControlledMonthFocus() {
+  const [month, setMonth] = React.useState(march);
+  const [selected, setSelected] = React.useState<Date | undefined>(march);
+  const [focusedDay, setFocusedDay] = React.useState<Date>();
+
+  const jumpToOtherMonth = () => {
+    const nextDay = isSameMonth(month, march) ? november : march;
+    setMonth(nextDay);
+    setSelected(nextDay);
+  };
+
+  return (
+    <fieldset
+      onKeyDown={(event) => {
+        if (event.key.toLowerCase() === "j") {
+          jumpToOtherMonth();
+        }
+      }}
+    >
+      <legend>Controlled month focus</legend>
+      <p>
+        Focus a day and press J to change the controlled month while preserving
+        focus. Use the button to change the month while focus is outside the day
+        grid.
+      </p>
+      <DayPicker
+        mode="single"
+        month={month}
+        onDayBlur={() => setFocusedDay(undefined)}
+        onDayFocus={setFocusedDay}
+        onMonthChange={setMonth}
+        onSelect={setSelected}
+        selected={selected}
+        footer={
+          focusedDay
+            ? `Focused day: ${format(focusedDay, "PPPP")}`
+            : "No day has focus"
+        }
+      />
+      <button type="button" onClick={jumpToOtherMonth}>
+        Jump to {isSameMonth(month, march) ? "November" : "March"}
+      </button>
+    </fieldset>
+  );
+}

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -11,6 +11,7 @@ export * from "./Buddhist";
 export * from "./BuddhistEn";
 export * from "./ContainerAttributes";
 export * from "./Controlled";
+export * from "./ControlledMonthFocus";
 export * from "./ControlledSelection";
 export * from "./CssModules";
 export * from "./CssVariables";

--- a/packages/react-day-picker/src/DayPicker.test.tsx
+++ b/packages/react-day-picker/src/DayPicker.test.tsx
@@ -502,6 +502,78 @@ describe("when the `month` is changed programmatically", () => {
     expect(grid("February 2023")).toBeInTheDocument();
   });
 
+  describe("when the controlled month removes the focused day", () => {
+    const initialDay = new Date(2026, 2, 15);
+    const newDay = new Date(2026, 10, 15);
+    const onSelect = jest.fn();
+
+    describe("when a day has focus", () => {
+      beforeEach(() => {
+        const { rerender } = render(
+          <DayPicker
+            month={initialDay}
+            mode="single"
+            onSelect={onSelect}
+            selected={initialDay}
+          />,
+        );
+        act(() => dateButton(initialDay).focus());
+
+        rerender(
+          <DayPicker
+            month={newDay}
+            mode="single"
+            onSelect={onSelect}
+            selected={newDay}
+          />,
+        );
+      });
+
+      test("moves focus to the selected day in the new month", () => {
+        expect(activeElement()).toBe(dateButton(newDay));
+      });
+    });
+
+    describe("when focus is outside the day grid", () => {
+      let outsideButton: HTMLButtonElement;
+
+      beforeEach(() => {
+        const { rerender } = render(
+          <>
+            <button type="button">Outside the calendar</button>
+            <DayPicker
+              month={initialDay}
+              mode="single"
+              onSelect={onSelect}
+              selected={initialDay}
+            />
+          </>,
+        );
+        outsideButton = screen.getByRole("button", {
+          name: "Outside the calendar",
+        });
+        act(() => dateButton(initialDay).focus());
+        act(() => outsideButton.focus());
+
+        rerender(
+          <>
+            <button type="button">Outside the calendar</button>
+            <DayPicker
+              month={newDay}
+              mode="single"
+              onSelect={onSelect}
+              selected={newDay}
+            />
+          </>,
+        );
+      });
+
+      test("does not move focus", () => {
+        expect(activeElement()).toBe(outsideButton);
+      });
+    });
+  });
+
   describe("when the month prop is rerendered with non-first-of-month dates", () => {
     const monthDates: unknown[] = [];
     const components = {

--- a/packages/react-day-picker/src/useFocus.ts
+++ b/packages/react-day-picker/src/useFocus.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import type { CalendarDay, DateLib } from "./classes/index.js";
 import { calculateFocusTarget } from "./helpers/calculateFocusTarget.js";
@@ -61,6 +61,17 @@ export function useFocus<T extends DayPickerProps>(
   const [focusedDay, setFocused] = useState<CalendarDay | undefined>(
     autoFocus ? focusTarget : undefined,
   );
+
+  useEffect(() => {
+    if (!focusedDay || !focusTarget) return;
+
+    const isFocusedDayDisplayed = calendar.days.some((day) =>
+      day.isEqualTo(focusedDay),
+    );
+    if (!isFocusedDayDisplayed) {
+      setFocused(focusTarget);
+    }
+  }, [calendar.days, focusedDay, focusTarget]);
 
   const blur = () => {
     setLastFocused(focusedDay);


### PR DESCRIPTION
## Context

Changing the controlled `month` and `selected` values while a day has focus replaces that day button. Focus currently falls back to the document body and keyboard navigation stops.

Closes #3009.

## Analysis

`useFocus` retains the `CalendarDay` from the previously visible month. Although `calculateFocusTarget` identifies the selected day in the new month, that target is only used for the roving tab index and is never promoted to the focused state. The replacement `DayButton` therefore never receives the focused modifier that triggers DOM focus.

## Solution

- Reconcile a stale focused day with the calculated focus target when the previous day is no longer displayed.
- Leave focus unchanged when it has already moved outside the day grid.
- Add source and consumer-level regression coverage for both focus paths.
- Add an interactive `ControlledMonthFocus` example to the examples app.
- Add a patch changeset for `react-day-picker` and `@daypicker/react`.
- Validate all Jest projects, TypeScript, Biome, the examples-app production build, and the changeset release plan.