### PR TITLE
test: cover time zone changes after mount

### DIFF
--- a/packages/react-day-picker/src/DayPicker.test.tsx
+++ b/packages/react-day-picker/src/DayPicker.test.tsx
@@ -533,6 +533,33 @@ describe("when the `month` is changed programmatically", () => {
   });
 });
 
+describe("when the timeZone changes after mount", () => {
+  const defaultMonth = new Date("2024-01-01T00:30:00.000Z");
+  let rerender: ReturnType<typeof render>["rerender"];
+
+  beforeEach(() => {
+    ({ rerender } = render(
+      <DayPicker defaultMonth={defaultMonth} timeZone="America/New_York" />,
+    ));
+  });
+
+  test("displays the month in the initial time zone", () => {
+    expect(grid("December 2023")).toBeInTheDocument();
+  });
+
+  describe("when the instant falls in the following month in the new time zone", () => {
+    beforeEach(() => {
+      rerender(
+        <DayPicker defaultMonth={defaultMonth} timeZone="Europe/Berlin" />,
+      );
+    });
+
+    test("displays the month in the new time zone", () => {
+      expect(grid("January 2024")).toBeInTheDocument();
+    });
+  });
+});
+
 test("extends the default locale", () => {
   render(
     <DayPicker


### PR DESCRIPTION
Changing the `timeZone` prop after mount intentionally reinitializes an uncontrolled displayed month. Without lifecycle coverage, removing that synchronization can leave the calendar rendering a month from the previous zone.

## What Changed

- Add a DayPicker component test using a fixed instant that falls in December in New York and January in Berlin.
- Assert the initial month and the month displayed after rerender as separate behaviors.

## Review Notes

- The test uses explicit IANA zones and does not depend on the process time zone.
- The test passes on `main` and fails on the exact head of #3005, where the calendar remains on December after the Berlin rerender.
- This is test-only, so no changeset is included.
