### PR TITLE
Keep focus in the grid when a controlled month change removes the focused day

### DIFF
--- a/packages/react-day-picker/src/DayPicker.test.tsx
+++ b/packages/react-day-picker/src/DayPicker.test.tsx
@@ -531,6 +531,67 @@ describe("when the `month` is changed programmatically", () => {
       expect(monthDates[monthDates.length - 1]).toEqual(new Date(2023, 1, 1));
     });
   });
+
+  describe("when the focused day is removed by the month change", () => {
+    test("moves focus to a day in the new month instead of losing it", () => {
+      const march = new Date(2024, 2, 15);
+      const november = new Date(2024, 10, 15);
+      const onSelect = jest.fn();
+
+      const { rerender } = render(
+        <DayPicker
+          mode="single"
+          month={march}
+          selected={march}
+          onSelect={onSelect}
+        />,
+      );
+
+      act(() => dateButton(march).focus());
+      expect(activeElement()).toBe(dateButton(march));
+
+      // A controlled update to both `month` and `selected`, as would happen
+      // e.g. after an external action changes the selection (see #3009).
+      rerender(
+        <DayPicker
+          mode="single"
+          month={november}
+          selected={november}
+          onSelect={onSelect}
+        />,
+      );
+
+      // Focus should land on the newly selected day, which calculateFocusTarget
+      // prioritizes above other days in the new month.
+      expect(activeElement()).toBe(dateButton(november));
+    });
+
+    test("does not move focus when it wasn't in the grid to begin with", () => {
+      const march = new Date(2024, 2, 15);
+      const november = new Date(2024, 10, 15);
+      const onSelect = jest.fn();
+
+      const { rerender } = render(
+        <DayPicker
+          mode="single"
+          month={march}
+          selected={march}
+          onSelect={onSelect}
+        />,
+      );
+
+      rerender(
+        <DayPicker
+          mode="single"
+          month={november}
+          selected={november}
+          onSelect={onSelect}
+        />,
+      );
+
+      expect(activeElement()).toBe(document.body);
+    });
+  });
 });
 
 describe("when the timeZone changes after mount", () => {

--- a/packages/react-day-picker/src/useFocus.ts
+++ b/packages/react-day-picker/src/useFocus.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import type { CalendarDay, DateLib } from "./classes/index.js";
 import { calculateFocusTarget } from "./helpers/calculateFocusTarget.js";
@@ -61,6 +61,16 @@ export function useFocus<T extends DayPickerProps>(
   const [focusedDay, setFocused] = useState<CalendarDay | undefined>(
     autoFocus ? focusTarget : undefined,
   );
+
+  useEffect(() => {
+    // If a day was focused but a controlled `month` change (or similar)
+    // removed it from the displayed days, move focus to the closest new
+    // target instead of leaving focus stranded on a removed element. Don't
+    // move focus if it wasn't in the grid to begin with.
+    if (focusedDay && !calendar.days.some((day) => day.isEqualTo(focusedDay))) {
+      setFocused(focusTarget);
+    }
+  }, [calendar.days, focusedDay, focusTarget]);
 
   const blur = () => {
     setLastFocused(focusedDay);


### PR DESCRIPTION
## Summary

Fixes #3009.

When the `month` prop changes under external control (e.g. an app updates both `month` and `selected` together, such as after undoing a date selection), the previously focused day can be removed from the DOM entirely. `useFocus`'s `focusedDay` state kept referring to that removed day, so no day had the `focused` modifier after the update, `DayButton` never called `.focus()` on anything, and focus silently fell back to `<body>` — breaking keyboard continuity (arrow keys stop moving between days) for any controlled calendar whose value can change externally.

```tsx
// Focus a day in March, then press J:
setMonth(november);
setSelected(november);
// November is displayed and November 15 is selected, but
// document.activeElement is <body>, and arrow keys do nothing.
```

## Fix

Added an effect in `useFocus` that detects when `focusedDay` is no longer among the currently displayed `calendar.days` and moves focus to `calculateFocusTarget`'s result instead — the same helper already used for `autoFocus`, which prioritizes the selected day, then today, then the first focusable day. Focus is left untouched when it wasn't in the grid to begin with, per the issue's expected behavior.

## Test plan

- Added two tests under `DayPicker.test.tsx`:
  - Focus a day in the initial month, then a controlled `month`+`selected` update (with `onSelect` wired up, so the selection is genuinely controlled): asserts focus lands on the newly selected day rather than `<body>`.
  - Same update without ever focusing a day first: asserts focus stays on `<body>` (i.e. the fix doesn't grab focus that wasn't in the grid).
- Verified the regression: reverting the source change turns the first new test from passing into failing, with `document.activeElement` on `<body>` — exactly the reported bug.
- Full package suite passes: `npx jest packages/react-day-picker` — 492 passing.
- `biome check` and `tsc --noEmit` both pass on the changed files.